### PR TITLE
Log Blip Server Space Fixes #428

### DIFF
--- a/bluetooth/api/README.md
+++ b/bluetooth/api/README.md
@@ -63,3 +63,22 @@ python blip_api.py -y 20180501 20180512 -a 156435 -a 165375 -d config.cfg
 
 Compares Blip route configurations in the database with the previous day's tables and sends an email if there are new or updated routes.
 This script runs on the EC2 in order to be able to use the [`email_notifications`](https://github.com/CityofToronto/bdit_python_utilities/tree/master/email_notifications) module
+
+### blip_space_log
+
+Fetches a JSON from a REST API on the Blip Server that reports the server's space. Checks whether the space is below 15 Gigs and logs whether there is sufficient space or not. IT's monitoring system monitors this log and will email us of any issues.
+
+#### TimedRotatingFileHandler
+
+The logger in this script implements [this handler](https://docs.python.org/3/library/logging.handlers.html#timedrotatingfilehandler) in order to ensure there is approximately only 1 line in the file every day. It will maintain a backup of 7 log files on a rotating basis for the 7 previous days. 
+
+```python
+logger = logging.getLogger('blip_space_logger')
+handler = TimedRotatingFileHandler(r'C:\Users\Public\Documents\blip_space\blip_space_log.log',
+                             when='D', interval=1, backupCount=7)
+logger.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s, %(levelname)s, %(message)s',
+                              "%Y-%m-%d %H:%M:%S")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+```

--- a/bluetooth/api/blip_space_log.py
+++ b/bluetooth/api/blip_space_log.py
@@ -11,12 +11,16 @@ import sys
 requests.packages.urllib3.disable_warnings()
 
 logger = logging.getLogger('blip_space_logger')
+logger.setLevel(logging.INFO)
+
 handler = TimedRotatingFileHandler(r'C:\Users\Public\Documents\blip_space\blip_space_log.log',
                              when='D', interval=1, backupCount=7)
-logger.setLevel(logging.INFO)
+handler.suffix = "%Y%m%d"
 formatter = logging.Formatter('%(asctime)s, %(levelname)s, %(message)s',
                               "%Y-%m-%d %H:%M:%S")
 handler.setFormatter(formatter)
+#Since TimedRotatingFileHandler won't rotate logs unless the program is running through midnight, force a manual rollover 
+handler.doRollover()
 logger.addHandler(handler)
 
 

--- a/bluetooth/api/blip_space_log.py
+++ b/bluetooth/api/blip_space_log.py
@@ -1,0 +1,54 @@
+import requests
+from requests import Session
+from requests.auth import HTTPBasicAuth
+from requests.exceptions import RequestException
+import configparser
+import logging
+from logging.handlers import TimedRotatingFileHandler
+import sys
+
+
+requests.packages.urllib3.disable_warnings()
+
+logger = logging.getLogger('blip_space_logger')
+handler = TimedRotatingFileHandler(r'C:\Users\Public\Documents\blip_space\blip_space_log.log',
+                             when='D', interval=1, backupCount=7)
+logger.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s, %(levelname)s, %(message)s',
+                              "%Y-%m-%d %H:%M:%S")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+
+def main():
+    session = Session()
+    session.verify = False
+    config = configparser.ConfigParser()
+    config.read('config.cfg')
+    space_api_settings = config['SPACE']
+
+    try:
+        result = session.get(space_api_settings['url'], 
+                         auth=HTTPBasicAuth(space_api_settings['username'], space_api_settings['password']))
+        result.raise_for_status()
+        result_dict = result.json()
+    except RequestException as exc:
+        logger.critical('Error querying API, %s', exc)
+        sys.exit(2)
+
+    try:
+        space_value = float(result_dict['data'][0][2])
+    except ValueError as exc:
+        logger.critical('ValueError trying to convert, %s',
+                         result['data'][0][2])
+        sys.exit(1)
+    if space_value < 15:
+        logger.warning('Disk Space Low, %s', space_value)
+    else:
+        logger.info('Disk Space OK, %s', space_value)
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as exc:
+        logger.critical('Unknown error, %s', exc)

--- a/bluetooth/api/blip_space_log.py
+++ b/bluetooth/api/blip_space_log.py
@@ -14,13 +14,12 @@ logger = logging.getLogger('blip_space_logger')
 logger.setLevel(logging.INFO)
 
 handler = TimedRotatingFileHandler(r'C:\Users\Public\Documents\blip_space\blip_space_log.log',
-                             when='D', interval=1, backupCount=7)
-handler.suffix = "%Y%m%d"
+                             when='midnight', interval=1, backupCount=7)
+
 formatter = logging.Formatter('%(asctime)s, %(levelname)s, %(message)s',
                               "%Y-%m-%d %H:%M:%S")
 handler.setFormatter(formatter)
-#Since TimedRotatingFileHandler won't rotate logs unless the program is running through midnight, force a manual rollover 
-handler.doRollover()
+
 logger.addHandler(handler)
 
 


### PR DESCRIPTION
## What this pull request accomplishes:

- create a process for checking the status of the blip server disks via REST API and log it
- implement a rotating file handler log so the `blip_space_log.log` always contains only one line, unless there's an error.

## Issue(s) this solves:

- #428 

## What, in particular, needs to reviewed:

- Check out the rotating file handler!
- Also the README.
