### PR TITLE
Add first draft of collisions pipeline (#348).

### DIFF
--- a/collisions/GettingStarted.md
+++ b/collisions/GettingStarted.md
@@ -1,0 +1,292 @@
+# Getting Started with Collision Data
+
+Welcome to the tutorial on query collision data! This tutorial assumes you are
+familiar with Postgres and PostGIS. If you'd like resources on those, please see
+the Data & Analytics Postgres onboarding documentation [here](https://www.notion.so/bditto/PostgreSQL-Exercises-322493ab085b442f96bfdb77b039cfca).
+
+## Layout
+
+`collisions.acc` is a direct mirror of the table on the MOVE server, and has not
+been processed to eg. convert category codes into text. It could be used for
+analysis, but is typically only examined for diagnostic purposes.
+
+`collisions.events` is a table of all data related to the collision event, such
+as its location and time of day, as opposed to data related to involved
+individuals, such as injury or manoeuver. `collisions.involved` includes all
+involved individual data - "involved data" for short.
+
+## Joining Events and Involved
+
+THe `events` and `involved` tables are often joined to get a single table, where
+each row represents an individual involved in a crash, but will contain data at
+both event and involved levels.
+
+To join the two tables together, we use
+
+```sql
+SELECT *
+FROM collisions.events
+LEFT JOIN collisions.involved USING (collision_no);
+```
+
+This will return *every* record available, so typically we also append a `WHERE`
+clause to restrict the query by time and place. This query is popular enough
+that it has been turned into a view, `collisions.alldata`. For example, to
+return all involved from January 2015, one could write:
+
+```sql
+SELECT *
+FROM collisions.alldata
+WHERE accdate >= '2015-01-01' AND accdate < '2015-02-01';
+```
+
+## Counting Events and Involved
+
+One common query is for the total number of collision events, or the total
+number of individuals involved in collisions, aggregated to the month, or year.
+If we, for example, wanted the number of collision events and involved from
+2015-2019 inclusive, we'd do:
+
+```sql
+SELECT accyear,
+       -- Number of collision **events**.
+       COUNT(DISTINCT collision_no) n_collisions,
+       -- Number of people **involved**.
+       COUNT(*) n_involved
+FROM collisions.alldata
+WHERE accyear BETWEEN 2015 AND 2019
+GROUP BY accyear
+ORDER BY 1;
+```
+
+As of 2021-07-05, the output looks like:
+
+accyear | n_collisions | n_involved
+-- | -- | --
+2015 | 50865 | 124226
+2016 | 55637 | 108283
+2017 | 58917 | 105669
+2018 | 62401 | 108103
+2019 | 64367 | 108316
+
+but be aware that due to the ever-refreshing nature of collisions mentioned in
+`Readme.md`, these numbers will surely change by small amounts with time.
+
+The `data_source` column lists whether the collision event comes from TPS or CRC
+(or cannot be deduced from the `ACCNB`). `validation_userid` gives the name of
+Data & Analytics staff member who most recently validated the involved
+(sometimes only some individals from a collision event are validated). If we
+want the number of events, involved and validated involved from the data
+subdivided by year and data source, we'd do:
+
+```sql
+SELECT accyear,
+       data_source,
+       -- Number of collision **events**.
+       COUNT(DISTINCT collision_no) n_collisions,
+       -- Number of people **involved**.
+       COUNT(*) n_involved,
+       -- Number of people **involved** whose data has been validated.
+	   COUNT(*) FILTER (WHERE validation_userid IS NOT NULL) n_valid_involved
+FROM collisions.alldata
+WHERE accyear BETWEEN 2015 AND 2019
+GROUP BY accyear, data_source
+ORDER BY 1, 2;
+```
+
+As of 2021-07-05, the output looks like:
+
+accyear | data_source | n_collisions | n_involved | n_valid_involved
+-- | -- | -- | -- | --
+2015 | CRC | 36059 | 89329 | 36490
+2015 | TPS | 14806 | 34897 | 28899
+2016 | CRC | 44106 | 80651 | 31763
+2016 | TPS | 11507 | 27601 | 22301
+2016 | NULL | 24 | 31 | 0
+2017 | CRC | 48978 | 81514 | 23135
+2017 | TPS | 9923 | 24127 | 20272
+2017 | NULL | 16 | 28 | 2
+2018 | CRC | 52697 | 84471 | 18595
+2018 | TPS | 9692 | 23611 | 17641
+2018 | NULL | 12 | 21 | 5
+2019 | CRC | 55132 | 85975 | 10663
+2019 | TPS | 9203 | 22291 | 5317
+2019 | NULL | 32 | 50 | 7
+
+We see that the majority of collisions come from the CRC (since they handle
+minor collisions). Collisions from TPS are much more likely to be validated
+(because they're much more likely to involved killed or seriously injured
+individuals, which are prioritized for validation). The number of validated
+collisions goes down with year (since it takes time to validate).
+
+## Summing Involved
+
+Data request clients will often ask for data aggregated up to the collision
+event level, but also ask for involved-level data. One way to satisfy these
+requests (though be sure to confirm with the client that this is acceptable to
+them!) is to sum up the number of involved of a particular category (see eg.
+[this data
+request](https://github.com/Toronto-Big-Data-Innovation-Team/bdit_data_requests/pull/140/)).
+If we, for example, wanted the number of killed or seriously injured (KSI) per
+collisions on 2015 involving at least one KSI, and at least one person under the
+age of 18 (who may or may not be the KSI):
+
+```sql
+SELECT collision_no,
+       accdate,
+	   COUNT(*) n_involved,
+	   COUNT(*) FILTER (WHERE involved_injury_class IN ('MAJOR', 'FATAL')) n_involved_ksi
+FROM collisions.alldata
+WHERE accyear = 2015
+GROUP BY collision_no, accdate
+HAVING COUNT(*) FILTER (WHERE involved_age < 18) > 0 AND COUNT(*) FILTER (WHERE involved_injury_class IN ('MAJOR', 'FATAL')) > 0
+ORDER BY 1, 2;
+```
+
+The first five rows are:
+
+collision_no | accdate | n_involved | n_involved_ksi
+-- | -- | -- | --
+1585672 | 2015-01-02 | 6 | 1
+1586806 | 2015-01-30 | 7 | 1
+1587918 | 2015-02-24 | 4 | 1
+1588728 | 2015-03-17 | 4 | 1
+1589186 | 2015-04-01 | 3 | 1
+
+## Geospatial Transformations of Collisions
+
+`collisions.events` includes a `geom` column (SRID 4329) based off of the
+`latitude` and `longitude` columns. No attempt has been made to clean bad
+lon-lats (in particular, those where `latitude` or `longitude` are close to
+zero, rather than 43 and -79, respectively), so they'll need to be cleaned
+either by removing latitudes and longitudes nowhere near Toronto, or by joining
+with another geometry. The latter is often done for data requests.
+
+Let's say we wanted to associate all 2015-2019 inclusive collisions that
+occurred along Yonge St. between Bloor and Dundas. We can generate a street
+geometry using the `gis.text_to_centreline_geom` function (documented
+[here](https://github.com/CityofToronto/bdit_data-sources/tree/master/gis/text_to_centreline)),
+and then buffer the geometry to spatially join with the collisions.
+
+```sql
+WITH raw_geom AS (
+	-- Create a geometry by joining Yonge centreline segments from Dundas to Bloor.
+	SELECT gis.text_to_centreline_geom('Yonge Street', 'Dundas Street West', 'Bloor Street West') street_geom
+), buffered_geom AS (
+	-- Buffer the geometry out 20 m. Note that we had to transform to SRID 2952 to do this,
+	-- since the units of SRID 4326 are degrees.
+	SELECT ST_TRANSFORM(ST_BUFFER(ST_TRANSFORM(street_geom, 2952), 20), 4326) street_geom
+	FROM raw_geom
+)
+SELECT b.collision_no,
+       b.geom
+FROM buffered_geom a
+-- Use ST_CONTAINS (https://postgis.net/docs/ST_Contains.html) for spatial association.
+LEFT JOIN collisions.events b ON ST_CONTAINS(a.street_geom, b.geom)
+WHERE b.accyear = 2015;
+```
+
+The first five lines returned are:
+
+collision_no | geom
+-- | --
+1549570 | 0101000020E6100000AAD903ADC0D853C0E6762FF7C9D54540
+1549852 | 0101000020E6100000BF66B96C74D853C0001C7BF65CD44540
+1549872 | 0101000020E6100000B5368DEDB5D853C0CBB9145795D54540
+1551137 | 0101000020E610000044FAEDEBC0D853C022A98592C9D54540
+1551443 | 0101000020E6100000F71F990E9DD853C01B9DF3531CD54540
+
+Notice that we transformed the street geometry back to SRID 4326 prior to
+spatially joining with the collisions. If our street geometry were in another
+spatial referencing system, we would have to transform the `geom` column of
+`collisions.events` to join with it. [CTEs and
+subqueries](https://gis.stackexchange.com/a/194036), once generated, do not use
+the indexes of their parent tables, so spatially joining two CTEs together will
+require a sequential rather than an index scan, which could slow the join down
+by orders of magnitude. To avoid this, either:
+- Do not spatially join the outputs large CTEs/subqueries.
+- Separate large CTEs/subqueries out as temporary tables, then create spatial
+  indexes for these tables before spatially joining with them.
+
+## Nuances of Collision Locations
+
+### Spatial Joining
+
+You may have noticed that we used a 20 m buffer in the previous example, and may
+be wondering if this is a standard definition used when joining street and
+collision geometries together; it is not. Indeed, *there is currently no
+standard practice for spatially associating collisions with other geometries*.
+Instead, you are expected to either define a buffer - with the help of clients
+for data requests - or perform sensitivity testing to ensure that an acceptable
+minority of collisions are being left out of the join. 20 m is typical of
+arterial streets, but larger numbers should be used for exceptionally wide
+streets like St. Clair West, or for highways, while smaller values may be used
+for local roads.
+
+When joining collisions with a network of buffered streets, the team typically
+uses a single buffer width for all streets, and performs sensitivity testing to
+make sure that the buffer width is wide enough that an acceptable minority of
+collisions are left out, but narrow enough that collisions not on the street
+network are being spuriously associated.
+
+You may be required to produce a one-to-one association between collision and
+road network (i.e. a collision can only be assigned to one road segment in the
+network). In that case, consider a multi-step process:
+- First, associate collisions with buffered street segments.
+- Then, calculate the orthogonal distance between the collision and *unbuffered*
+  street segments.
+- Finally, associate the collision with the closest-distance street segment.
+
+For an example of this process in action, see the
+[pattern](https://github.com/Toronto-Big-Data-Innovation-Team/bdit_vz_analysis/blob/d60503c00ca821558532a1a52cfbdb6f8e8ff0f8/network_screening/roadscreen/roadscreen/ingest.py#L802)
+for producing collision/midblock associations for the Vision Zero pedestrian
+midblock crossing network screening. In particular, `multi_conflation_1` and
+`multi_conflation_2` use the process above to produce a one-to-one association.
+
+### Using Geolocation Versus `stname`, `location_type`, `location_class`, `traffic_control`, or `px`
+
+There are a large number of columns that encode collision location in some way
+(the list in the title is incomplete). For all sorts of reasons they are not all
+consistent with one-another. Please see the collision coding manual in the
+[Manuals
+page](https://www.notion.so/bditto/ca4e026b4f20474cbb32ccfeecf9dd76?v=a9428dc0fb3447e5b9c1427f8868e7c8)
+on Notion for details.
+
+Here are a few factors to consider:
+- Geolocation (lon/lat) is usually assumed to take precedence over other
+  quantities, though it is possible for a collision to be mis-geocoded either in
+  the original TPS/CRC report, or during validation.
+- `stname1` is the dominant road the collision, and `stname2` the cross-road.
+  For midblocks `stname2` is `NULL`. For intersections, `stname1` is the name of
+  the road with the higher functional class (eg. for a collision at the
+  intersection of arterial road Eglinton Ave W. and local road Maxwell Ave,
+  `stname1` will be `EGLINTON` and `stname2` will be `MAXWELL`).
+- `location_type` (named `ACCLOC` in `collisions.acc`) comes from the original
+  TPS and CRC reports. `location_class` (`LOCOORD` in `collisions.acc`)
+  is a simplified version that conforms to Transportation Services standards.
+  Notably `LOCOORD` is not defined in the collision coding manual. You should be
+  careful when using either to select for collisions at intersections or along
+  midblocks. For example, `location_class` may be labeled `MID-BLOCK` if a crash
+  occurs just after a vehicle clears the intersection but is still only a few
+  metres away. These ambiguities need to be better documented than they are now
+  (since some of the details appear to be passed down orally from staff member
+  to staff member).
+- `traffic_control` lists the traffic control system most relevant to the
+  collision (though does not need to be a factor of the collision itself). For
+  example, if at a signalized intersection, a vehicle is exiting a driveway (30
+  metres within) and strikes a cyclist on the sidewalk, the control is `NO
+  CONTROL`.
+- `px` indicates the geographic association between a collision and a signalized
+  intersection (so collisions with a non-null `px` may have `traffic_control =
+  NO CONTROL`). If a client is interested in all collisions geographically close
+  to signalized intersections (regardless if they were being controlled by the
+  signal), it is better to query using `px` than `traffic_control`.
+
+For an example of querying using a combination of these variables, see the query
+to generate the `signalized_twodriver_collisions` temporary table [here](https://github.com/Toronto-Big-Data-Innovation-Team/bdit_data_requests/issues/144#issuecomment-829498207).
+
+Due to these complexities, it is imperative that any analyst *perform thorough
+quality control checks* when selecting by location. It may even be prudent to
+select using two separate combinations of variables to see which produces a
+better dataset. This is especially true when reusing queries that filter using
+one or more location columns - please be *very* careful when doing that!

--- a/collisions/Readme.md
+++ b/collisions/Readme.md
@@ -4,8 +4,8 @@ The collisions dataset consists of data on individuals involved in traffic
 collisions from approximately 1985 to the present day (though there are some
 historical collisions from even earlier included). The data comes from the
 Toronto Police Services (TPS) and the Collision Reporting Centre (CRC), and
-is combined by a Data & Analytics team in Transportation Services Policy &
-Innovation, currently led by Racheal Saunders. It is currently hosted in an
+is combined by a Data Collections team in Transportation Services Policy &
+Innovation, currently led by David McElroy. It is currently hosted in an
 Oracle database and maintained using legacy software from the 1990s, but is in
 the process of being completely transitioned into the [MOVE platform](https://github.com/CityofToronto/bdit_flashcrow).
 
@@ -34,6 +34,23 @@ Properties of `collisions.acc`:
 - There is no UID. `ACCNB` serves as one starting in 2013, but prior to that the
   number would reset annually. Derived tables use `collision_no`, defined in
   `collisions.collision_no`.
+  - `ACCNB` [is
+    generated from TPS and CRC counterparts](https://github.com/CityofToronto/bdit_data-sources/pull/349#issuecomment-803133700)
+    when data is loaded into the Oracle database. It can only be 10 characters
+    long (by antiquated convention). TPS GO numbers, with format
+    `GO-{YEAR_REPORTED}{NUMBER}`, are converted into `ACCNB` by extracting
+    `{NUMBER}`, zero-padding it to 9 digits, and adding the last digit of the
+    year to the front (eg. `GO-2020267847` is translated to `0000267847`). CRC
+    collision numbers are recycled annually, with convention dictating that the
+    first CRC number be `8000000` (then the next `8000001`, etc.). To convert
+    these to `ACCNB`s, the last two digits of the year are added to the front
+    (eg. `8000285` reported in 2019 is converted to `198000285`).
+  - To keep the dataset current, particularly for fatal collisions, Data
+    Collections will occasionally manually enter collisions using information
+    directly obtained from TPS, or from public media. These entries may not
+    follow ACCNB naming conventions. When formal data is transferred from TPS,
+    they are manually merged with these human-generated entries.
+  - The date the collision was reported is not included in `acc`.
 - Some rows are derived from other rows by the Data & Analytics team; for
   example `LOCCOORD` is a simplified version of `ACCLOC`.
 - Categorical data is coded using numbers. These numbers come from the Motor

--- a/collisions/Readme.md
+++ b/collisions/Readme.md
@@ -30,7 +30,7 @@ In particular see the Colliion Coding Manual, Motor Vehicle Collision Report
 Properties of `collisions.acc`:
 - Each row represents one individual involved in a collision, so some data is
   repeated between rows. The data dictionary indicates which values are at the
-  event-level, and which at the individual level.
+  **event** level, and which at the individual **involved** level.
 - There is no UID. `ACCNB` serves as one starting in 2013, but prior to that the
   number would reset annually. Derived tables use `collision_no`, defined in
   `collisions.collision_no`.
@@ -61,6 +61,14 @@ Properties of `collisions.acc`:
   privacy concerns. The most egregious of these are only available in the
   original Oracle database, and have already been removed in the MOVE server
   data.
+- TPS and CRC send collision records once they are reported and entered into
+  their respective databases, which often leads to collisions being reported
+  months, or even years, after they occurred. TPS and CRC will also send changes
+  to existing collision records to eg. correct data entry errors or update the
+  health status of an injured individual. Moreover, staff at Data & Analytics
+  are constantly validating collision records, writing these changes directly to
+  the Oracle database. Therefore, one **cannot compare** historical control
+  totals on eg. the number of individuals involved with recently-generated ones.
 
 ### Collision Factors
 

--- a/collisions/Readme.md
+++ b/collisions/Readme.md
@@ -167,8 +167,34 @@ future `collisions.acc` will be directly mirrored from the MOVE server.
    `collisions.involved` materialized views.
 4. Perform simple consistency checks to ensure all data were properly copied.
 
+`pull_acc_script.py` requires:
+
+```
+click>=7.1.2
+psycopg2>=2.8.4
+```
+
 Scripts that define the tables and materialized views can be found in this
 folder.
+
+### Running the Data Replication
+
+1. Ensure you have a ConfigParser file available. See the [official Python
+   documentation](https://docs.python.org/3/library/configparser.html) to set
+   one up if you do not.
+2. Obtain the PEM key for connecting to MOVE over SSH from either your manager
+   or the MOVE product team.
+3. Add `'POSTGRES'` and `'FLASHCROW'` entries to your ConfigParser file.
+   `'POSTGRES'` should contain `user`, `password`, `host` and `port` entries,
+   corresponding to the Postgres credentials of the user running
+   `pull_acc_script.py`. `'FLASHCROW'` should have a `pem` entry, which gives
+   the filepath and name of the PEM key.
+4. Run `pull_acc_script.py`. You're required to pass the path of the
+   ConfigParser file using the `cfgpath` keyword:
+   ```
+   python pull_acc_script.py --cfgpath /{PATH}/{TO}/{FILE}/{FILENAME}
+   ```
+   For additional options, run `python pull_acc_script.py --help`.
 
 **It is highly recommended to run this process outside of regular work hours, as
 large file transfers from Flashcrow and to the Postgres can sometimes be

--- a/collisions/Readme.md
+++ b/collisions/Readme.md
@@ -53,65 +53,67 @@ The derived tables use a different naming scheme for columns:
 
 #### `collision.events`
 
-Event Column | Relation to ACC Column | Notes
--- | -- | --
-collision_no |   |  
-accnb | ACCNB |  
-accyear | Derived from ACCDATE |  
-acctime | ACCTIME |  
-longitude | LONGITUDE + 0.00021 |  
-latitude | LATITUDE + 0.000045 |  
-stname1 | STNAME1 |  
-streetype1 | STREETYPE1 |  
-dir1 | DIR1 |  
-stname2 | STNAME2 |  
-streetype2 | STREETYPE2 |  
-dir2 | DIR2 |  
-stname3 | STNAME3 |  
-streetype3 | STREETYPE3 |  
-dir3 | DIR3 |  
-road_class | ROAD_CLASS |  
-location_type | ACCLOC |  
-location_class | LOCCOORD | Simplified location_type
-collision_type | ACCLASS |  
-visibility | VISIBLE |  
-light | LIGHT |  
-road_surface_cond | RDSFCOND |  
-traffic_control | TRAFFICTL |  
-traffic_control_cond | TRAFCTLCOND |  
-on_private_property | PRIVATE_PROPERTY |  
-description | DESCRIPTION |  
+Event   Column | Equivalent ACC Column | Definition | Notes
+-- | -- | -- | --
+collision_no |   | Collision event unique identifier |  
+accnb | ACCNB | Original Oracle data UID | Restarted each year before 1996; use collision_no as a unique ID instead
+accyear | Derived from ACCDATE | Year of collision |  
+acctime | ACCTIME | Time of collision |  
+longitude | LONGITUDE + 0.00021 | Longitude |  
+latitude | LATITUDE + 0.000045 | Latitude |  
+stname1 | STNAME1 | Street name or address | For intersections, the largest road is recorded under stname1
+streetype1 | STREETYPE1 | Street type (Av, Ave, Blvd, etc.) |  
+dir1 | DIR1 | Direction in street name | Eg. W if street is St. Clair W; NOT the street direction of travel!
+stname2 | STNAME2 | Cross street name |  
+streetype2 | STREETYPE2 | Cross street type |  
+dir2 | DIR2 | Cross street direction |  
+stname3 | STNAME3 | Additional street name or address |  
+streetype3 | STREETYPE3 | Additional street type |  
+dir3 | DIR3 | Additional street direction |  
+road_class | ROAD_CLASS | Road class |  
+location_type | ACCLOC | Detailed collision location classification |  
+location_class | LOCCOORD | Simplified collision location classification | Simplified location_type
+collision_type | ACCLASS | Ontario Ministry of Transportation collision class |  
+visibility | VISIBLE | Visibility (usually due to inclement weather) |  
+light | LIGHT | Road lighting conditions |  
+road_surface_cond | RDSFCOND | Road surface conditions |  
+traffic_control | TRAFFICTL | Type of traffic control |  
+traffic_control_cond | TRAFCTLCOND | Status of traffic control |  
+on_private_property | PRIVATE_PROPERTY | Whether collision is on private property |  
+description | DESCRIPTION | Long-form comments |  
+
 
 #### `collisions.involved`
 
-Involved Column | Relation to ACC Column | Notes
--- | -- | --
-collision_no |   |  
-vehicle_no | VEH_NO |  
-person_no | PER_NO |  
-vehicle_class | VEHTYPE |  
-initial_dir | INITDIR |  
-impact_type | IMPACTYPE |  
-event1 | EVENT1 |  
-event2 | EVENT2 |  
-event3 | EVENT3 |  
-involved_class | INVTYPE |  
-involved_age | INVAGE or BIRTHDATE | Selects from whichever is available/more accurate
-involved_injury_class | INJURY |  
-safety_equip_used | SAFEQUIP |  
-driver_action | DRIVACT |  
-driver_condition | DRIVCOND |  
-pedestrian_action | PEDACT |  
-pedestrian_condition | PEDCOND |  
-pedestrian_collision_type | PEDTYPE |  
-cyclist_action | CYCACT |  
-cyclist_condition | CYCCOND |  
-cyclist_collision_type | CYCLISTYPE |  
-manoeuver | MANOEUVER |  
-posted_speed | POSTED_SPEED |  
-actual_speed | ACTUAL_SPEED |  
-failed_to_remain | FAILTOREM |  
-is_validated | USERID | True if RSU user ID exists
+Involved   Column | Equivalent ACC Column | Definition | Notes
+-- | -- | -- | --
+collision_no |   | Collision event unique identifier |  
+vehicle_no | VEH_NO | Vehicle identifier for individual collision event |  
+person_no | PER_NO | Person identifier for individual collision event |  
+vehicle_class | VEHTYPE | Vehicle class |  
+initial_dir | INITDIR | Initial direction of travel |  
+impact_type | IMPACTYPE | Impact type (eg. rear end, sideswipe) |  
+event1 | EVENT1 | First event that occurred for involved |  
+event2 | EVENT2 | Second event |  
+event3 | EVENT3 | Third event |  
+involved_class | INVTYPE | Class of road user (eg. driver,   passenger, pedestrian)
+involved_age | INVAGE or BIRTHDATE | Age of involved | Selects from whichever is available/more accurate
+involved_injury_class | INJURY | Level of injury |  
+safety_equip_used | SAFEQUIP | Safety equipment used (eg. seat belt) |  
+driver_action | DRIVACT | Driver action |  
+driver_condition | DRIVCOND | Driver condition (eg. impaired) |  
+pedestrian_action | PEDACT | Pedestrian action |  
+pedestrian_condition | PEDCOND | Pedestrian condition |  
+pedestrian_collision_type | PEDTYPE | Pedestrian collision type (eg.   pedestrian hit on sidewalk or shoulder)
+cyclist_action | CYCACT | Cyclist action |  
+cyclist_condition | CYCCOND | Cyclist condition |  
+cyclist_collision_type | CYCLISTYPE | Cyclist collision type (eg. cyclist   struck in parking lot)
+manoeuver | MANOEUVER | Vehicle manoeuver |  
+posted_speed | POSTED_SPEED | Posted speed limit |  
+actual_speed | ACTUAL_SPEED | Speed of vehicle |  
+failed_to_remain | FAILTOREM | Whether the involved fled the scene of the crash |  
+is_validated | USERID | Whether the collision has been validated by Transportation Services | True if RSU user ID exists
+
 
 ## Data Replication Process
 

--- a/collisions/Readme.md
+++ b/collisions/Readme.md
@@ -45,7 +45,7 @@ generate three derived tables:
   1985-01-01 and present. Columns have proper data types (rather than all
   integers like in `collisions.acc`) and categorical columns use their text
   descriptions rather than numerical codes.
-- `collisions.events`: all collision individual-level data for collisions
+- `collisions.involved`: all collision individual-level data for collisions
   between 1985-01-01 and present, with refinements similar to
   `collisions.events`.
 

--- a/collisions/Readme.md
+++ b/collisions/Readme.md
@@ -15,6 +15,8 @@ The raw dataset is stored under `collisions.acc`, a direct mirror of the same
 table on the MOVE server (which itself mirrors from Oracle). The data dictionary
 for this table is maintained jointly with MOVE and found on [Notion
 here](https://www.notion.so/bditto/5cf7a4b3ee7d40de8557ac77c1cd2e69?v=56499d5d41e04f2097750ca3267f44bc).
+The guidebook that defines the values and categories for many colums is found
+[here](http://insideto.toronto.ca/transportation/files/carsmap/user-manual.pdf).
 
 ### Properties of `collisions.acc`
 - Each row represents one individual involved in a collision, so some data is

--- a/collisions/Readme.md
+++ b/collisions/Readme.md
@@ -1,0 +1,130 @@
+# Collisions
+
+The collisions dataset consists of data on individuals involved in traffic
+collisions from approximately 1985 to the present day (though there are some
+historical collisions from even earlier included). The data comes from the
+Toronto Police Services (TPS) and the Collision Reporting Centre (CRC), and
+is combined by a Data & Analytics team in Transportation Services Policy &
+Innovation, currently led by Racheal Saunders. It is currently hosted in an
+Oracle database and maintained using legacy software from the 1990s, but is in
+the process of being completely transitioned into the [MOVE platform](https://github.com/CityofToronto/bdit_flashcrow).
+
+## Table Structure
+
+The raw dataset is stored under `collisions.acc`, a direct mirror of the same
+table on the MOVE server (which itself mirrors from Oracle). The data dictionary
+for this table is maintained jointly with MOVE and found on [Notion
+here](https://www.notion.so/bditto/5cf7a4b3ee7d40de8557ac77c1cd2e69?v=56499d5d41e04f2097750ca3267f44bc).
+
+### Properties of `collisions.acc`
+- Each row represents one individual involved in a collision, so some data is
+  repeated between rows. The data dictionary indicates which values are at the
+  event-level, and which at the individual level.
+- There is no UID. `ACCNB` serves as one starting in 2013, but prior to that the
+  number would reset annually. Derived tables use `collision_no`, defined in
+  `collisions.collision_no`.
+- Some rows are derived from other rows by the Data & Analytics team; for
+  example `LOCCOORD` is a simplified version of `ACCLOC`.
+- Categorical data is coded using numbers. These numbers come from the Motor
+  Vehicle Accident (MVA) reporting scheme.
+- Some columns are not included due to privacy concerns.
+
+### Collision Factors
+
+Categorical data codes are in the `collision_factors` schema as tables. Each
+table name corresponds to the categorical column in `collisions.acc`.
+
+### Derived Tables
+
+Because `collisions.acc` in its raw form is somewhat difficult to use, we
+generate three derived tables:
+
+- `collisions.collision_no`: assigns a UID to each collision between 1985-01-01
+  and the most recent data refresh date.
+- `collisions.events`: all collision event-level data for collisions between
+  1985-01-01 and present. Columns have proper data types (rather than all
+  integers like in `collisions.acc`) and categorical columns use their text
+  descriptions rather than numerical codes.
+- `collisions.events`: all collision individual-level data for collisions
+  between 1985-01-01 and present, with refinements similar to
+  `collisions.events`.
+
+The derived tables use a different naming scheme for columns:
+
+#### `collision.events`
+
+Event Column | Relation to ACC Column | Notes
+-- | -- | --
+collision_no |   |  
+accnb | ACCNB |  
+accyear | Derived from ACCDATE |  
+acctime | ACCTIME |  
+longitude | LONGITUDE + 0.00021 |  
+latitude | LATITUDE + 0.000045 |  
+stname1 | STNAME1 |  
+streetype1 | STREETYPE1 |  
+dir1 | DIR1 |  
+stname2 | STNAME2 |  
+streetype2 | STREETYPE2 |  
+dir2 | DIR2 |  
+stname3 | STNAME3 |  
+streetype3 | STREETYPE3 |  
+dir3 | DIR3 |  
+road_class | ROAD_CLASS |  
+location_type | ACCLOC |  
+location_class | LOCCOORD | Simplified location_type
+collision_type | ACCLASS |  
+visibility | VISIBLE |  
+light | LIGHT |  
+road_surface_cond | RDSFCOND |  
+traffic_control | TRAFFICTL |  
+traffic_control_cond | TRAFCTLCOND |  
+on_private_property | PRIVATE_PROPERTY |  
+description | DESCRIPTION |  
+
+#### `collisions.involved`
+
+Involved Column | Relation to ACC Column | Notes
+-- | -- | --
+collision_no |   |  
+vehicle_no | VEH_NO |  
+person_no | PER_NO |  
+vehicle_class | VEHTYPE |  
+initial_dir | INITDIR |  
+impact_type | IMPACTYPE |  
+event1 | EVENT1 |  
+event2 | EVENT2 |  
+event3 | EVENT3 |  
+involved_class | INVTYPE |  
+involved_age | INVAGE or BIRTHDATE | Selects from whichever is available/more accurate
+involved_injury_class | INJURY |  
+safety_equip_used | SAFEQUIP |  
+driver_action | DRIVACT |  
+driver_condition | DRIVCOND |  
+pedestrian_action | PEDACT |  
+pedestrian_condition | PEDCOND |  
+pedestrian_collision_type | PEDTYPE |  
+cyclist_action | CYCACT |  
+cyclist_condition | CYCCOND |  
+cyclist_collision_type | CYCLISTYPE |  
+manoeuver | MANOEUVER |  
+posted_speed | POSTED_SPEED |  
+actual_speed | ACTUAL_SPEED |  
+failed_to_remain | FAILTOREM |  
+is_validated | USERID | True if RSU user ID exists
+
+## Data Replication Process
+
+Currently, `pull_acc_script.py` is used to manually refresh the data. In the
+future `collisions.acc` will be directly mirrored from the MOVE server.
+
+`pull_acc_script.py` performs the following steps:
+1. Obtain a copy of `ACC.dat` (a dump of the ACC table from the Oracle server).
+2. `TRUCACTE` the current `collisions.acc` table on the BDITTO Postgres, then
+   replace it using `ACC.dat`.
+3. Refresh `collisions.collision_no`, `collisions.events` and
+   `collisions.involved` materialized views.
+4. Perform simple consistency checks to ensure all data were properly copied.
+
+Scripts that define the tables and materialized views can be found in this
+folder.

--- a/collisions/Readme.md
+++ b/collisions/Readme.md
@@ -11,14 +11,23 @@ the process of being completely transitioned into the [MOVE platform](https://gi
 
 ## Table Structure
 
-The raw dataset is stored under `collisions.acc`, a direct mirror of the same
-table on the MOVE server (which itself mirrors from Oracle). The data dictionary
-for this table is maintained jointly with MOVE and found on [Notion
-here](https://www.notion.so/bditto/5cf7a4b3ee7d40de8557ac77c1cd2e69?v=56499d5d41e04f2097750ca3267f44bc).
-The guidebook that defines the values and categories for many colums is found
-[here](http://insideto.toronto.ca/transportation/files/carsmap/user-manual.pdf).
+The `collisions` schema houses raw and derived collision data tables. The
+`collision_factors` schema houses tables to convert raw Motor Vehicle Accident
+(MVA) report codes to human-readable categories (discussed further below). Both
+are owned by `collision_admins`.
 
-### Properties of `collisions.acc`
+### `acc`
+
+The raw dataset is `collisions.acc`, a direct mirror of the same table on the
+MOVE server (which itself mirrors from Oracle). The data dictionary for `ACC`
+is maintained jointly with MOVE and found on [Notion here](
+https://www.notion.so/bditto/5cf7a4b3ee7d40de8557ac77c1cd2e69?v=56499d5d41e04f2097750ca3267f44bc).
+The guides that define values and categories for most columns can be found in
+the [Manuals page on Notion](https://www.notion.so/bditto/ca4e026b4f20474cbb32ccfeecf9dd76?v=a9428dc0fb3447e5b9c1427f8868e7c8).
+In particular see the Colliion Coding Manual, Motor Vehicle Collision Report
+2015, and Motor Vehicle Accident Codes Ver. 1.
+
+Properties of `collisions.acc`:
 - Each row represents one individual involved in a collision, so some data is
   repeated between rows. The data dictionary indicates which values are at the
   event-level, and which at the individual level.
@@ -29,12 +38,16 @@ The guidebook that defines the values and categories for many colums is found
   example `LOCCOORD` is a simplified version of `ACCLOC`.
 - Categorical data is coded using numbers. These numbers come from the Motor
   Vehicle Accident (MVA) reporting scheme.
-- Some columns are not included due to privacy concerns.
+- Some columns, such as the TPS officer badge number, are not included due to
+  privacy concerns. The most egregious of these are only available in the
+  original Oracle database, and have already been removed in the MOVE server
+  data.
 
 ### Collision Factors
 
 Categorical data codes are in the `collision_factors` schema as tables. Each
-table name corresponds to the categorical column in `collisions.acc`.
+table name corresponds to the categorical column in `collisions.acc`. These are
+joined against `collisions.acc` to produce the derived tables.
 
 ### Derived Tables
 
@@ -132,3 +145,7 @@ future `collisions.acc` will be directly mirrored from the MOVE server.
 
 Scripts that define the tables and materialized views can be found in this
 folder.
+
+**It is highly recommended to run this process outside of regular work hours, as
+large file transfers from Flashcrow and to the Postgres can sometimes be
+interrupted by the VPN.**

--- a/collisions/Readme.md
+++ b/collisions/Readme.md
@@ -44,7 +44,9 @@ Properties of `collisions.acc`:
     collision numbers are recycled annually, with convention dictating that the
     first CRC number be `8000000` (then the next `8000001`, etc.). To convert
     these to `ACCNB`s, the last two digits of the year are added to the front
-    (eg. `8000285` reported in 2019 is converted to `198000285`).
+    (eg. `8000285` reported in 2019 is converted to `198000285`). The format of
+    each `ACCNB` is reverse engineered to determine the source of the data for
+    the `data_source` column in `collisions.events`.
   - To keep the dataset current, particularly for fatal collisions, Data
     Collections will occasionally manually enter collisions using information
     directly obtained from TPS, or from public media. These entries may not
@@ -93,26 +95,30 @@ accyear | Derived from ACCDATE | Year of collision |  
 acctime | ACCTIME | Time of collision |  
 longitude | LONGITUDE + 0.00021 | Longitude |  
 latitude | LATITUDE + 0.000045 | Latitude |  
+geom | Derived from longitude and latitude |  Point geometry of collision  |  Coordinate reference system is EPSG:4326
 stname1 | STNAME1 | Street name or address | For intersections, the largest road is recorded under stname1
 streetype1 | STREETYPE1 | Street type (Av, Ave, Blvd, etc.) |  
 dir1 | DIR1 | Direction in street name | Eg. W if street is St. Clair W; NOT the street direction of travel!
 stname2 | STNAME2 | Cross street name |  
 streetype2 | STREETYPE2 | Cross street type |  
 dir2 | DIR2 | Cross street direction |  
-stname3 | STNAME3 | Additional street name or address |  
+stname3 | STNAME3 | Additional street name, offset distance, or address |  
 streetype3 | STREETYPE3 | Additional street type |  
 dir3 | DIR3 | Additional street direction |  
 road_class | ROAD_CLASS | Road class |  
 location_type | ACCLOC | Detailed collision location classification |  
 location_class | LOCCOORD | Simplified collision location classification | Simplified location_type
 collision_type | ACCLASS | Ontario Ministry of Transportation collision class |  
+impact_type | IMPACTYPE | Impact type (eg. rear end, sideswipe) |  
 visibility | VISIBLE | Visibility (usually due to inclement weather) |  
 light | LIGHT | Road lighting conditions |  
 road_surface_cond | RDSFCOND | Road surface conditions |  
+px | PX | Signalized intersection PX number |  
 traffic_control | TRAFFICTL | Type of traffic control |  
 traffic_control_cond | TRAFCTLCOND | Status of traffic control |  
 on_private_property | PRIVATE_PROPERTY | Whether collision is on private property |  
 description | DESCRIPTION | Long-form comments |  
+data_source | ACCNB | Source of data | See properties of `collisions.acc`, above, for details
 
 
 #### `collisions.involved`
@@ -120,11 +126,11 @@ description | DESCRIPTION | Long-form comments |  
 Involved   Column | Equivalent ACC Column | Definition | Notes
 -- | -- | -- | --
 collision_no |   | Collision event unique identifier |  
-vehicle_no | VEH_NO | Vehicle identifier for individual collision event |  
 person_no | PER_NO | Person identifier for individual collision event |  
+vehicle_no | VEH_NO | Vehicle identifier for individual collision event |  
 vehicle_class | VEHTYPE | Vehicle class |  
 initial_dir | INITDIR | Initial direction of travel |  
-impact_type | IMPACTYPE | Impact type (eg. rear end, sideswipe) |  
+impact_location | IMPLOC | Location of impact on road |  
 event1 | EVENT1 | First event that occurred for involved |  
 event2 | EVENT2 | Second event |  
 event3 | EVENT3 | Third event |  
@@ -144,7 +150,8 @@ manoeuver | MANOEUVER | Vehicle manoeuver |  
 posted_speed | POSTED_SPEED | Posted speed limit |  
 actual_speed | ACTUAL_SPEED | Speed of vehicle |  
 failed_to_remain | FAILTOREM | Whether the involved fled the scene of the crash |  
-is_validated | USERID | Whether the collision has been validated by Transportation Services | True if RSU user ID exists
+validation_userid | USERID | ID of last Transportation Services staff member to validate this involved |  
+time_last_edited | TS | Time of last edit from Transportation Services |  
 
 
 ## Data Replication Process

--- a/collisions/collisions_acc.sql
+++ b/collisions/collisions_acc.sql
@@ -117,7 +117,7 @@ GRANT SELECT ON TABLE collisions.acc TO bdit_humans;
 GRANT SELECT ON TABLE collisions.acc TO rsaunders;
 GRANT SELECT ON TABLE collisions.acc TO kchan;
 
-COMMENT ON TABLE czhu.involvedraw2019
+COMMENT ON TABLE collisions.acc
     IS 'Raw collision database, from Flashcrow /data/replicator/flashcrow-CRASH/dat/ACC.dat.'
 
 CREATE INDEX collisions_acc_idx

--- a/collisions/collisions_acc.sql
+++ b/collisions/collisions_acc.sql
@@ -1,0 +1,125 @@
+-- Table schema for storing data from /data/replicator/flashcrow-CRASH/dat/ACC.dat.
+
+CREATE TABLE collisions.acc (
+      "ACCNB" varchar(10) NOT NULL
+    , "RELACCNB" varchar(10)
+    , "ACCDATE" timestamp
+    , "DAY_NO" varchar(1)
+    , "ACCTIME" varchar(4)
+    , "PATAREA" varchar(4)
+    , "STNAME1" varchar(35)
+    , "STREETYPE1" varchar(4)
+    , "DIR1" varchar(1)
+    , "STNAME2" varchar(35)
+    , "STREETYPE2" varchar(4)
+    , "DIR2" varchar(1)
+    , "STNAME3" varchar(35)
+    , "STREETYPE3" varchar(4)
+    , "DIR3" varchar(1)
+    , "PER_INV" varchar(2)
+    , "VEH_INV" varchar(2)
+    , "MUNICIPAL" varchar(2)
+    , "LOCCOORD" varchar(2)
+    , "IMPCTAREA" varchar(2)
+    , "ACCLASS" varchar(2)
+    , "ACCLOC" varchar(2)
+    , "TRAFFICTL" varchar(2)
+    , "DRIVAGE" varchar(2)
+    , "VEH_NO" varchar(2)
+    , "VEHTYPE" varchar(2)
+    , "TOWEDVEH" varchar(2)
+    , "INITDIR" varchar(2)
+    , "IMPACTYPE" varchar(2)
+    , "IMPLOC" varchar(2)
+    , "EVENT1" varchar(2)
+    , "EVENT2" varchar(2)
+    , "EVENT3" varchar(2)
+    , "PER_NO" varchar(2)
+    , "INVTYPE" varchar(2)
+    , "INVAGE" varchar(2)
+    , "INJURY" varchar(1)
+    , "SAFEQUIP" varchar(2)
+    , "DRIVACT" varchar(2)
+    , "DRIVCOND" varchar(2)
+    , "PEDCOND" varchar(2)
+    , "PEDACT" varchar(2)
+    , "CHARGE" varchar(5)
+    , "CHARGE2" varchar(5)
+    , "CHARGE3" varchar(5)
+    , "CHARGE4" varchar(5)
+    , "VISIBLE" varchar(2)
+    , "LIGHT" varchar(2)
+    , "RDSFCOND" varchar(2)
+    , "VEHIMPTYPE" varchar(2)
+    , "MANOEUVER" varchar(2)
+    , "ENTRY" varchar(1)
+    , "GEOCODE" varchar(6)
+    , "FACTOR_ERR" varchar(1)
+    , "REP_TYPE" varchar(1)
+    , "BADGE_NO" varchar(8)
+    , "POSTAL" varchar(7)
+    , "XCOORD" varchar(10)
+    , "YCOORD" varchar(10)
+    , "PRECISE_XY" varchar(1)
+    , "LONGITUDE" float8
+    , "LATITUDE" float8
+    , "CHANGED" int2
+    , "SENT_UNIT" varchar(12)
+    , "SENT_DATE" timestamp
+    , "STATUS" varchar(12)
+    , "CITY_AREA" varchar(12)
+    , "USER_ID" varchar(12)
+    , "CRC_UNIT" varchar(12)
+    , "COMMENTS" varchar(5000)
+    , "MTP_DIVISION" varchar(12)
+    , "POLICE_AGENCY" varchar(12)
+    , "SUBMIT_BADGE_NUMBER" varchar(10)
+    , "SUBMIT_DATE" timestamp
+    , "BIRTHDATE" timestamp
+    , "PRIVATE_PROPERTY" varchar(1)
+    , "PERSON_ID" int8
+    , "USERID" varchar(50)
+    , "TS" timestamp
+    , "ROAD_CLASS" varchar(50)
+    , "SYMBOL_NUM" int8
+    , "ROTATION_NUM" int8
+    , "PX" varchar(10)
+    , "DISTRICT" varchar(30)
+    , "QUADRANT" varchar(5)
+    , "FAILTOREM" int2
+    , "YEAR" varchar(5)
+    , "REC_ID" int8 NOT NULL
+    , "PEDTYPE" varchar(2)
+    , "CYCLISTYPE" varchar(2)
+    , "SIDEWALKCYCLE" varchar(10)
+    , "CYCACT" varchar(2)
+    , "CYCCOND" varchar(2)
+    , "MVAIMG" int2
+    , "WARDNUM" varchar(40)
+    , "FATAL_NO" float8
+    , "DESCRIPTION" varchar(4000)
+    , "TAB_REPORT" varchar(500)
+    , "ACTUAL_SPEED" int2
+    , "POSTED_SPEED" int2
+    , "TRAFCTLCOND" varchar(2)
+    , PRIMARY KEY ("REC_ID")
+)
+WITH (
+    OIDS = FALSE
+)
+TABLESPACE pg_default;
+
+ALTER TABLE collisions.acc
+    OWNER to czhu;
+
+GRANT ALL ON TABLE collisions.acc TO czhu;
+GRANT SELECT ON TABLE collisions.acc TO bdit_humans;
+GRANT SELECT ON TABLE collisions.acc TO rsaunders;
+GRANT SELECT ON TABLE collisions.acc TO kchan;
+
+COMMENT ON TABLE czhu.involvedraw2019
+    IS 'Raw collision database, from Flashcrow /data/replicator/flashcrow-CRASH/dat/ACC.dat.'
+
+CREATE INDEX collisions_acc_idx
+    ON collisions.acc USING btree
+    ("ACCNB", "ACCDATE");

--- a/collisions/collisions_acc.sql
+++ b/collisions/collisions_acc.sql
@@ -110,9 +110,8 @@ WITH (
 TABLESPACE pg_default;
 
 ALTER TABLE collisions.acc
-    OWNER to czhu;
+    OWNER to collision_admins;
 
-GRANT ALL ON TABLE collisions.acc TO czhu;
 GRANT SELECT ON TABLE collisions.acc TO bdit_humans;
 GRANT SELECT ON TABLE collisions.acc TO rsaunders;
 GRANT SELECT ON TABLE collisions.acc TO kchan;
@@ -122,4 +121,5 @@ COMMENT ON TABLE collisions.acc
 
 CREATE INDEX collisions_acc_idx
     ON collisions.acc USING btree
-    ("ACCNB", "ACCDATE");
+    ("ACCNB", "ACCDATE")
+    TABLESPACE pg_default;

--- a/collisions/collisions_alldata.sql
+++ b/collisions/collisions_alldata.sql
@@ -1,0 +1,21 @@
+-- View to shorten joining the events and involved tables together, effectively
+-- creating a version of `collisions.acc` with all numeric codes translated into
+-- text. This is a very common first analysis step.
+
+
+CREATE OR REPLACE VIEW collisions.alldata AS (
+    SELECT *
+    FROM collisions.events
+    LEFT JOIN collisions.involved USING (collision_no)
+);
+
+ALTER TABLE collisions.alldata
+    OWNER TO collision_admins;
+
+COMMENT ON VIEW collisions.alldata
+    IS 'View linking collisions.events and collisions.involved together through collision_no.';
+
+GRANT SELECT ON TABLE collisions.alldata TO bdit_humans;
+GRANT SELECT ON TABLE collisions.alldata TO rsaunders;
+GRANT SELECT ON TABLE collisions.alldata TO kchan;
+GRANT SELECT ON TABLE collisions.alldata TO ksun;

--- a/collisions/collisions_collision_no.sql
+++ b/collisions/collisions_collision_no.sql
@@ -1,0 +1,36 @@
+-- Creation script for collisions.collision_no.
+
+CREATE MATERIALIZED VIEW collisions.collision_no
+TABLESPACE pg_default
+AS
+    -- Select all unique ACCNB and year combinations - these should be unique to each collision event.
+    WITH unique_collisions AS (
+        SELECT DISTINCT a."ACCNB"::bigint AS accnb,
+                        date_part('year', a."ACCDATE"::date) AS accyear
+        FROM collisions.acc a
+        WHERE a."ACCDATE"::date >= '1985-01-01'::date AND a."ACCDATE"::date <= current_date
+    )
+    SELECT c.accyear,
+           c.accnb,
+           row_number() OVER (ORDER BY c.accyear, c.accnb) AS collision_no
+    FROM unique_collisions c
+WITH DATA;
+
+
+ALTER TABLE collisions.collision_no
+    OWNER TO czhu;
+
+COMMENT ON MATERIALIZED VIEW collisions.collision_no
+    IS 'Collision number to link involved and events matviews.';
+
+
+GRANT ALL ON TABLE collisions.collision_no TO czhu;
+GRANT SELECT ON TABLE collisions.collision_no TO bdit_humans;
+GRANT SELECT ON TABLE collisions.collision_no TO rsaunders;
+GRANT SELECT ON TABLE collisions.collision_no TO kchan;
+
+
+CREATE INDEX collisions_collision_no_idx
+    ON collisions.collision_no USING btree
+    (accnb, accyear)
+    TABLESPACE pg_default;

--- a/collisions/collisions_collision_no.sql
+++ b/collisions/collisions_collision_no.sql
@@ -28,6 +28,7 @@ GRANT ALL ON TABLE collisions.collision_no TO czhu;
 GRANT SELECT ON TABLE collisions.collision_no TO bdit_humans;
 GRANT SELECT ON TABLE collisions.collision_no TO rsaunders;
 GRANT SELECT ON TABLE collisions.collision_no TO kchan;
+GRANT SELECT ON TABLE collisions.collision_no TO ksun;
 
 
 CREATE INDEX collisions_collision_no_idx

--- a/collisions/collisions_collision_no.sql
+++ b/collisions/collisions_collision_no.sql
@@ -18,13 +18,11 @@ WITH DATA;
 
 
 ALTER TABLE collisions.collision_no
-    OWNER TO czhu;
+    OWNER TO collision_admins;
 
 COMMENT ON MATERIALIZED VIEW collisions.collision_no
     IS 'Collision number to link involved and events matviews.';
 
-
-GRANT ALL ON TABLE collisions.collision_no TO czhu;
 GRANT SELECT ON TABLE collisions.collision_no TO bdit_humans;
 GRANT SELECT ON TABLE collisions.collision_no TO rsaunders;
 GRANT SELECT ON TABLE collisions.collision_no TO kchan;

--- a/collisions/collisions_events.sql
+++ b/collisions/collisions_events.sql
@@ -1,0 +1,108 @@
+-- Script for creating a table of event-level variables from collisions.acc.
+
+-- DROP MATERIALIZED VIEW collisions.events;
+
+CREATE MATERIALIZED VIEW collisions.events
+TABLESPACE pg_default
+AS
+    WITH valid_rows AS (
+        SELECT *
+        FROM collisions.acc
+        WHERE "ACCDATE"::date >= '1985-01-01'::date AND "ACCDATE"::date <= current_date
+    ), event_desc AS (
+        SELECT a."ACCNB"::bigint accnb,
+               date_part('year', a."ACCDATE"::date) accyear,
+               -- Purposely not combining date and time to ensure compatibility with older queries.
+               a."ACCDATE"::date accdate,
+               a."ACCTIME"::time acctime,
+               a."LONGITUDE" + 0.00021::double precision longitude,
+               a."LATITUDE" + 0.000045::double precision latitude,
+               a."STNAME1" stname1,
+               a."STREETYPE1" streetype1,
+               a."DIR1" dir1,
+               a."STNAME2" stname2,
+               a."STREETYPE2" streetype2,
+               a."DIR2" dir2,
+               a."STNAME3" stname3,
+               a."STREETYPE3" streetype3,
+               a."DIR3" dir3,
+               a."ROAD_CLASS" road_class,
+               upper(btrim(b.description)) location_type,
+               upper(btrim(c.description)) location_class,
+               upper(btrim(d.description)) collision_type,
+               upper(btrim(e.description)) visibility,
+               upper(btrim(f.description)) light,
+               upper(btrim(g.description)) road_surface_cond,
+               upper(btrim(h.description)) traffic_control,
+               upper(btrim(i.description)) traffic_control_cond,
+               CASE
+                WHEN a."PRIVATE_PROPERTY" = 'Y' THEN True
+                WHEN a."PRIVATE_PROPERTY" = 'N' THEN False
+                ELSE NULL
+               END on_private_property
+        FROM valid_rows a
+        LEFT JOIN collision_factors.accloc b ON a."ACCLOC"::text = b.accloc
+        LEFT JOIN collision_factors.loccoord c ON a."LOCCOORD"::text = c.loccoord
+        LEFT JOIN collision_factors.acclass d ON a."ACCLASS"::text = d.acclass
+        LEFT JOIN collision_factors.visible e ON a."VISIBLE"::text = e.visible
+        LEFT JOIN collision_factors.light f ON a."LIGHT"::text = f.light
+        LEFT JOIN collision_factors.rdsfcond g ON a."RDSFCOND"::text = g.rdsfcond
+        LEFT JOIN collision_factors.traffictl h ON a."TRAFFICTL"::text = h.traffictl
+        LEFT JOIN collision_factors.trafctlcond i ON a."TRAFCTLCOND"::text = i.trafctlcond
+    -- There's only one non-NULL description per collision event, so must select for it.
+    ), events_desc AS (
+        SELECT a."ACCNB"::bigint accnb,
+               date_part('year', a."ACCDATE"::date) accyear,
+               -- Will just retrieve the non-NULL result.
+               MAX(a."DESCRIPTION") description
+        FROM valid_rows a
+        GROUP BY a."ACCNB"::bigint, date_part('year', a."ACCDATE"::date)
+    )
+    SELECT DISTINCT b.collision_no,
+           a.accnb,
+           a.accyear,
+           a.accdate,
+           a.acctime,
+           a.longitude,
+           a.latitude,
+           a.stname1,
+           a.streetype1,
+           a.dir1,
+           a.stname2,
+           a.streetype2,
+           a.dir2,
+           a.stname3,
+           a.streetype3,
+           a.dir3,
+           a.road_class,
+           a.location_type,
+           a.location_class,
+           a.collision_type,
+           a.visibility,
+           a.light,
+           a.road_surface_cond,
+           a.traffic_control,
+           a.traffic_control_cond,
+           a.on_private_property,
+           c.description
+    FROM event_desc a
+    LEFT JOIN collisions.collision_no b USING (accnb, accyear)
+    LEFT JOIN events_desc c USING (accnb, accyear)
+    -- This should only matter if collision.events is refreshed more than a day after collision.collision_no.
+    WHERE b.collision_no IS NOT NULL
+    ORDER BY b.collision_no
+WITH DATA;
+
+ALTER TABLE collisions.events
+    OWNER TO czhu;
+
+COMMENT ON MATERIALIZED VIEW collisions.events
+    IS 'Event-level variables in collisions.acc.';
+
+GRANT ALL ON TABLE collisions.events TO czhu;
+GRANT SELECT ON TABLE collisions.events TO bdit_humans;
+
+CREATE INDEX collision_events_idx
+    ON collisions.events USING btree
+    (collision_no)
+    TABLESPACE pg_default;

--- a/collisions/collisions_events.sql
+++ b/collisions/collisions_events.sql
@@ -47,6 +47,9 @@ AS
                END on_private_property,
                -- Based on https://github.com/CityofToronto/bdit_data-sources/pull/349#issuecomment-803133700
                CASE
+                   -- In the case of 2020 TPS collisions, the leading digit of
+                   -- ACCNB is 0, which must be treated uniquely.
+                   WHEN LEFT(a."ACCNB", 1) = '0' AND LENGTH(a."ACCNB") = 10 AND a."ACCDATE" BETWEEN '2020-01-01' AND '2020-12-31' THEN 'TPS'
                    WHEN a."ACCNB"::bigint >= 1000000000 THEN 'TPS'
                    WHEN a."ACCNB"::bigint >= 100000000 THEN 'CRC'
                    ELSE NULL

--- a/collisions/collisions_events.sql
+++ b/collisions/collisions_events.sql
@@ -9,7 +9,7 @@ AS
         SELECT *
         FROM collisions.acc
         WHERE "ACCDATE"::date >= '1985-01-01'::date AND "ACCDATE"::date <= current_date
-    ), event_desc AS (
+    ), events_dat AS (
         SELECT a."ACCNB"::bigint accnb,
                date_part('year', a."ACCDATE"::date) accyear,
                -- Purposely not combining date and time to ensure compatibility with older queries.
@@ -85,11 +85,9 @@ AS
            a.traffic_control_cond,
            a.on_private_property,
            c.description
-    FROM event_desc a
-    LEFT JOIN collisions.collision_no b USING (accnb, accyear)
+    FROM events_dat a
+    JOIN collisions.collision_no b USING (accnb, accyear)
     LEFT JOIN events_desc c USING (accnb, accyear)
-    -- This should only matter if collision.events is refreshed more than a day after collision.collision_no.
-    WHERE b.collision_no IS NOT NULL
     ORDER BY b.collision_no
 WITH DATA;
 
@@ -101,6 +99,9 @@ COMMENT ON MATERIALIZED VIEW collisions.events
 
 GRANT ALL ON TABLE collisions.events TO czhu;
 GRANT SELECT ON TABLE collisions.events TO bdit_humans;
+GRANT SELECT ON TABLE collisions.events TO rsaunders;
+GRANT SELECT ON TABLE collisions.events TO kchan;
+GRANT SELECT ON TABLE collisions.events TO ksun;
 
 CREATE INDEX collision_events_idx
     ON collisions.events USING btree

--- a/collisions/collisions_involved.sql
+++ b/collisions/collisions_involved.sql
@@ -5,7 +5,7 @@
 CREATE MATERIALIZED VIEW collisions.involved
 TABLESPACE pg_default
 AS
-	WITH involved_desc AS (
+    WITH involved_desc AS (
         SELECT a."ACCNB"::bigint AS accnb,
                date_part('year', a."ACCDATE"::date) AS accyear,
                CASE
@@ -13,8 +13,8 @@ AS
                    ELSE NULL::integer
                END vehicle_no,
                CASE
-               	   WHEN btrim(a."PER_NO"::text) ~ '^[0-9]+$'::text THEN btrim(a."PER_NO"::text)::integer
-               	   ELSE NULL::integer
+                      WHEN btrim(a."PER_NO"::text) ~ '^[0-9]+$'::text THEN btrim(a."PER_NO"::text)::integer
+                      ELSE NULL::integer
                END person_no,
                upper(btrim(i.description)) AS vehicle_class,
                upper(btrim(j.description)) AS initial_dir,
@@ -75,39 +75,39 @@ AS
         LEFT JOIN collision_factors.cyclistype y ON a."CYCLISTYPE"::text = y.cyclistype
         LEFT JOIN collision_factors.manoeuver z ON a."MANOEUVER"::text = z.manoeuver
     )
-	SELECT b.collision_no,
-	       a.vehicle_no,
-	       a.person_no,
-	       a.vehicle_class,
-	       a.initial_dir,
-	       a.impact_type,
-	       a.event1,
-	       a.event2,
-	       a.event3,
-	       a.involved_class,
-	       CASE
-	           WHEN a.involved_age > 0 THEN a.involved_age
-	           WHEN a.involved_age = 0 AND a.birthdate IS NOT NULL THEN a.involved_age
-	           ELSE NULL::integer
-	       END AS involved_age,
-	       a.involved_injury_class,
-	       a.safety_equip_used,
-	       a.driver_action,
-	       a.driver_condition,
-	       a.pedestrian_action,
-	       a.pedestrian_condition,
-	       a.pedestrian_collision_type,
-	       a.cyclist_action,
-	       a.cyclist_condition,
-	       a.cyclist_collision_type,
-	       a.manoeuver,
-	       a.posted_speed,
-	       a.actual_speed,
-	       a.failed_to_remain,
+    SELECT b.collision_no,
+           a.vehicle_no,
+           a.person_no,
+           a.vehicle_class,
+           a.initial_dir,
+           a.impact_type,
+           a.event1,
+           a.event2,
+           a.event3,
+           a.involved_class,
+           CASE
+               WHEN a.involved_age > 0 THEN a.involved_age
+               WHEN a.involved_age = 0 AND a.birthdate IS NOT NULL THEN a.involved_age
+               ELSE NULL::integer
+           END AS involved_age,
+           a.involved_injury_class,
+           a.safety_equip_used,
+           a.driver_action,
+           a.driver_condition,
+           a.pedestrian_action,
+           a.pedestrian_condition,
+           a.pedestrian_collision_type,
+           a.cyclist_action,
+           a.cyclist_condition,
+           a.cyclist_collision_type,
+           a.manoeuver,
+           a.posted_speed,
+           a.actual_speed,
+           a.failed_to_remain,
            a.is_validated
-	FROM involved_desc a
-	JOIN collisions.collision_no b USING (accnb, accyear)
-	ORDER BY b.collision_no
+    FROM involved_desc a
+    JOIN collisions.collision_no b USING (accnb, accyear)
+    ORDER BY b.collision_no
 WITH DATA;
 
 ALTER TABLE collisions.involved

--- a/collisions/collisions_involved.sql
+++ b/collisions/collisions_involved.sql
@@ -106,9 +106,7 @@ AS
 	       a.failed_to_remain,
            a.is_validated
 	FROM involved_desc a
-	LEFT JOIN collisions.collision_no b USING (accnb, accyear)
-    -- This should only matter if collision.events is refreshed more than a day after collision.collision_no.
-    WHERE b.collision_no IS NOT NULL
+	JOIN collisions.collision_no b USING (accnb, accyear)
 	ORDER BY b.collision_no
 WITH DATA;
 
@@ -120,6 +118,9 @@ COMMENT ON MATERIALIZED VIEW collisions.involved
 
 GRANT ALL ON TABLE collisions.involved TO czhu;
 GRANT SELECT ON TABLE collisions.involved TO bdit_humans;
+GRANT SELECT ON TABLE collisions.involved TO rsaunders;
+GRANT SELECT ON TABLE collisions.involved TO kchan;
+GRANT SELECT ON TABLE collisions.involved TO ksun;
 
 CREATE INDEX collision_involved_idx
     ON collisions.involved USING btree

--- a/collisions/collisions_involved.sql
+++ b/collisions/collisions_involved.sql
@@ -1,0 +1,127 @@
+-- Script for creating a table of individual-level variables from collisions.acc.
+
+-- DROP MATERIALIZED VIEW collisions.involved;
+
+CREATE MATERIALIZED VIEW collisions.involved
+TABLESPACE pg_default
+AS
+	WITH involved_desc AS (
+        SELECT a."ACCNB"::bigint AS accnb,
+               date_part('year', a."ACCDATE"::date) AS accyear,
+               CASE
+                   WHEN btrim(a."VEH_NO"::text) ~ '^[0-9]+$'::text THEN btrim(a."VEH_NO"::text)::integer
+                   ELSE NULL::integer
+               END vehicle_no,
+               CASE
+               	   WHEN btrim(a."PER_NO"::text) ~ '^[0-9]+$'::text THEN btrim(a."PER_NO"::text)::integer
+               	   ELSE NULL::integer
+               END person_no,
+               upper(btrim(i.description)) AS vehicle_class,
+               upper(btrim(j.description)) AS initial_dir,
+               upper(btrim(k.description)) AS impact_type,
+               upper(btrim(l.description)) AS event1,
+               upper(btrim(m.description)) AS event2,
+               upper(btrim(n.description)) AS event3,
+               upper(btrim(o.description)) AS involved_class,
+               CASE
+                   WHEN btrim(a."INVAGE"::text) ~ '^[0-9]+$'::text THEN btrim(a."INVAGE"::text)::integer
+                   ELSE NULL::integer
+               END AS involved_age,
+               upper(btrim(p.description)) AS involved_injury_class,
+               upper(btrim(q.description)) AS safety_equip_used,
+               upper(btrim(r.description)) AS driver_action,
+               upper(btrim(s.description)) AS driver_condition,
+               upper(btrim(t.description)) AS pedestrian_action,
+               upper(btrim(u.description)) AS pedestrian_condition,
+               upper(btrim(v.description)) AS pedestrian_collision_type,
+               upper(btrim(w.description)) AS cyclist_action,
+               upper(btrim(x.description)) AS cyclist_condition,
+               upper(btrim(y.description)) AS cyclist_collision_type,
+               upper(btrim(z.description)) AS manoeuver,
+               a."POSTED_SPEED"::integer AS posted_speed,
+               a."ACTUAL_SPEED"::integer AS actual_speed,
+               CASE
+                   WHEN a."FAILTOREM" = 1 THEN true
+                   ELSE false
+               END AS failed_to_remain,
+               a."BIRTHDATE" AS birthdate,
+               -- Validation is sometimes partial, so keep it at an individual level.
+               CASE
+                 WHEN a."USERID" IS NOT NULL THEN True
+                 ELSE False
+               END is_validated
+        FROM (SELECT *
+              FROM collisions.acc
+              WHERE "ACCDATE"::date >= '1985-01-01'::date AND "ACCDATE"::date <= current_date) a
+        LEFT JOIN (SELECT DISTINCT ON (vehtype.vehtype) vehtype.vehtype,
+                          vehtype.description
+                   FROM collision_factors.vehtype
+                   ORDER BY vehtype.vehtype, (char_length(vehtype.description))) i ON a."VEHTYPE"::text = i.vehtype
+        LEFT JOIN collision_factors.initdir j ON a."INITDIR"::text = j.initdir
+        LEFT JOIN collision_factors.impactype k ON a."IMPACTYPE"::text = k.impactype
+        LEFT JOIN collision_factors.event1 l ON a."EVENT1"::text = l.event1
+        LEFT JOIN collision_factors.event2 m ON a."EVENT2"::text = m.event2
+        LEFT JOIN collision_factors.event3 n ON a."EVENT3"::text = n.event3
+        LEFT JOIN collision_factors.invtype o ON a."INVTYPE"::text = o.invtype
+        LEFT JOIN collision_factors.injury p ON a."INJURY"::text = p.injury
+        LEFT JOIN collision_factors.safequip q ON a."SAFEQUIP"::text = q.safequip
+        LEFT JOIN collision_factors.drivact r ON a."DRIVACT"::text = r.drivact
+        LEFT JOIN collision_factors.drivcond s ON a."DRIVCOND"::text = s.drivcond
+        LEFT JOIN collision_factors.pedact t ON a."PEDACT"::text = t.pedact
+        LEFT JOIN collision_factors.pedcond u ON a."PEDCOND"::text = u.pedcond
+        LEFT JOIN collision_factors.pedtype v ON a."PEDTYPE"::text = v.pedtype
+        LEFT JOIN collision_factors.cycact w ON a."CYCACT"::text = w.cycact
+        LEFT JOIN collision_factors.cyccond x ON a."CYCCOND"::text = x.cyccond
+        LEFT JOIN collision_factors.cyclistype y ON a."CYCLISTYPE"::text = y.cyclistype
+        LEFT JOIN collision_factors.manoeuver z ON a."MANOEUVER"::text = z.manoeuver
+    )
+	SELECT b.collision_no,
+	       a.vehicle_no,
+	       a.person_no,
+	       a.vehicle_class,
+	       a.initial_dir,
+	       a.impact_type,
+	       a.event1,
+	       a.event2,
+	       a.event3,
+	       a.involved_class,
+	       CASE
+	           WHEN a.involved_age > 0 THEN a.involved_age
+	           WHEN a.involved_age = 0 AND a.birthdate IS NOT NULL THEN a.involved_age
+	           ELSE NULL::integer
+	       END AS involved_age,
+	       a.involved_injury_class,
+	       a.safety_equip_used,
+	       a.driver_action,
+	       a.driver_condition,
+	       a.pedestrian_action,
+	       a.pedestrian_condition,
+	       a.pedestrian_collision_type,
+	       a.cyclist_action,
+	       a.cyclist_condition,
+	       a.cyclist_collision_type,
+	       a.manoeuver,
+	       a.posted_speed,
+	       a.actual_speed,
+	       a.failed_to_remain,
+           a.is_validated
+	FROM involved_desc a
+	LEFT JOIN collisions.collision_no b USING (accnb, accyear)
+    -- This should only matter if collision.events is refreshed more than a day after collision.collision_no.
+    WHERE b.collision_no IS NOT NULL
+	ORDER BY b.collision_no
+WITH DATA;
+
+ALTER TABLE collisions.involved
+    OWNER TO czhu;
+
+COMMENT ON MATERIALIZED VIEW collisions.involved
+    IS 'Individual-level variables in collisions.acc.';
+
+GRANT ALL ON TABLE collisions.involved TO czhu;
+GRANT SELECT ON TABLE collisions.involved TO bdit_humans;
+
+CREATE INDEX collision_involved_idx
+    ON collisions.involved USING btree
+    (collision_no)
+    TABLESPACE pg_default;

--- a/collisions/pull_acc_script.py
+++ b/collisions/pull_acc_script.py
@@ -118,7 +118,7 @@ def upload_acc(accpath, postgres_settings, logger, deletefile):
             cur.execute("COMMENT ON TABLE collisions.acc IS "
                         "'Raw collision database, from Flashcrow "
                         "/data/replicator/flashcrow-CRASH/dat/ACC.dat. "
-                        "Refreshed on %s.';".format(
+                        "Refreshed on {td:s}.';".format(
                             td=str(datetime.date.today())))
 
     if deletefile:

--- a/collisions/pull_acc_script.py
+++ b/collisions/pull_acc_script.py
@@ -71,7 +71,8 @@ def download_acc(flashcrow_settings, templocation, accpath, logger):
 
     logger.info('Downloading ACC.dat from Flashcrow server.')
     rsync_command = [
-        'rsync', '-Pav', '-e', 'ssh -i {:s}'.format(flashcrow_settings['pem']),
+        '/usr/bin/rsync', '-Pav', '-e',
+        'ssh -i {:s}'.format(flashcrow_settings['pem']),
         ('ec2-user@flashcrow-etl.intra.dev-toronto.ca:'
          '/data/replicator/flashcrow-CRASH/dat/ACC.dat'), templocation]
     # check_returncode raises an exception if the command failed.
@@ -88,7 +89,7 @@ def download_acc(flashcrow_settings, templocation, accpath, logger):
     # https://stackoverflow.com/questions/15361632/delete-a-column-with-awk-or-sed
     logger.info('Removing double-quotes from ACC.dat for '
                 'compatibility with PSQL.')
-    sed_command = ['sed', '-i', 's/"//g', accpath]
+    sed_command = ['/bin/sed', '-i', 's/"//g', accpath]
     outcome = subprocess.run(sed_command, stderr=subprocess.PIPE)
     try:
         outcome.check_returncode()
@@ -118,7 +119,7 @@ def upload_acc(accpath, postgres_settings, logger, deletefile):
     # Upload new data.
     logger.info('Uploading ACC.dat to Postgres.')
     upload_command = [
-        'psql', '-U', postgres_settings['user'], '-h',
+        '/usr/bin/psql', '-U', postgres_settings['user'], '-h',
         postgres_settings['host'], '-d', postgres_settings['dbname'], '-c',
         ('\\COPY collisions.acc FROM \'{0}\' WITH (DELIMITER E\'\\t\', NULL '
          '\'\\N\', FORMAT CSV, HEADER FALSE);').format(accpath)
@@ -144,7 +145,7 @@ def upload_acc(accpath, postgres_settings, logger, deletefile):
 
     if deletefile:
         logger.info('Deleting ACC.dat')
-        outcome = subprocess.run(['rm', accpath], stderr=subprocess.PIPE)
+        outcome = subprocess.run(['/bin/rm', accpath], stderr=subprocess.PIPE)
         try:
             outcome.check_returncode()
         except subprocess.CalledProcessError:

--- a/collisions/pull_acc_script.py
+++ b/collisions/pull_acc_script.py
@@ -1,0 +1,240 @@
+"""ACC dataset puller.
+
+Pulls ACC.dat from the Flashcrow server and uploads it to collisions.ACC
+"""
+
+import click
+import configparser
+import os
+import datetime
+import pathlib
+import psycopg2
+import logging
+
+
+def logger():
+    """Generic logger, from intersection_tmc.py."""
+
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    formatter = logging.Formatter(
+        '%(asctime)s        %(levelname)s    %(message)s',
+        datefmt='%d %b %Y %H:%M:%S')
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    return logger
+
+
+logger = logger()
+logger.debug('Start')
+
+
+@click.command()
+@click.option('--cfgpath',
+              help='The filepath of the configparser settings file.')
+@click.option('--templocation',
+              default='./',
+              help='Filepath for temporarily storing ACC.dat.')
+@click.option('--deletefile', default=True, type=bool,
+              help="If True, delete ACC.dat after use.")
+def pull_acc(cfgpath, templocation, deletefile):
+    """Main function."""
+
+    # Extract the location of the pem key.
+    config = configparser.ConfigParser()
+    config.read(cfgpath)
+    flashcrow_settings = config['FLASHCROW']
+
+    # Extract Postgres creds.
+    postgres_settings = config['POSTGRES']
+
+    # Full filepath of downloaded ACC.dat.
+    accpath = str(pathlib.Path(templocation).joinpath('ACC.dat'))
+
+    logger.info('Upload ACC.dat from Flashcrow to Postgres table.')
+    acc_lc = download_acc(flashcrow_settings, templocation, accpath, logger)
+    upload_acc(accpath, postgres_settings, logger, deletefile)
+
+    logger.info('Processing derived matviews on Postgres.')
+    process_acc(postgres_settings, logger)
+
+    logger.info('Checking upload self-consistency.')
+    check_tables(acc_lc, postgres_settings, logger)
+
+    logger.info('Complete!')
+
+
+def download_acc(flashcrow_settings, templocation, accpath, logger):
+    """Downloads ACC.dat from Flashcrow."""
+
+    logger.info('Downloading ACC.dat from Flashcrow server.')
+    rsync_command = (
+        'rsync -Pav -e "ssh -i {pk:s}" '
+        'ec2-user@flashcrow-etl.intra.dev-toronto.ca:'
+        '/data/replicator/flashcrow-CRASH/dat/ACC.dat {fl:s}')
+    os.system(rsync_command
+              .format(pk=flashcrow_settings['pem'], fl=templocation))
+
+    # To also delete columns, use """sed -i -r 's/\S+//{COLUMN NUMBER}' {FILE}"""
+    # https://stackoverflow.com/questions/15361632/delete-a-column-with-awk-or-sed
+    sedcommand = """sed -i 's/"//g' {fp:s}"""
+    logger.info('Reformatting ACC for compatibility with PSQL using '
+                + sedcommand.format(fp=accpath))
+    os.system(sedcommand.format(fp=accpath))
+
+    # Get number of lines in ACC.dat, which is used later for self-consistency
+    # checks.
+    with open(accpath) as f:
+        acc_lc = sum(1 for _ in f)
+
+    return acc_lc
+
+
+def upload_acc(accpath, postgres_settings, logger, deletefile):
+    """Uploads ACC.dat to collisions.acc."""
+
+    # Ensure modified rows are replaced.
+    logger.info('Truncating collisions.acc.')
+    with psycopg2.connect(**postgres_settings) as conn:
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE collisions.acc;")
+
+    # Upload new data.
+    upload_kwargs = dict(postgres_settings)
+    upload_kwargs['accpath'] = accpath
+    upload_command = (
+        r"""psql -U {user} -h {host} -d {dbname} -c "\COPY """
+        r"""collisions.acc FROM '{accpath}' WITH """
+        r"""(DELIMITER E'\t', NULL '\N', FORMAT CSV, HEADER FALSE);" """)
+    logger.info('Uploading ACC.dat using '
+                + upload_command.format(**upload_kwargs))
+    os.system(upload_command.format(**upload_kwargs))
+
+    with psycopg2.connect(**postgres_settings) as conn:
+        with conn.cursor() as cur:
+            # Mention date of latest upload.
+            cur.execute("COMMENT ON TABLE collisions.acc IS "
+                        "'Raw collision database, from Flashcrow "
+                        "/data/replicator/flashcrow-CRASH/dat/ACC.dat. "
+                        "Refreshed on %s.';".format(
+                            td=str(datetime.date.today())))
+
+    if deletefile:
+        logger.info('Deleting ACC.dat')
+        os.remove(accpath)
+
+
+def process_acc(postgres_settings, logger):
+    """Processes child materialized views of collisions.acc."""
+
+    with psycopg2.connect(**postgres_settings) as conn:
+        with conn.cursor() as cur:
+            # Refresh materialized views.
+            logger.info('Refreshing collisions.collision_no.')
+            cur.execute("REFRESH MATERIALIZED VIEW collisions.collision_no;")
+            cur.execute("COMMENT ON MATERIALIZED VIEW "
+                        "collisions.collision_no IS "
+                        "'Collision number to link involved and "
+                        "events matviews. Refreshed on {td:s}.';".format(
+                            td=str(datetime.date.today())))
+
+            logger.info('Refreshing collisions.events.')
+            cur.execute("REFRESH MATERIALIZED VIEW collisions.events;")
+            cur.execute("COMMENT ON MATERIALIZED VIEW "
+                        "collisions.events IS "
+                        "'Event-level variables in collisions.acc. "
+                        "Refreshed on {td:s}.';".format(
+                            td=str(datetime.date.today())))
+
+            logger.info('Refreshing collisions.involved.')
+            cur.execute("REFRESH MATERIALIZED VIEW collisions.involved;")
+            cur.execute("COMMENT ON MATERIALIZED VIEW "
+                        "collisions.involved IS "
+                        "'Individual-level variables in collisions.acc. "
+                        "Refreshed on {td:s}.';".format(
+                            td=str(datetime.date.today())))
+
+
+def check_tables(acc_lc, postgres_settings, logger):
+    """Basic self-consistency checks of processed tables."""
+
+    # Processing self-consistency checks.
+    with psycopg2.connect(**postgres_settings) as conn:
+        with conn.cursor() as cur:
+            # Number of lines in collisions.acc
+            cur.execute("SELECT COUNT(*) total_lc FROM collisions.acc")
+            pgacc_lc = cur.fetchone()[0]
+
+            # Number of unique ACCNB/year.
+            cur.execute(
+                """WITH distinct_col AS (
+                       SELECT DISTINCT "ACCNB",
+                              EXTRACT(year FROM "ACCDATE"::date) accyear
+                       FROM collisions.acc
+                       WHERE "ACCDATE"::date >= '1985-01-01'::date
+                           AND "ACCDATE"::date <= current_date
+                   )
+                   SELECT COUNT(*) FROM distinct_col""")
+            n_col_events = cur.fetchone()[0]
+
+            # Lines in collisions.collision_no.
+            cur.execute("SELECT COUNT(*) FROM collisions.collision_no")
+            colno_lc = cur.fetchone()[0]
+
+            # Lines in collisions.events.
+            cur.execute("SELECT COUNT(*) FROM collisions.events")
+            n_events = cur.fetchone()[0]
+
+            # Unique collision numbers in in collisions.involved.
+            cur.execute("SELECT COUNT(DISTINCT collision_no) "
+                        "FROM collisions.involved")
+            n_colno_involved = cur.fetchone()[0]
+
+            # Number of NaN collision numbers in events.
+            cur.execute("SELECT COUNT(*) FROM collisions.events "
+                        "WHERE collision_no IS NULL")
+            n_events_nan = cur.fetchone()[0]
+
+            # Number of NaN collision numbers in involved.
+            cur.execute("SELECT COUNT(*) FROM collisions.involved "
+                        "WHERE collision_no IS NULL")
+            n_involved_nan = cur.fetchone()[0]
+
+        if acc_lc != pgacc_lc:
+            logger.warning("Number of lines in ACC.dat ({0}) differs "
+                           "from number of lines in collisions.acc ({1})!"
+                           .format(acc_lc, pgacc_lc))
+
+        if n_col_events != colno_lc:
+            logger.warning("Number of unique ACCNB/years in collisions.acc "
+                           "({0}) differs from number of lines in "
+                           "collisions.collision_no ({1})!"
+                           .format(n_col_events, colno_lc))
+
+        if n_events != colno_lc:
+            logger.warning("Number of lines in collisions.events "
+                           "({0}) differs from number of lines in "
+                           "collisions.collision_no ({1})!"
+                           .format(n_events, colno_lc))
+
+        if n_events != n_colno_involved:
+            logger.warning("Number of lines in collisions.events "
+                           "({0}) differs from number of unique collision "
+                           "numbers in collisions.involved ({1})!"
+                           .format(n_events, colno_lc))
+
+        if n_events_nan:
+            logger.warning("Found {0} lines in collisions.events "
+                           "without a collision number!"
+                           .format(n_events_nan))
+
+        if n_involved_nan:
+            logger.warning("Found {0} lines in collisions.involved "
+                           "without a collision number!"
+                           .format(n_involved_nan))
+
+
+if __name__ == '__main__':
+    pull_acc()

--- a/collisions/pull_acc_script.py
+++ b/collisions/pull_acc_script.py
@@ -102,11 +102,10 @@ def upload_acc(accpath, postgres_settings, logger, deletefile):
             cur.execute("TRUNCATE collisions.acc;")
 
     # Upload new data.
-    logger.info('Uploading ACC.dat using '
-                + upload_command.format(**upload_kwargs))
+    logger.info('Uploading ACC.dat to Postgres.')
     upload_command = [
-        'psql', '-U', upload_kwargs['user'], '-h', upload_kwargs['host'],
-        '-d', upload_kwargs['dbname'], '-c',
+        'psql', '-U', postgres_settings['user'], '-h',
+        postgres_settings['host'], '-d', postgres_settings['dbname'], '-c',
         ('\\COPY czhu.acctest FROM \'{0}\' WITH (DELIMITER E\'\\t\', NULL '
          '\'\\N\', FORMAT CSV, HEADER FALSE);').format(accpath)
     ]


### PR DESCRIPTION
## What this pull request accomplishes:

- Adds table and view definitions for collisions dataset on Postgres.
- Adds a Python script, `pull_acc_script.py`, that manually retrieves `ACC.dat` from the MOVE server and uploads it to Postgres. This will become deprecated once the RDS gets moved to Canada East, but most of the Postgres components of the script should still be useful.
- Cleaned RDS of old versions of ACC, and added legacy suffixes to those tables that still have parent views in production (see #347 for progress).

## Issue(s) this solves:

- #348

## What, in particular, needs to reviewed:

- Check of the SQL scripts to make sure I'm not doing anything silly.
- Check resulting table structures on Postgres (under `collisions` schema) to ensure everything makes sense.
- Quick read of Readme.md to make sure I'm not missing anything.

- Should we get rid of `collision_factors.collision_id` and `collision_factors.collision_id_date`?