### PR TITLE
Fix Miovision API Puller Bugs

### DIFF
--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -370,8 +370,9 @@ def pull_data(conn, start_time, end_time, intersection, path, pull, key, dupes):
             table.extend(table_veh)
             table.extend(table_ped)
 
-        logger.info('Completed data pulling from {0:s} to {1:s}'
-                    .format(c_start_t, c_end_t))
+        logger.info('Completed data pulling from %s to %s'
+                    %(c_start_t, c_end_t))
+
         try:
             insert_data(conn, c_start_t, c_end_t, table, dupes)
         except psycopg2.Error as exc:

--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -300,7 +300,7 @@ def insert_data(conn, start_time, end_iteration_time, table, dupes):
 
 def daterange(start_time, end_time, dt):
     """Generator for a sequence of regular time periods."""
-    for i in range(math.ceil((end_time - start_time) / dt)):
+    for i in range(math.ceil((end_time - start_time) / dt) - 1):
         c_start_t = start_time + i * dt
         yield (c_start_t, c_start_t + dt)
 


### PR DESCRIPTION
## What this pull request accomplishes:

- Stop the API from pulling one extra bin of data beyond the endpoint of the datetime range (cherry-picked from [d9c042](https://github.com/CityofToronto/bdit_data-sources/commit/d9c042b18acf4ee52660aab2a69c03b7a05caa0a)).
- Fix a timestamp display issue in the logging.

## Issue(s) this solves:

- Closes #339 
- Closes #345

## What, in particular, needs to reviewed:

- Glance at the source code (and then push to productionization for tomorrow's run).
