### PR TITLE
Remove former team membership from ownership

### DIFF
--- a/volumes/miovision/sql/csv_data/create-view-report_volumes_15min.sql
+++ b/volumes/miovision/sql/csv_data/create-view-report_volumes_15min.sql
@@ -33,4 +33,4 @@
 WITH DATA;
 
 ALTER TABLE miovision.report_volumes_15min
-  OWNER TO bdit_humans;
+  OWNER TO miovision_admins;

--- a/volumes/miovision/sql/csv_data/create-view-report_volumes_15min.sql
+++ b/volumes/miovision/sql/csv_data/create-view-report_volumes_15min.sql
@@ -1,4 +1,4 @@
-﻿CREATE MATERIALIZED VIEW miovision.report_volumes_15min AS 
+﻿CREATE MATERIALIZED VIEW miovision_csv.report_volumes_15min AS 
  WITH valid_bins AS (
          SELECT a_1.intersection_uid,
             a_1.class_type_id,
@@ -32,5 +32,5 @@
   WHERE b.time_bin = a.datetime_bin::time without time zone
 WITH DATA;
 
-ALTER TABLE miovision.report_volumes_15min
+ALTER TABLE miovision_csv.report_volumes_15min
   OWNER TO miovision_admins;

--- a/volumes/miovision/sql/csv_data/function-aggregate-volumes_15min_tmc_2020.sql
+++ b/volumes/miovision/sql/csv_data/function-aggregate-volumes_15min_tmc_2020.sql
@@ -72,11 +72,11 @@ END;
 $BODY$;
 
 ALTER FUNCTION miovision_csv.aggregate_15_min_tmc_2020(date, date)
-    OWNER TO czhu;
+    OWNER TO miovision_admins;
 
 GRANT EXECUTE ON FUNCTION miovision_csv.aggregate_15_min_tmc_2020(date, date) TO PUBLIC;
 
 GRANT EXECUTE ON FUNCTION miovision_csv.aggregate_15_min_tmc_2020(date, date) TO miovision_api_bot;
 
-GRANT EXECUTE ON FUNCTION miovision_csv.aggregate_15_min_tmc_2020(date, date) TO czhu;
+GRANT EXECUTE ON FUNCTION miovision_csv.aggregate_15_min_tmc_2020(date, date) TO miovision_admins;
 

--- a/volumes/miovision/sql/function-aggregate-volumes_15min_tmc.sql
+++ b/volumes/miovision/sql/function-aggregate-volumes_15min_tmc.sql
@@ -71,11 +71,11 @@ END;
 $BODY$;
 
 ALTER FUNCTION miovision_api.aggregate_15_min_tmc(date, date)
-    OWNER TO jchew;
+    OWNER TO miovision_admins;
 
 GRANT EXECUTE ON FUNCTION miovision_api.aggregate_15_min_tmc(date, date) TO PUBLIC;
 
 GRANT EXECUTE ON FUNCTION miovision_api.aggregate_15_min_tmc(date, date) TO miovision_api_bot;
 
-GRANT EXECUTE ON FUNCTION miovision_api.aggregate_15_min_tmc(date, date) TO jchew;
+GRANT EXECUTE ON FUNCTION miovision_api.aggregate_15_min_tmc(date, date) TO miovision_admins;
 

--- a/volumes/miovision/sql/function-api_log.sql
+++ b/volumes/miovision/sql/function-api_log.sql
@@ -18,4 +18,4 @@ $BODY$
   LANGUAGE plpgsql VOLATILE
   COST 100;
 ALTER FUNCTION miovision_api.api_log(date, date)
-  OWNER TO rliu;
+  OWNER TO miovision_admins;


### PR DESCRIPTION
## What this pull request accomplishes:

- Removes Rick, Joven and myself from `miovision_api`/`miovision_csv` table ownership. 😩

## Issue(s) this solves:

- 😩

## What, in particular, needs to reviewed:

- Need admin help to switch ownership of all elements of `miovision_api` and `miovision_csv` schemas to `miovision_admins`.
- Charles to put #380 into production once that's finished (currently Joven owns a table that need to be changed).
- We should consider making it a rule that any permanent table generated outside of one's personal schema must be owned by an admin group. (I suppose that means I'll need to create `collisions_admins` and `vz_admins` groups. For the next purge we should change all schema element ownership in `vz_analysis`, `vz_challenge`, `vz_safety_programs`, etc. to group ownership.
