### PR TITLE
Move slack alert

### DIFF
--- a/dags/check_miovision.py
+++ b/dags/check_miovision.py
@@ -31,7 +31,7 @@ def check_miovision(con, start_date, end_date):
             LOGGER.info(broken_flag)
             raise Exception ('A Miovision camera may be broken!')
             
-SLACK_CONN_ID = 'slack'
+SLACK_CONN_ID = 'slack_data_pipeline'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     slack_msg = """

--- a/dags/check_rescu.py
+++ b/dags/check_rescu.py
@@ -33,14 +33,14 @@ def check_rescu(con, date_to_pull):
         if raw_num == 0 or raw_num < volume_num or volume_num < 7000:
             raise Exception ('There is a PROBLEM here. There is no raw data OR raw_data is less than volume_15min OR volumes_15min is less than 7000 which is way too low')
 
-SLACK_CONN_ID = 'slack'
+SLACK_CONN_ID = 'slack_data_pipeline'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     
     # print this task_msg and tag these users
     task_msg = """The Task {task} failed, the total volume is too low. 
         Either a lot of loop detectors are down or there's a problem in the pipeline.
-        <@U1XGLNWG2> <@UG60NMTPC> <@U1XFV23D4> please fix it :thanks_japanese: """.format(
+        <@U1XGLNWG2> please fix it :thanks_japanese: """.format(
         task=context.get('task_instance').task_id,)    
         
     # this adds the error log url at the end of the msg

--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -10,7 +10,7 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 from airflow.hooks.postgres_hook import PostgresHook
 
-SLACK_CONN_ID = 'slack'
+SLACK_CONN_ID = 'slack_data_pipeline'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     slack_msg = """

--- a/dags/pull_interventions_dag.py
+++ b/dags/pull_interventions_dag.py
@@ -10,7 +10,7 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 
 
-SLACK_CONN_ID = 'slack'
+SLACK_CONN_ID = 'slack_data_pipeline'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     slack_msg = """

--- a/dags/pull_miovision.py
+++ b/dags/pull_miovision.py
@@ -9,13 +9,13 @@ from airflow.operators.bash_operator import BashOperator
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 
-SLACK_CONN_ID = 'slack'
+SLACK_CONN_ID = 'slack_data_pipeline'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     
     # print this task_msg and tag these users
     task_msg = """:meow_camera: Miovision pulling failed :meow_headache:.
-        <@U1XGLNWG2> <@UG60NMTPC> please fix it :thanks_japanese: """.format(
+        <@U1XGLNWG2> please fix it :thanks_japanese: """.format(
         task=context.get('task_instance').task_id,)    
         
     # this adds the error log url at the end of the msg

--- a/dags/pull_wys.py
+++ b/dags/pull_wys.py
@@ -22,13 +22,13 @@ except:
     raise ImportError("Cannot import functions to pull watch your speed data")
 
 
-SLACK_CONN_ID = 'slack'
+SLACK_CONN_ID = 'slack_data_pipeline'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
 
     if context.get('task_instance').task_id == 't1':
         task_msg = """:cat_shock: The Task {task} in Pull WYS dag  failed, 
-			<@UHJA7GHQV> please check.""".format(
+			someone please check.""".format(
             task=context.get('task_instance').task_id,)
     
     # else other msg for task2

--- a/dags/refresh_wys_monthly.py
+++ b/dags/refresh_wys_monthly.py
@@ -9,7 +9,7 @@ from airflow.operators.postgres_operator import PostgresOperator
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 from dateutil.relativedelta import relativedelta
-SLACK_CONN_ID = 'slack'
+SLACK_CONN_ID = 'slack_data_pipeline'
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password

--- a/dags/vz_google_sheets.py
+++ b/dags/vz_google_sheets.py
@@ -13,7 +13,7 @@ from googleapiclient.discovery import build
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 
-SLACK_CONN_ID = 'slack'
+SLACK_CONN_ID = 'slack_data_pipeline'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     slack_msg = """
@@ -34,8 +34,7 @@ def task_fail_slack_alert(context):
         http_conn_id='slack',
         webhook_token=slack_webhook_token,
         message=slack_msg,
-        username='airflow',
-        # proxy='http://137.15.73.132:8080'
+        username='airflow'
         )
     return failed_alert.execute(context=context)
 


### PR DESCRIPTION
## What this pull request accomplishes:

move all airflow dag to alert data pipeline channel and got rid of past member's username tag in alert message
## Issue(s) this solves:

- #450 


