### PR TITLE
Fix Miovision aggregation to properly use 1 hour pads for short gaps

### DIFF
--- a/volumes/miovision/sql/function-aggregate-volumes_15min_tmc.sql
+++ b/volumes/miovision/sql/function-aggregate-volumes_15min_tmc.sql
@@ -34,8 +34,8 @@ FROM zero_padding_movements pad
 --To set unacceptable ones to NULL instead (& only gap fill light vehicles, cyclist and pedestrian)
 LEFT JOIN miovision_api.unacceptable_gaps un 
 	ON un.intersection_uid = pad.intersection_uid
-	AND pad.datetime_bin15 BETWEEN DATE_TRUNC('hour', gap_start) 
-	AND DATE_TRUNC('hour', gap_end) + interval '1 hour' -- may get back to this later on for fear of removing too much data
+	AND pad.datetime_bin15 >= DATE_TRUNC('hour', gap_start)
+	AND pad.datetime_bin15 < DATE_TRUNC('hour', gap_end) + interval '1 hour' -- may get back to this later on for fear of removing too much data
 --To get 1min bins
 LEFT JOIN miovision_api.volumes A
 	ON A.datetime_bin >= start_date - INTERVAL '1 hour' 


### PR DESCRIPTION
## What this pull request accomplishes:

- Fixes a bug in the Miovision data processing pipeline where the 15-minute aggregation script would pad out 1 hour 15 minutes around short gaps rather than 1 hour.

## Issue(s) this solves:

- #338

## What, in particular, needs to reviewed:

- Cursory glance at the code.
