### PR TITLE
Fix missing timebin issue with daterange (#355).

### DIFF
--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -13,7 +13,6 @@ import configparser
 import click
 import traceback
 from time import sleep
-from datetimerange import DateTimeRange
 
 
 class BreakingError(Exception):
@@ -296,6 +295,14 @@ def insert_data(conn, start_time, end_iteration_time, table, dupes):
             logger.info(conn.notices[-1])
 
 
+def daterange(start_time, end_time, time_delta):
+    """Generator for a sequence of regular time periods."""
+    curr_time = start_time
+    while curr_time < end_time:
+        yield curr_time
+        curr_time += time_delta
+
+
 def pull_data(conn, start_time, end_time, intersection, path, pull, key, dupes):
 
     time_delta = datetime.timedelta(hours=6)
@@ -323,12 +330,7 @@ def pull_data(conn, start_time, end_time, intersection, path, pull, key, dupes):
         logger.critical('No intersections found in miovision_api.intersections for the specified start time')
         sys.exit(3)
 
-    # Subtract 1 minute because DateTimeRange goes from start_time to end_time
-    # inclusive.
-    start_time_range = DateTimeRange(
-        start_time, end_time - datetime.timedelta(minutes=1)).range(time_delta)
-
-    for c_start_t in start_time_range:
+    for c_start_t in daterange(start_time, end_time, time_delta):
 
         c_end_t = c_start_t + time_delta
         table = []

--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -8,7 +8,6 @@ import dateutil.parser
 import psycopg2
 from psycopg2.extras import execute_values
 from psycopg2 import connect, Error
-import math
 import logging
 import configparser
 import click
@@ -300,7 +299,7 @@ def insert_data(conn, start_time, end_iteration_time, table, dupes):
 
 def daterange(start_time, end_time, dt):
     """Generator for a sequence of regular time periods."""
-    for i in range(math.ceil((end_time - start_time) / dt) - 1):
+    for i in range(round((end_time - start_time) / dt)):
         c_start_t = start_time + i * dt
         yield (c_start_t, c_start_t + dt)
 

--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -13,6 +13,7 @@ import configparser
 import click
 import traceback
 from time import sleep
+from datetimerange import DateTimeRange
 
 
 class BreakingError(Exception):
@@ -55,7 +56,7 @@ logger.debug('Start')
 time_delta = datetime.timedelta(days=1)
 default_start=str(datetime.date.today()-time_delta)
 default_end=str(datetime.date.today())
-local_tz=pytz.timezone('US/Eastern')
+
 session = Session()
 session.proxies = {}
 url='https://api.miovision.com/intersections/'
@@ -90,11 +91,9 @@ def run_api(start_date, end_date, path, intersection, pull, dupes):
     conn.autocommit = True
     logger.debug('Connected to DB')
 
-    start_date= dateutil.parser.parse(str(start_date))
-    end_date= dateutil.parser.parse(str(end_date))
-    start_time=local_tz.localize(start_date)
-    end_time=local_tz.localize(end_date)
-    logger.info('Pulling from %s to %s' %(start_time,end_time))
+    start_time = dateutil.parser.parse(str(start_date))
+    end_time = dateutil.parser.parse(str(end_date))
+    logger.info('Pulling from %s to %s' %(start_time, end_time))
 
     try:
         pull_data(conn, start_time, end_time, intersection, path, pull, key, dupes)
@@ -297,12 +296,6 @@ def insert_data(conn, start_time, end_iteration_time, table, dupes):
             logger.info(conn.notices[-1])
 
 
-def daterange(start_time, end_time, time_delta):
-    """Generator for a sequence of regular time periods."""
-    for i in range(round((end_time - start_time) / time_delta)):
-        yield start_time + i * time_delta
-
-
 def pull_data(conn, start_time, end_time, intersection, path, pull, key, dupes):
 
     time_delta = datetime.timedelta(hours=6)
@@ -330,7 +323,12 @@ def pull_data(conn, start_time, end_time, intersection, path, pull, key, dupes):
         logger.critical('No intersections found in miovision_api.intersections for the specified start time')
         sys.exit(3)
 
-    for c_start_t in daterange(start_time, end_time, time_delta):
+    # Subtract 1 minute because DateTimeRange goes from start_time to end_time
+    # inclusive.
+    start_time_range = DateTimeRange(
+        start_time, end_time - datetime.timedelta(minutes=1)).range(time_delta)
+
+    for c_start_t in start_time_range:
 
         c_end_t = c_start_t + time_delta
         table = []

--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -297,11 +297,10 @@ def insert_data(conn, start_time, end_iteration_time, table, dupes):
             logger.info(conn.notices[-1])
 
 
-def daterange(start_time, end_time, dt):
+def daterange(start_time, end_time, time_delta):
     """Generator for a sequence of regular time periods."""
-    for i in range(round((end_time - start_time) / dt)):
-        c_start_t = start_time + i * dt
-        yield (c_start_t, c_start_t + dt)
+    for i in range(round((end_time - start_time) / time_delta)):
+        yield start_time + i * time_delta
 
 
 def pull_data(conn, start_time, end_time, intersection, path, pull, key, dupes):
@@ -331,8 +330,9 @@ def pull_data(conn, start_time, end_time, intersection, path, pull, key, dupes):
         logger.critical('No intersections found in miovision_api.intersections for the specified start time')
         sys.exit(3)
 
-    for (c_start_t, c_end_t) in daterange(start_time, end_time, time_delta):
+    for c_start_t in daterange(start_time, end_time, time_delta):
 
+        c_end_t = c_start_t + time_delta
         table = []
 
         for interxn in intersection_list:


### PR DESCRIPTION
## What this pull request accomplishes:

- Fixes a bug in `daterange` in `intersection_tmc.py` where the last interval of the range would be missing when `dt` divides evenly into `end_time - start_time`.

## Issue(s) this solves:

- Closes #355

## What, in particular, needs to reviewed:

- Confirm the fix and work in #355 is sensible.
- Quick brainstorm of edge cases where `daterange` may break that we should address.
