### PR TITLE
catches null speed and count values #388

### DIFF
--- a/wys/api/python/wys_api.py
+++ b/wys/api/python/wys_api.py
@@ -150,7 +150,9 @@ def parse_counts_for_location(api_id, raw_records):
         datetime_bin= dateutil.parser.parse(str(datetime_bin))
         counter=record['counter']
         for item in counter:
-            speed_row=[api_id, datetime_bin, item['speed'], item['count']]
+            this_speed=int(item['speed']) if item['speed'] else None
+            this_count=int(item['count']) if item['count'] else None
+            speed_row=[api_id, datetime_bin, this_speed, this_count]
             speed_counts.append(speed_row)
     return speed_counts
 


### PR DESCRIPTION
## What this pull request accomplishes:

- checks for null speed and count and only converts to `int` for non-NULL values in `parse_counts_for_location()` that takes in raw data records from the WYS api


## Issue(s) this solves:

- #388 

## What, in particular, needs to reviewed:

- pls review the fix
