### PR TITLE
Synchronize functions between Miovision CSV and API pipelines

### DIFF
--- a/volumes/miovision/sql/csv_data/function-aggregate-volumes_15min_tmc_2020.sql
+++ b/volumes/miovision/sql/csv_data/function-aggregate-volumes_15min_tmc_2020.sql
@@ -12,12 +12,12 @@ BEGIN
 
 WITH zero_padding_movements AS (
 	-- Cross product of legal movement for cars, bikes, and peds and the bins to aggregate
-	SELECT m.*, datetime_bin15 
+	SELECT m.*, datetime_bin15
 	FROM miovision_api.intersection_movements m
 	CROSS JOIN generate_series(start_date - interval '1 hour', end_date - interval '1 hour 15 minutes', INTERVAL '15 minutes') AS dt(datetime_bin15)
 	-- Make sure that the intersection is still active
-	LEFT JOIN miovision_api.intersections mai USING (intersection_uid)
-	-- Date installed or 
+	JOIN miovision_api.intersections mai USING (intersection_uid)
+	-- Only include dates during which intersection is active.
 	WHERE datetime_bin15::date > mai.date_installed AND (mai.date_decommissioned IS NULL OR (datetime_bin15::date < mai.date_decommissioned))
 )
 , aggregate_insert AS (

--- a/volumes/miovision/sql/csv_data/function-find_gaps_2020.sql
+++ b/volumes/miovision/sql/csv_data/function-find_gaps_2020.sql
@@ -36,7 +36,7 @@ WITH wkdy_lookup(period, isodow) AS (
             WHEN avg(mio.vol) >= 500::numeric AND avg(mio.vol) < 1500::numeric THEN 10
             WHEN avg(mio.vol) > 1500::numeric THEN 5
             ELSE NULL::integer
-        END AS gap_size
+        END AS gap_tolerance
    FROM mio
      CROSS JOIN wkdy_lookup d
   WHERE date_part('isodow'::text, mio.hourly_bin)::integer <@ d.isodow
@@ -82,9 +82,9 @@ WITH wkdy_lookup(period, isodow) AS (
 ), acceptable AS (
 	-- THEN, MATCH IT TO THE LOOKUP TABLE TO CHECK IF ACCEPTABLE
 	SELECT sel.intersection_uid, sel.gap_start, sel.gap_end,
-		sel.gap_minute, gapsize_lookup.gap_size AS allowed_gap,
-	CASE WHEN gap_minute < gapsize_lookup.gap_size THEN TRUE
-	WHEN gap_minute >= gapsize_lookup.gap_size THEN FALSE
+		sel.gap_minute, gapsize_lookup.gap_tolerance AS allowed_gap,
+	CASE WHEN gap_minute < gapsize_lookup.gap_tolerance THEN TRUE
+	WHEN gap_minute >= gapsize_lookup.gap_tolerance THEN FALSE
 	END AS accept
 	FROM sel 
 	LEFT JOIN gapsize_lookup

--- a/volumes/miovision/sql/function-find_gaps.sql
+++ b/volumes/miovision/sql/function-find_gaps.sql
@@ -17,13 +17,13 @@ BEGIN
 WITH wkdy_lookup(period, isodow) AS (
          VALUES ('Weekday'::text,'[1,6)'::int4range), ('Weekend'::text,'[6,8)'::int4range)
 ), mio AS (
- SELECT volumes.intersection_uid,
-    datetime_bin(volumes.datetime_bin, 60) AS hourly_bin,
-    sum(volumes.volume) AS vol
+ SELECT intersection_uid,
+    datetime_bin(datetime_bin, 60) AS hourly_bin,
+    sum(volume) AS vol
    FROM miovision_api.volumes
-  WHERE volumes.datetime_bin > (GREATEST(end_date::timestamp without time zone, '2019-03-01'::timestamp without time zone) - '60 days'::interval) AND
-        volumes.datetime_bin <= GREATEST(end_date::timestamp without time zone, '2019-03-01'::timestamp without time zone)
-  GROUP BY volumes.intersection_uid, (datetime_bin(volumes.datetime_bin, 60))
+  WHERE datetime_bin > (GREATEST(end_date::timestamp without time zone, '2019-03-01'::timestamp without time zone) - '60 days'::interval) AND
+        datetime_bin <= GREATEST(end_date::timestamp without time zone, '2019-03-01'::timestamp without time zone)
+  GROUP BY intersection_uid, (datetime_bin(datetime_bin, 60))
 ), gapsize_lookup AS (
  SELECT mio.intersection_uid,
     d.period,


### PR DESCRIPTION
## What this pull request accomplishes:

- Synchronizes Postgres functions for Miovision API and CSV pipelines. In particular
  - Makes variable names more clear in API gap-finding function.
  - Ports the zero-padding CTE from `function-aggregate-volumes_15min_tmc_2020.sql` (CSV version) to `function-aggregate-volumes_15min_tmc.sql` (API).

## Issue(s) this solves:

- Closes #379.

## What, in particular, needs to reviewed:

- Scan of the changes to make sure I haven't introduced silly errors.
