### PR TITLE
Volume pipeline

### DIFF
--- a/dags/traffic_transfer.py
+++ b/dags/traffic_transfer.py
@@ -1,0 +1,110 @@
+#This script should run after the MOVE dag dumps data into the "TRAFFIC_NEW" schema...
+
+# Operators; we need this to operate!
+from airflow import DAG
+from datetime import datetime, timedelta
+from airflow.operators.postgres_operator import PostgresOperator 
+from airflow.hooks.base_hook import BaseHook
+from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
+SLACK_CONN_ID = 'slack_data_pipeline'
+
+#This script does things with those operators:
+#1) does 9 upsert queries to update data in arc_link, arterydata, category, cnt_det, cnt_spd, countinfo, countinfomics, det, node
+#2) throws a nattery slack alert message when it fails
+
+def task_fail_nattery_slack_alert(context):
+    slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
+    task_msg = 'The {task} in updating traffic failed, <@U02NSCSKFEU> go fix it meow :meow_notlike: '.format(
+            task=context.get('task_instance').task_id,) #K just gotta point out that the last 3 letters in my slack id spell FIRE in French!!!   
+        
+    slack_msg = task_msg + """(<{log_url}|log>)""".format(
+            log_url=context.get('task_instance').log_url,)
+    failed_alert = SlackWebhookOperator(
+        task_id='slack_test',
+        http_conn_id='slack',
+        webhook_token=slack_webhook_token,
+        message=slack_msg,
+        username='airflow'
+        )
+    return failed_alert.execute(context=context)
+
+default_args = {'owner':'scannon',
+                'depends_on_past':False,
+                'start_date': datetime(2022, 6, 16), #start this Thursday, why not?
+                'email': ['sarah.cannon@toronto.ca'],
+                'email_on_failure': False,
+                 'email_on_success': False,
+                 'retries': 0,
+                 'retry_delay': timedelta(minutes=5),
+                 'on_failure_callback': task_fail_nattery_slack_alert
+                }
+
+
+with DAG('traffic_transfer', 
+         default_args = default_args,
+         schedule_interval='0 2 * * *') as daily_update: #runs at 2am every day
+         
+    update_arc_link = PostgresOperator(sql = 'SELECT traffic.update_arc_link()',
+				task_id = 'update_arc_link',
+				postgres_conn_id = 'traffic_bot',
+				autocommit = True,
+				retries = 0
+    )
+    
+    update_arterydata = PostgresOperator(sql = 'SELECT traffic.update_arterydata()',
+				task_id = 'update_arterydata',
+				postgres_conn_id = 'traffic_bot',
+				autocommit = True,
+				retries = 0
+    )
+    
+    update_category = PostgresOperator(sql = 'SELECT traffic.update_category()',
+				task_id = 'update_category',
+				postgres_conn_id = 'traffic_bot',
+				autocommit = True,
+				retries = 0
+    )
+    
+    update_cnt_det = PostgresOperator(sql = 'SELECT traffic.update_cnt_det()',
+				task_id = 'update_cnt_det',
+				postgres_conn_id = 'traffic_bot',
+				autocommit = True,
+				retries = 0
+    )
+    
+    update_cnt_spd = PostgresOperator(sql = 'SELECT traffic.update_cnt_spd()',
+				task_id = 'update_cnt_spd',
+				postgres_conn_id = 'traffic_bot',
+				autocommit = True,
+				retries = 0
+    )
+    
+    update_countinfo = PostgresOperator(sql = 'SELECT traffic.update_countinfo()',
+				task_id = 'update_countinfo',
+				postgres_conn_id = 'traffic_bot',
+				autocommit = True,
+				retries = 0
+    )
+    
+    update_countinfomics = PostgresOperator(sql = 'SELECT traffic.update_countinfomics()',
+				task_id = 'update_countinfomics',
+				postgres_conn_id = 'traffic_bot',
+				autocommit = True,
+				retries = 0
+    )
+    
+    update_det = PostgresOperator(sql = 'SELECT traffic.update_det()',
+				task_id = 'update_det',
+				postgres_conn_id = 'traffic_bot',
+				autocommit = True,
+				retries = 0
+    )
+    
+    update_node = PostgresOperator(sql = 'SELECT traffic.update_node()',
+				task_id = 'update_node',
+				postgres_conn_id = 'traffic_bot',
+				autocommit = True,
+				retries = 0
+    )
+                                   
+    update_arc_link >> update_arterydata >> update_category >> update_cnt_det >> update_cnt_spd >> update_countinfo >> update_countinfomics >> update_det >> update_node

--- a/volumes/README.md
+++ b/volumes/README.md
@@ -51,6 +51,28 @@ Raw data is available in `rescu.raw_15min` whereas processed 15-min data is avai
 
 ### 1. Loading Data
 
+**Here is your quick July 2022 loading data update:**
+- Data are loaded into the TRAFFIC_NEW schema on BigData every night
+- For nine tables, data are upserted from TRAFFIC_NEW into traffic. The nine tables are:
+    - arc_link
+    - arterydata
+    - category
+    - cnt_det
+    - cnt_spd
+    - countinfo
+    - countinfomics
+    - det
+    - nodes
+- We audit some of these tables (in traffic.logged_actions) but not all of them because some of these tables are huge! With huge changes! Here are the tables we're auditing:
+    - arc_link
+    - arterydata
+    - category
+    - countinfo
+    - countinfomics
+    - nodes
+
+**And now back to your regularly scheduled documentation...**
+
 The data in the schema comes from an image of FLOW Oracle database, which was reconstituted with a free version of [Oracle Database](http://www.oracle.com/technetwork/database/database-technologies/express-edition/downloads/index.html), [Oracle SQL Developer](http://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/index-098778.html) to view the table structures and data. `impdp` was used to import first the full schema, and then select tables of data to import into a local Oracle DB.
 
 In a SQL window, create the `TRAFFIC` tablespace for import.

--- a/volumes/sql/traffic_new/func_upd_arc_link.sql
+++ b/volumes/sql/traffic_new/func_upd_arc_link.sql
@@ -1,0 +1,38 @@
+-- FUNCTION: traffic.update_arc_link()
+
+-- DROP FUNCTION IF EXISTS traffic.update_arc_link();
+
+CREATE OR REPLACE FUNCTION traffic.update_arc_link(
+	)
+    RETURNS void
+    LANGUAGE 'sql'
+    COST 100
+    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+AS $BODY$
+
+    insert into traffic.arc_link (
+	select * from "TRAFFIC_NEW"."ARC_LINK"
+	except
+	select * from traffic.arc_link)
+	on conflict (link_id) 
+	DO UPDATE 
+		SET arc_id = EXCLUDED.arc_id,
+			frequency = EXCLUDED.frequency;
+
+with delrec as (
+	select * from traffic.arc_link 
+	except 
+	select * from "TRAFFIC_NEW"."ARC_LINK")
+
+Delete from traffic.arc_link where link_id in (SELECT link_id from delrec);
+
+$BODY$;
+
+ALTER FUNCTION traffic.update_arc_link()
+    OWNER TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_arc_link() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_arc_link() TO traffic_bot;
+
+REVOKE ALL ON FUNCTION traffic.update_arc_link() FROM PUBLIC;

--- a/volumes/sql/traffic_new/func_upd_arc_link.sql
+++ b/volumes/sql/traffic_new/func_upd_arc_link.sql
@@ -29,7 +29,7 @@ Delete from traffic.arc_link where link_id in (SELECT link_id from delrec);
 $BODY$;
 
 ALTER FUNCTION traffic.update_arc_link()
-    OWNER TO scannon;
+    OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_arc_link() TO scannon;
 

--- a/volumes/sql/traffic_new/func_upd_arterydata.sql
+++ b/volumes/sql/traffic_new/func_upd_arterydata.sql
@@ -45,7 +45,7 @@ Delete from traffic.arterydata where arterycode in (SELECT arterycode from delre
 $BODY$;
 
 ALTER FUNCTION traffic.update_arterydata()
-    OWNER TO scannon;
+    OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_arterydata() TO scannon;
 

--- a/volumes/sql/traffic_new/func_upd_arterydata.sql
+++ b/volumes/sql/traffic_new/func_upd_arterydata.sql
@@ -1,0 +1,54 @@
+-- FUNCTION: traffic.update_arterydata()
+
+-- DROP FUNCTION IF EXISTS traffic.update_arterydata();
+
+CREATE OR REPLACE FUNCTION traffic.update_arterydata(
+	)
+    RETURNS void
+    LANGUAGE 'sql'
+    COST 100
+    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+AS $BODY$
+
+    insert into traffic.arterydata (
+	select * from "TRAFFIC_NEW"."ARTERYDATA"
+	except
+	select * from traffic.arterydata)
+	on conflict (arterycode) 
+	DO UPDATE 
+		SET geomcode = EXCLUDED.geomcode,
+			street1 = EXCLUDED.street1,
+			street1type = EXCLUDED.street1type,
+			street1dir = EXCLUDED.street1dir,
+			street2 = EXCLUDED.street2,
+			street2type = EXCLUDED.street2type,
+			street2dir = EXCLUDED.street2dir,
+			street3 = EXCLUDED.street3,
+			street3type = EXCLUDED.street3type,
+			street3dir = EXCLUDED.street3dir,
+			stat_code = EXCLUDED.stat_code,
+			count_type = EXCLUDED.count_type,
+			location = EXCLUDED.location,
+			apprdir = EXCLUDED.apprdir,
+			sideofint = EXCLUDED.sideofint,
+			linkid = EXCLUDED.linkid,
+			seq_order = EXCLUDED.seq_order,
+			geo_id = EXCLUDED.geo_id;
+
+with delrec as (
+	select * from traffic.arterydata 
+	except 
+	select * from "TRAFFIC_NEW"."ARTERYDATA")
+
+Delete from traffic.arterydata where arterycode in (SELECT arterycode from delrec);
+
+$BODY$;
+
+ALTER FUNCTION traffic.update_arterydata()
+    OWNER TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_arterydata() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_arterydata() TO traffic_bot;
+
+REVOKE ALL ON FUNCTION traffic.update_arterydata() FROM PUBLIC;

--- a/volumes/sql/traffic_new/func_upd_category.sql
+++ b/volumes/sql/traffic_new/func_upd_category.sql
@@ -1,0 +1,37 @@
+-- FUNCTION: traffic.update_category()
+
+-- DROP FUNCTION IF EXISTS traffic.update_category();
+
+CREATE OR REPLACE FUNCTION traffic.update_category(
+	)
+    RETURNS void
+    LANGUAGE 'sql'
+    COST 100
+    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+AS $BODY$
+
+    insert into traffic.category (
+	select * from "TRAFFIC_NEW"."CATEGORY"
+	except
+	select * from traffic.category)
+	on conflict (category_id) 
+	DO UPDATE 
+		SET category_name = EXCLUDED.category_name;
+
+with delrec as (
+	select * from traffic.category 
+	except 
+	select * from "TRAFFIC_NEW"."CATEGORY")
+
+Delete from traffic.category where category_id in (SELECT category_id from delrec);
+
+$BODY$;
+
+ALTER FUNCTION traffic.update_category()
+    OWNER TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_category() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_category() TO traffic_bot;
+
+REVOKE ALL ON FUNCTION traffic.update_category() FROM PUBLIC;

--- a/volumes/sql/traffic_new/func_upd_category.sql
+++ b/volumes/sql/traffic_new/func_upd_category.sql
@@ -28,7 +28,7 @@ Delete from traffic.category where category_id in (SELECT category_id from delre
 $BODY$;
 
 ALTER FUNCTION traffic.update_category()
-    OWNER TO scannon;
+    OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_category() TO scannon;
 

--- a/volumes/sql/traffic_new/func_upd_cnt_det.sql
+++ b/volumes/sql/traffic_new/func_upd_cnt_det.sql
@@ -31,7 +31,7 @@ Delete from traffic.cnt_det where id in (SELECT id from delrec);
 $BODY$;
 
 ALTER FUNCTION traffic.update_cnt_det()
-    OWNER TO scannon;
+    OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_cnt_det() TO scannon;
 

--- a/volumes/sql/traffic_new/func_upd_cnt_det.sql
+++ b/volumes/sql/traffic_new/func_upd_cnt_det.sql
@@ -1,0 +1,40 @@
+-- FUNCTION: traffic.update_cnt_det()
+
+-- DROP FUNCTION IF EXISTS traffic.update_cnt_det();
+
+CREATE OR REPLACE FUNCTION traffic.update_cnt_det(
+	)
+    RETURNS void
+    LANGUAGE 'sql'
+    COST 100
+    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+AS $BODY$
+
+    insert into traffic.cnt_det (
+	select * from "TRAFFIC_NEW"."CNT_DET"
+	except
+	select * from traffic.cnt_det)
+	on conflict (id) 
+	DO UPDATE 
+		SET count_info_id = EXCLUDED.count_info_id,
+			count = EXCLUDED.count,
+			timecount = EXCLUDED.timecount,
+			speed_class = EXCLUDED.speed_class;
+
+with delrec as (
+	select * from traffic.cnt_det 
+	except 
+	select * from "TRAFFIC_NEW"."CNT_DET")
+
+Delete from traffic.cnt_det where id in (SELECT id from delrec);
+
+$BODY$;
+
+ALTER FUNCTION traffic.update_cnt_det()
+    OWNER TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_cnt_det() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_cnt_det() TO traffic_bot;
+
+REVOKE ALL ON FUNCTION traffic.update_cnt_det() FROM PUBLIC;

--- a/volumes/sql/traffic_new/func_upd_cnt_det.sql
+++ b/volumes/sql/traffic_new/func_upd_cnt_det.sql
@@ -10,23 +10,9 @@ CREATE OR REPLACE FUNCTION traffic.update_cnt_det(
     VOLATILE SECURITY DEFINER PARALLEL UNSAFE
 AS $BODY$
 
-    insert into traffic.cnt_det (
-	select * from "TRAFFIC_NEW"."CNT_DET"
-	except
-	select * from traffic.cnt_det)
-	on conflict (id) 
-	DO UPDATE 
-		SET count_info_id = EXCLUDED.count_info_id,
-			count = EXCLUDED.count,
-			timecount = EXCLUDED.timecount,
-			speed_class = EXCLUDED.speed_class;
-
-with delrec as (
-	select * from traffic.cnt_det 
-	except 
-	select * from "TRAFFIC_NEW"."CNT_DET")
-
-Delete from traffic.cnt_det where id in (SELECT id from delrec);
+TRUNCATE TABLE traffic.cnt_det;
+INSERT INTO traffic.cnt_det
+(select * from "TRAFFIC_NEW"."CNT_DET")
 
 $BODY$;
 
@@ -34,6 +20,8 @@ ALTER FUNCTION traffic.update_cnt_det()
     OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_cnt_det() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_cnt_det() TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_cnt_det() TO traffic_bot;
 

--- a/volumes/sql/traffic_new/func_upd_cnt_det.sql
+++ b/volumes/sql/traffic_new/func_upd_cnt_det.sql
@@ -12,7 +12,7 @@ AS $BODY$
 
 TRUNCATE TABLE traffic.cnt_det;
 INSERT INTO traffic.cnt_det
-(select * from "TRAFFIC_NEW"."CNT_DET")
+(select * from "TRAFFIC_NEW"."CNT_DET");
 
 $BODY$;
 

--- a/volumes/sql/traffic_new/func_upd_cnt_spd.sql
+++ b/volumes/sql/traffic_new/func_upd_cnt_spd.sql
@@ -1,0 +1,39 @@
+-- FUNCTION: traffic.update_cnt_spd()
+
+-- DROP FUNCTION IF EXISTS traffic.update_cnt_spd();
+
+CREATE OR REPLACE FUNCTION traffic.update_cnt_spd(
+	)
+    RETURNS void
+    LANGUAGE 'sql'
+    COST 100
+    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+AS $BODY$
+
+    insert into traffic.cnt_spd (
+	select * from "TRAFFIC_NEW"."CNT_SPD"
+	except
+	select * from traffic.cnt_spd)
+	on conflict (id) 
+	DO UPDATE 
+		SET count_info_id = EXCLUDED.count_info_id,
+			speed = EXCLUDED.speed,
+			timecount = EXCLUDED.timecount;
+
+with delrec as (
+	select * from traffic.cnt_spd 
+	except 
+	select * from "TRAFFIC_NEW"."CNT_SPD")
+
+Delete from traffic.cnt_spd where id in (SELECT id from delrec);
+
+$BODY$;
+
+ALTER FUNCTION traffic.update_cnt_spd()
+    OWNER TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_cnt_spd() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_cnt_spd() TO traffic_bot;
+
+REVOKE ALL ON FUNCTION traffic.update_cnt_spd() FROM PUBLIC;

--- a/volumes/sql/traffic_new/func_upd_cnt_spd.sql
+++ b/volumes/sql/traffic_new/func_upd_cnt_spd.sql
@@ -30,7 +30,7 @@ Delete from traffic.cnt_spd where id in (SELECT id from delrec);
 $BODY$;
 
 ALTER FUNCTION traffic.update_cnt_spd()
-    OWNER TO scannon;
+    OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_cnt_spd() TO scannon;
 

--- a/volumes/sql/traffic_new/func_upd_countinfo.sql
+++ b/volumes/sql/traffic_new/func_upd_countinfo.sql
@@ -30,7 +30,7 @@ AS $BODY$
 with delrec as (
 	select * from traffic.countinfo 
 	except 
-	select * from "TRAFFIC_NEW"."COUNTINFO")
+	select "COUNT_INFO_ID", "ARTERYCODE", "COUNT_DATE"::date, "DAY_NO", "COMMENT_", "FILE_NAME", "SOURCE1", "SOURCE2", "LOAD_DATE", "SPEED_INFO_ID", "CATEGORY_ID" from "TRAFFIC_NEW"."COUNTINFO")
 
 Delete from traffic.countinfo where count_info_id in (SELECT count_info_id from delrec);
 

--- a/volumes/sql/traffic_new/func_upd_countinfo.sql
+++ b/volumes/sql/traffic_new/func_upd_countinfo.sql
@@ -1,0 +1,46 @@
+-- FUNCTION: traffic.update_countinfo()
+
+-- DROP FUNCTION IF EXISTS traffic.update_countinfo();
+
+CREATE OR REPLACE FUNCTION traffic.update_countinfo(
+	)
+    RETURNS void
+    LANGUAGE 'sql'
+    COST 100
+    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+AS $BODY$
+
+    insert into traffic.countinfo (
+	select * from "TRAFFIC_NEW"."COUNTINFO"
+	except
+	select * from traffic.countinfo)
+	on conflict (count_info_id) 
+	DO UPDATE 
+		SET arterycode = EXCLUDED.arterycode,
+			count_date = EXCLUDED.count_date,
+			day_no = EXCLUDED.day_no,
+			comment_ = EXCLUDED.comment_,
+			file_name = EXCLUDED.file_name,
+			source1 = EXCLUDED.source1,
+			source2 = EXCLUDED.source2,
+			load_date = EXCLUDED.load_date,
+			speed_info_id = EXCLUDED.speed_info_id,
+			category_id = EXCLUDED.category_id;
+
+with delrec as (
+	select * from traffic.countinfo 
+	except 
+	select * from "TRAFFIC_NEW"."COUNTINFO")
+
+Delete from traffic.countinfo where count_info_id in (SELECT count_info_id from delrec);
+
+$BODY$;
+
+ALTER FUNCTION traffic.update_countinfo()
+    OWNER TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_countinfo() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_countinfo() TO traffic_bot;
+
+REVOKE ALL ON FUNCTION traffic.update_countinfo() FROM PUBLIC;

--- a/volumes/sql/traffic_new/func_upd_countinfo.sql
+++ b/volumes/sql/traffic_new/func_upd_countinfo.sql
@@ -37,7 +37,7 @@ Delete from traffic.countinfo where count_info_id in (SELECT count_info_id from 
 $BODY$;
 
 ALTER FUNCTION traffic.update_countinfo()
-    OWNER TO scannon;
+    OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_countinfo() TO scannon;
 

--- a/volumes/sql/traffic_new/func_upd_countinfomics.sql
+++ b/volumes/sql/traffic_new/func_upd_countinfomics.sql
@@ -38,7 +38,7 @@ Delete from traffic.countinfomics where count_info_id in (SELECT count_info_id f
 $BODY$;
 
 ALTER FUNCTION traffic.update_countinfomics()
-    OWNER TO scannon;
+    OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_countinfomics() TO scannon;
 

--- a/volumes/sql/traffic_new/func_upd_countinfomics.sql
+++ b/volumes/sql/traffic_new/func_upd_countinfomics.sql
@@ -1,0 +1,47 @@
+-- FUNCTION: traffic.update_countinfomics()
+
+-- DROP FUNCTION IF EXISTS traffic.update_countinfomics();
+
+CREATE OR REPLACE FUNCTION traffic.update_countinfomics(
+	)
+    RETURNS void
+    LANGUAGE 'sql'
+    COST 100
+    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+AS $BODY$
+
+    insert into traffic.countinfomics (
+	select * from "TRAFFIC_NEW"."COUNTINFOMICS"
+	except
+	select * from traffic.countinfomics)
+	on conflict (count_info_id) 
+	DO UPDATE 
+		SET arterycode = EXCLUDED.arterycode,
+			count_type = EXCLUDED.count_type,
+			count_date = EXCLUDED.count_date,
+			day_no = EXCLUDED.day_no,
+			comment_ = EXCLUDED.comment_,
+			file_name = EXCLUDED.file_name,
+			source1 = EXCLUDED.source1,
+			source2 = EXCLUDED.source2,
+			load_date = EXCLUDED.load_date,
+			transfer_rec = EXCLUDED.transfer_rec,
+			category_id = EXCLUDED.category_id;
+
+with delrec as (
+	select * from traffic.countinfomics 
+	except 
+	select * from "TRAFFIC_NEW"."COUNTINFOMICS")
+
+Delete from traffic.countinfomics where count_info_id in (SELECT count_info_id from delrec);
+
+$BODY$;
+
+ALTER FUNCTION traffic.update_countinfomics()
+    OWNER TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_countinfomics() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_countinfomics() TO traffic_bot;
+
+REVOKE ALL ON FUNCTION traffic.update_countinfomics() FROM PUBLIC;

--- a/volumes/sql/traffic_new/func_upd_det.sql
+++ b/volumes/sql/traffic_new/func_upd_det.sql
@@ -77,7 +77,7 @@ Delete from traffic.det where id in (SELECT id from delrec);
 $BODY$;
 
 ALTER FUNCTION traffic.update_det()
-    OWNER TO scannon;
+    OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_det() TO scannon;
 

--- a/volumes/sql/traffic_new/func_upd_det.sql
+++ b/volumes/sql/traffic_new/func_upd_det.sql
@@ -1,0 +1,86 @@
+-- FUNCTION: traffic.update_det()
+
+-- DROP FUNCTION IF EXISTS traffic.update_det();
+
+CREATE OR REPLACE FUNCTION traffic.update_det(
+	)
+    RETURNS void
+    LANGUAGE 'sql'
+    COST 100
+    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+AS $BODY$
+
+    insert into traffic.det (
+	select * from "TRAFFIC_NEW"."DET"
+	except
+	select * from traffic.det)
+	on conflict (id) 
+	DO UPDATE 
+		SET count_info_id = EXCLUDED.count_info_id,
+			count_time = EXCLUDED.count_time,
+			n_cars_r = EXCLUDED.n_cars_r,
+			n_cars_t = EXCLUDED.n_cars_t,
+			n_cars_l = EXCLUDED.n_cars_l,
+			s_cars_r = EXCLUDED.s_cars_r,
+			s_cars_t = EXCLUDED.s_cars_t,
+			s_cars_l = EXCLUDED.s_cars_l,
+			e_cars_r = EXCLUDED.e_cars_r,
+			e_cars_t = EXCLUDED.e_cars_t,
+			e_cars_l = EXCLUDED.e_cars_l,
+			w_cars_r = EXCLUDED.w_cars_r,
+			w_cars_t = EXCLUDED.w_cars_t,
+			w_cars_l = EXCLUDED.w_cars_l,
+			n_truck_r = EXCLUDED.n_truck_r,
+			n_truck_t = EXCLUDED.n_truck_t,
+			n_truck_l = EXCLUDED.n_truck_l,
+			s_truck_r = EXCLUDED.s_truck_r,
+			s_truck_t = EXCLUDED.s_truck_t,
+			s_truck_l = EXCLUDED.s_truck_l,
+			e_truck_r = EXCLUDED.e_truck_r,
+			e_truck_t = EXCLUDED.e_truck_t,
+			e_truck_l = EXCLUDED.e_truck_l,
+			w_truck_r = EXCLUDED.w_truck_r,
+			w_truck_t = EXCLUDED.w_truck_t,
+			w_truck_l = EXCLUDED.w_truck_l,
+			n_bus_r = EXCLUDED.n_bus_r,
+			n_bus_t = EXCLUDED.n_bus_t,
+			n_bus_l = EXCLUDED.n_bus_l,
+			s_bus_r = EXCLUDED.s_bus_r,
+			s_bus_t = EXCLUDED.s_bus_t,
+			s_bus_l = EXCLUDED.s_bus_l,
+			e_bus_r = EXCLUDED.e_bus_r,
+			e_bus_t = EXCLUDED.e_bus_t,
+			e_bus_l = EXCLUDED.e_bus_l,
+			w_bus_r = EXCLUDED.w_bus_r,
+			w_bus_t = EXCLUDED.w_bus_t,
+			w_bus_l = EXCLUDED.w_bus_l,
+			n_peds = EXCLUDED.n_peds,
+			s_peds = EXCLUDED.s_peds,
+			e_peds = EXCLUDED.e_peds,
+			w_peds = EXCLUDED.w_peds,
+			n_bike = EXCLUDED.n_bike,
+			s_bike = EXCLUDED.s_bike,
+			e_bike = EXCLUDED.e_bike,
+			w_bike = EXCLUDED.w_bike,
+			n_other = EXCLUDED.n_other,
+			s_other = EXCLUDED.s_other,
+			e_other = EXCLUDED.e_other,
+			w_other = EXCLUDED.w_other;
+
+with delrec as (
+	select * from traffic.det 
+	except 
+	select * from "TRAFFIC_NEW"."DET")
+
+Delete from traffic.det where id in (SELECT id from delrec);
+
+$BODY$;
+
+ALTER FUNCTION traffic.update_det()
+    OWNER TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_det() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_det() TO traffic_bot;
+
+REVOKE ALL ON FUNCTION traffic.update_det() FROM PUBLIC;

--- a/volumes/sql/traffic_new/func_upd_det.sql
+++ b/volumes/sql/traffic_new/func_upd_det.sql
@@ -10,69 +10,9 @@ CREATE OR REPLACE FUNCTION traffic.update_det(
     VOLATILE SECURITY DEFINER PARALLEL UNSAFE
 AS $BODY$
 
-    insert into traffic.det (
-	select * from "TRAFFIC_NEW"."DET"
-	except
-	select * from traffic.det)
-	on conflict (id) 
-	DO UPDATE 
-		SET count_info_id = EXCLUDED.count_info_id,
-			count_time = EXCLUDED.count_time,
-			n_cars_r = EXCLUDED.n_cars_r,
-			n_cars_t = EXCLUDED.n_cars_t,
-			n_cars_l = EXCLUDED.n_cars_l,
-			s_cars_r = EXCLUDED.s_cars_r,
-			s_cars_t = EXCLUDED.s_cars_t,
-			s_cars_l = EXCLUDED.s_cars_l,
-			e_cars_r = EXCLUDED.e_cars_r,
-			e_cars_t = EXCLUDED.e_cars_t,
-			e_cars_l = EXCLUDED.e_cars_l,
-			w_cars_r = EXCLUDED.w_cars_r,
-			w_cars_t = EXCLUDED.w_cars_t,
-			w_cars_l = EXCLUDED.w_cars_l,
-			n_truck_r = EXCLUDED.n_truck_r,
-			n_truck_t = EXCLUDED.n_truck_t,
-			n_truck_l = EXCLUDED.n_truck_l,
-			s_truck_r = EXCLUDED.s_truck_r,
-			s_truck_t = EXCLUDED.s_truck_t,
-			s_truck_l = EXCLUDED.s_truck_l,
-			e_truck_r = EXCLUDED.e_truck_r,
-			e_truck_t = EXCLUDED.e_truck_t,
-			e_truck_l = EXCLUDED.e_truck_l,
-			w_truck_r = EXCLUDED.w_truck_r,
-			w_truck_t = EXCLUDED.w_truck_t,
-			w_truck_l = EXCLUDED.w_truck_l,
-			n_bus_r = EXCLUDED.n_bus_r,
-			n_bus_t = EXCLUDED.n_bus_t,
-			n_bus_l = EXCLUDED.n_bus_l,
-			s_bus_r = EXCLUDED.s_bus_r,
-			s_bus_t = EXCLUDED.s_bus_t,
-			s_bus_l = EXCLUDED.s_bus_l,
-			e_bus_r = EXCLUDED.e_bus_r,
-			e_bus_t = EXCLUDED.e_bus_t,
-			e_bus_l = EXCLUDED.e_bus_l,
-			w_bus_r = EXCLUDED.w_bus_r,
-			w_bus_t = EXCLUDED.w_bus_t,
-			w_bus_l = EXCLUDED.w_bus_l,
-			n_peds = EXCLUDED.n_peds,
-			s_peds = EXCLUDED.s_peds,
-			e_peds = EXCLUDED.e_peds,
-			w_peds = EXCLUDED.w_peds,
-			n_bike = EXCLUDED.n_bike,
-			s_bike = EXCLUDED.s_bike,
-			e_bike = EXCLUDED.e_bike,
-			w_bike = EXCLUDED.w_bike,
-			n_other = EXCLUDED.n_other,
-			s_other = EXCLUDED.s_other,
-			e_other = EXCLUDED.e_other,
-			w_other = EXCLUDED.w_other;
-
-with delrec as (
-	select * from traffic.det 
-	except 
-	select * from "TRAFFIC_NEW"."DET")
-
-Delete from traffic.det where id in (SELECT id from delrec);
+    TRUNCATE TABLE traffic.det;
+	INSERT INTO traffic.det
+	(Select * from "TRAFFIC_NEW"."DET");
 
 $BODY$;
 
@@ -80,6 +20,8 @@ ALTER FUNCTION traffic.update_det()
     OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_det() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_det() TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_det() TO traffic_bot;
 

--- a/volumes/sql/traffic_new/func_upd_node.sql
+++ b/volumes/sql/traffic_new/func_upd_node.sql
@@ -1,0 +1,40 @@
+-- FUNCTION: traffic.update_node()
+
+-- DROP FUNCTION IF EXISTS traffic.update_node();
+
+CREATE OR REPLACE FUNCTION traffic.update_node(
+	)
+    RETURNS void
+    LANGUAGE 'sql'
+    COST 100
+    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+AS $BODY$
+
+    insert into traffic.node (
+	select * from "TRAFFIC_NEW"."NODE"
+	except
+	select * from traffic.node)
+	on conflict (node_id) 
+	DO UPDATE 
+		SET link_id = EXCLUDED.link_id,
+			x_coord = EXCLUDED.x_coord,
+			y_coord = EXCLUDED.y_coord,
+			ts = EXCLUDED.ts;
+
+with delrec as (
+	select * from traffic.node 
+	except 
+	select * from "TRAFFIC_NEW"."NODE")
+
+Delete from traffic.node where node_id in (SELECT node_id from delrec);
+
+$BODY$;
+
+ALTER FUNCTION traffic.update_node()
+    OWNER TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_node() TO scannon;
+
+GRANT EXECUTE ON FUNCTION traffic.update_node() TO traffic_bot;
+
+REVOKE ALL ON FUNCTION traffic.update_node() FROM PUBLIC;

--- a/volumes/sql/traffic_new/func_upd_node.sql
+++ b/volumes/sql/traffic_new/func_upd_node.sql
@@ -31,7 +31,7 @@ Delete from traffic.node where node_id in (SELECT node_id from delrec);
 $BODY$;
 
 ALTER FUNCTION traffic.update_node()
-    OWNER TO scannon;
+    OWNER TO traffic_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.update_node() TO scannon;
 

--- a/volumes/sql/traffic_new/logged_actions.sql
+++ b/volumes/sql/traffic_new/logged_actions.sql
@@ -1,0 +1,100 @@
+-- Table: traffic.logged_actions
+
+-- DROP TABLE IF EXISTS traffic.logged_actions;
+
+CREATE TABLE IF NOT EXISTS traffic.logged_actions
+(
+    event_id bigint NOT NULL DEFAULT nextval('traffic.logged_actions_event_id_seq'::regclass),
+    schema_name text COLLATE pg_catalog."default" NOT NULL,
+    table_name text COLLATE pg_catalog."default" NOT NULL,
+    relid oid NOT NULL,
+    session_user_name text COLLATE pg_catalog."default",
+    action_tstamp_clk timestamp with time zone NOT NULL,
+    transaction_id bigint,
+    application_name text COLLATE pg_catalog."default",
+    client_query text COLLATE pg_catalog."default",
+    action text COLLATE pg_catalog."default" NOT NULL,
+    row_data hstore,
+    changed_fields hstore,
+    statement_only boolean NOT NULL,
+    CONSTRAINT logged_actions_pkey PRIMARY KEY (event_id),
+    CONSTRAINT logged_actions_action_check CHECK (action = ANY (ARRAY['I'::text, 'D'::text, 'U'::text, 'T'::text]))
+)
+WITH (
+    OIDS = FALSE
+);
+--TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS traffic.logged_actions
+    OWNER to collision_admins;
+
+GRANT SELECT ON TABLE traffic.logged_actions TO bdit_humans;
+
+GRANT ALL ON TABLE traffic.logged_actions TO collision_admins;
+
+COMMENT ON TABLE traffic.logged_actions
+    IS 'History of auditable actions on audited tables, from traffic.if_modified_func(). 
+	All 8 tables updated via TRAFFIC_NEW data dumps are in except traffic.det';
+
+COMMENT ON COLUMN traffic.logged_actions.event_id
+    IS 'Unique identifier for each auditable event';
+
+COMMENT ON COLUMN traffic.logged_actions.schema_name
+    IS 'Database schema audited table for this event is in';
+
+COMMENT ON COLUMN traffic.logged_actions.table_name
+    IS 'Non-schema-qualified table name of table event occured in';
+
+COMMENT ON COLUMN traffic.logged_actions.relid
+    IS 'Table OID. Changes with drop/create. Get with ''tablename''::regclass';
+
+COMMENT ON COLUMN traffic.logged_actions.session_user_name
+    IS 'Login / session user whose statement caused the audited event';
+
+COMMENT ON COLUMN traffic.logged_actions.action_tstamp_clk
+    IS 'Wall clock time at which audited event''s trigger call occurred';
+
+COMMENT ON COLUMN traffic.logged_actions.transaction_id
+    IS 'Identifier of transaction that made the change. May wrap, but unique paired.';
+
+COMMENT ON COLUMN traffic.logged_actions.application_name
+    IS 'Application name set when this audit event occurred. Can be changed in-session by client.';
+
+COMMENT ON COLUMN traffic.logged_actions.client_query
+    IS 'Top-level query that caused this auditable event. May be more than one statement.';
+
+COMMENT ON COLUMN traffic.logged_actions.action
+    IS 'Action type; I = insert, D = delete, U = update, T = truncate';
+
+COMMENT ON COLUMN traffic.logged_actions.row_data
+    IS 'Record value. Null for statement-level trigger. For INSERT this is the new tuple. For DELETE and UPDATE it is the old tuple.';
+
+COMMENT ON COLUMN traffic.logged_actions.changed_fields
+    IS 'New values of fields changed by UPDATE. Null except for row-level UPDATE events.';
+
+COMMENT ON COLUMN traffic.logged_actions.statement_only
+    IS '''t'' if audit event is from an FOR EACH STATEMENT trigger, ''f'' for FOR EACH ROW';
+-- Index: logged_actions_action_idx
+
+-- DROP INDEX IF EXISTS traffic.logged_actions_action_idx;
+
+CREATE INDEX IF NOT EXISTS logged_actions_action_idx
+    ON traffic.logged_actions USING btree
+    (action COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;
+-- Index: logged_actions_action_tstamp_clk_idx
+
+-- DROP INDEX IF EXISTS traffic.logged_actions_action_tstamp_clk_idx;
+
+CREATE INDEX IF NOT EXISTS logged_actions_action_tstamp_clk_idx
+    ON traffic.logged_actions USING brin
+    (action_tstamp_clk)
+    TABLESPACE pg_default;
+-- Index: logged_actions_table_name_idx
+
+-- DROP INDEX IF EXISTS traffic.logged_actions_table_name_idx;
+
+CREATE INDEX IF NOT EXISTS logged_actions_table_name_idx
+    ON traffic.logged_actions USING btree
+    (table_name COLLATE pg_catalog."default" ASC NULLS LAST)
+    TABLESPACE pg_default;

--- a/volumes/sql/traffic_new/logged_actions.sql
+++ b/volumes/sql/traffic_new/logged_actions.sql
@@ -26,7 +26,7 @@ WITH (
 --TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS traffic.logged_actions
-    OWNER to collision_admins;
+    OWNER to traffic_admins;
 
 GRANT SELECT ON TABLE traffic.logged_actions TO bdit_humans;
 

--- a/volumes/sql/traffic_new/trfunc_log.sql
+++ b/volumes/sql/traffic_new/trfunc_log.sql
@@ -1,0 +1,113 @@
+-- FUNCTION: traffic.if_modified_func()
+
+-- DROP FUNCTION IF EXISTS traffic.if_modified_func();
+
+CREATE OR REPLACE FUNCTION traffic.if_modified_func()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE NOT LEAKPROOF SECURITY DEFINER
+    SET search_path=public
+AS $BODY$
+DECLARE
+    audit_row traffic.logged_actions;
+    include_values boolean;
+    log_diffs boolean;
+    h_old hstore;
+    h_new hstore;
+    excluded_cols text[] = ARRAY[]::text[];
+BEGIN
+    IF TG_WHEN <> 'AFTER' THEN
+        RAISE EXCEPTION 'collisions_replicator.if_modified_func() may only run as an AFTER trigger';
+    END IF;
+
+    audit_row = ROW(
+        nextval('traffic.logged_actions_event_id_seq'), -- event_id
+        TG_TABLE_SCHEMA::text,                        -- schema_name
+        TG_TABLE_NAME::text,                          -- table_name
+        TG_RELID,                                     -- relation OID for much quicker searches
+        session_user::text,                           -- session_user_name
+        clock_timestamp() at time zone 'America/Toronto', -- action_tstamp_clk
+        txid_current(),                               -- transaction ID
+        current_setting('application_name'),          -- client application
+        current_query(),                              -- top-level query or queries (if multistatement) from client
+        substring(TG_OP,1,1),                         -- action
+        NULL, NULL,                                   -- row_data, changed_fields
+        'f'                                           -- statement_only
+        );
+
+    IF NOT TG_ARGV[0]::boolean IS DISTINCT FROM 'f'::boolean THEN
+        audit_row.client_query = NULL;
+    END IF;
+
+    IF TG_ARGV[1] IS NOT NULL THEN
+        excluded_cols = TG_ARGV[1]::text[];
+    END IF;
+    
+    IF (TG_OP = 'UPDATE' AND TG_LEVEL = 'ROW') THEN
+        audit_row.row_data = hstore(OLD.*) - excluded_cols;
+        audit_row.changed_fields =  (hstore(NEW.*) - audit_row.row_data) - excluded_cols;
+        IF audit_row.changed_fields = hstore('') THEN
+            -- All changed fields are ignored. Skip this update.
+            RETURN NULL;
+        END IF;
+    ELSIF (TG_OP = 'DELETE' AND TG_LEVEL = 'ROW') THEN
+        audit_row.row_data = hstore(OLD.*) - excluded_cols;
+    ELSIF (TG_OP = 'INSERT' AND TG_LEVEL = 'ROW') THEN
+        audit_row.row_data = hstore(NEW.*) - excluded_cols;
+    ELSIF (TG_LEVEL = 'STATEMENT' AND TG_OP IN ('INSERT','UPDATE','DELETE','TRUNCATE')) THEN
+        audit_row.statement_only = 't';
+    ELSE
+        RAISE EXCEPTION '[traffic.if_modified_func] - Trigger func added as trigger for unhandled case: %, %',TG_OP, TG_LEVEL;
+        RETURN NULL;
+    END IF;
+    IF TG_TABLE_NAME = traffic.det THEN
+		RETURN NULL;
+	END IF;
+	
+	INSERT INTO traffic.logged_actions VALUES (audit_row.*);
+    RETURN NULL;
+END;
+$BODY$;
+
+ALTER FUNCTION traffic.if_modified_func()
+    OWNER TO traffic_admins;
+
+GRANT EXECUTE ON FUNCTION traffic.if_modified_func() TO traffic_admins;
+
+REVOKE ALL ON FUNCTION traffic.if_modified_func() FROM PUBLIC;
+
+COMMENT ON FUNCTION traffic.if_modified_func()
+    IS '
+Track changes to a table at the statement and/or row level.
+
+Changes to the table traffic.det are excluded because there are
+so many of them it will cause chonk.
+
+Optional parameters to trigger in CREATE TRIGGER call:
+
+param 0: boolean, whether to log the query text. Default ''t''.
+
+param 1: text[], columns to ignore in updates. Default [].
+
+         Updates to ignored cols are omitted from changed_fields.
+
+         Updates with only ignored cols changed are not inserted
+         into the audit log.
+
+         Almost all the processing work is still done for updates
+         that ignored. If you need to save the load, you need to use
+         WHEN clause on the trigger instead.
+
+         No warning or error is issued if ignored_cols contains columns
+         that do not exist in the target table. This lets you specify
+         a standard set of ignored columns.
+
+There is no parameter to disable logging of values. Add this trigger as
+a ''FOR EACH STATEMENT'' rather than ''FOR EACH ROW'' trigger if you do not
+want to log row values.
+
+Note that the user name logged is the login role for the session. The audit trigger
+cannot obtain the active role because it is reset by the SECURITY DEFINER invocation
+of the audit trigger its self.
+';

--- a/volumes/sql/traffic_new/trfunc_traffic_if_mod.sql
+++ b/volumes/sql/traffic_new/trfunc_traffic_if_mod.sql
@@ -61,9 +61,6 @@ BEGIN
         RAISE EXCEPTION '[traffic.if_modified_func] - Trigger func added as trigger for unhandled case: %, %',TG_OP, TG_LEVEL;
         RETURN NULL;
     END IF;
-    IF TG_TABLE_NAME = traffic.det THEN
-		RETURN NULL;
-	END IF;
 	
 	INSERT INTO traffic.logged_actions VALUES (audit_row.*);
     RETURN NULL;


### PR DESCRIPTION
## What this pull request accomplishes:

- upserts data in 9 tables on traffic using data updated on TRAFFIC_NEW
- logs changes to 6 of the tables (3 tables were excluded from auditing because they are large and frequently updated).

## Issue(s) this solves:

- #462

## What, in particular, needs to reviewed:

- tested on airflow; it worked
- compared table record counts in both schemas and they matched
- reasonable output in logged_actions table
- maybe make sure the dag is efficient??? Would it be better to update all of the tables at the same time?
