### PR TITLE
smol pr for changing pygresql to use psycopg2 in blip api 

### DIFF
--- a/bluetooth/api/blip_api.py
+++ b/bluetooth/api/blip_api.py
@@ -256,20 +256,21 @@ def update_configs(all_analyses, dbset):
             with conn:
                 with conn.cursor() as cur:  
                     cur.execute(upsert_sql, row)
-            with conn:
-                with conn.cursor() as cur:
-                    cur.execute('SELECT pull_data, analysis_id, report_name FROM bluetooth.all_analyses')
-                    upserted = cur.fetchone()
-                    
-            analyses_pull_data[upserted[1]] = {'pull_data': upserted[0],
-                                                           'report_name': upserted[2]}
+      
+            analyses_pull_data[row['analysis_id']] = {'pull_data': True,
+                                                           'report_name': row['report_name']}
         except IntegrityError as err:
             LOGGER.error(err)
 
+<<<<<<< HEAD
     db.close()
 
+=======
+    conn.close()
+>>>>>>> 65c4a6f... #131 fix upsert returned values to use inserting row
     analyses_to_pull = {analysis_id: analysis for (
-        analysis_id, analysis) in analyses_pull_data.items() if analysis['pull_data']}
+                                                analysis_id, analysis) in analyses_pull_data.items() if analysis['pull_data']}
+
     return analyses_to_pull
 
 def move_data(dbset):
@@ -309,7 +310,7 @@ def move_data(dbset):
         if query[0] != 1:
             conn.rollback()
             raise DatabaseError('king_pilot.load_bt_data did not complete successfully') 
-        ## Truncate and delete 
+        ## Truncate and delete if successful 
         with conn:
             with conn.cursor() as cur:
                 cur.execute("TRUNCATE bluetooth.raw_data;")
@@ -361,10 +362,18 @@ def main(dbsetting: 'path/to/config.cfg' = None,
         db = DB(**dbset)
 
     if live:
+<<<<<<< HEAD
         
         
         query = db.query("SELECT analysis_id, report_name from king_pilot.bt_segments INNER JOIN bluetooth.all_analyses USING(analysis_id)")
         routes_to_pull = {analysis_id: dict(report_name = report_name) for analysis_id, report_name in query.getresult()}
+=======
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT analysis_id, report_name from king_pilot.bt_segments INNER JOIN bluetooth.all_analyses USING(analysis_id)")
+        routes_to_pull = {analysis_id: dict(report_name = report_name) for analysis_id, report_name in cur.fetchone()}
+
+>>>>>>> 65c4a6f... #131 fix upsert returned values to use inserting row
     else:
         #Querying data that's been further processed overnight
         if not analysis:
@@ -373,6 +382,7 @@ def main(dbsetting: 'path/to/config.cfg' = None,
                                                             api_settings['pw'])
             LOGGER.info('Updating route configs')
             routes_to_pull = update_configs(all_analyses, dbset)
+
         else:
             LOGGER.info('Fetching info on the following analyses from the database: %s', analysis)
 <<<<<<< HEAD
@@ -387,7 +397,11 @@ def main(dbsetting: 'path/to/config.cfg' = None,
                 with conn.cursor() as cur:
                     cur.execute(sql, (analysis,))
             routes_to_pull = {analysis_id: dict(report_name = report_name) for analysis_id, report_name in cur.fetchone()}
+<<<<<<< HEAD
 >>>>>>> c7cf1df... #131 update upsert sql
+=======
+
+>>>>>>> 65c4a6f... #131 fix upsert returned values to use inserting row
         date_to_process = None
 
     if years is None and live:

--- a/bluetooth/api/blip_api.py
+++ b/bluetooth/api/blip_api.py
@@ -243,16 +243,15 @@ def update_configs(all_analyses, dbset):
                                                                 route_id, route_name, route_points)
                             VALUES (%(device_class_set_name)s, %(analysis_id)s, %(minimum_point_completed)s, %(outcomes)s, %(report_id)s, %(report_name)s, %(route_id)s, %(route_name)s, %(route_points)s)
                             ON CONFLICT (analysis_id)
-                            DO UPDATE SET (device_class_set_name, minimum_point_completed, outcomes, report_id, report_name, route_id, route_name, route_points, pull_data)
-                                            = (device_class_set_name = excluded.device_class_set_name,
-                                               minimum_point_completed = excluded.minimum_point_completed,
-                                               outcomes = excluded.outcomes ,
-                                               report_id = excluded.report_id,
-                                               report_name = excluded.report_name,
-                                               route_id = excluded.route_id ,
-                                               route_name = excluded.route_name ,
-                                               route_points = excluded.route_points,
-                                               pull_data = included.pull_data); 
+                            DO UPDATE SET (device_class_set_name, minimum_point_completed, outcomes, report_id, report_name, route_id, route_name, route_points)
+                                            = (EXCLUDED.device_class_set_name,
+                                               EXCLUDED.minimum_point_completed,
+                                               EXCLUDED.outcomes ,
+                                               EXCLUDED.report_id,
+                                               EXCLUDED.report_name,
+                                               EXCLUDED.route_id ,
+                                               EXCLUDED.route_name ,
+                                               EXCLUDED.route_points); 
                         '''
             with conn:
                 with conn.cursor() as cur:  

--- a/bluetooth/api/blip_api.py
+++ b/bluetooth/api/blip_api.py
@@ -279,6 +279,7 @@ def move_data(dbset):
         except RetryError as retry_err:
             LOGGER.critical('Number of retries exceeded to connect to DB with the error:')
             retry_err.reraise()
+<<<<<<< HEAD
         db.begin()
         query = db.query("SELECT bluetooth.move_raw_data();")
         if query.getresult()[0][0] != 1:
@@ -291,6 +292,30 @@ def move_data(dbset):
         query = db.query("TRUNCATE bluetooth.raw_data;")
         db.query('DELETE FROM king_pilot.daily_raw_bt WHERE measured_timestamp < now()::DATE;')
         db.commit()
+=======
+        ## BT move raw data
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT bluetooth.move_raw_data();")
+                query = cur.fetchone()
+        if query[0] != 1:
+            conn.rollback()
+            raise DatabaseError('bluetooth.move_raw_data did not complete successfully') 
+        ## King pilot 
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT king_pilot.load_bt_data();")
+                query = cur.fetchone()    
+        if query[0] != 1:
+            conn.rollback()
+            raise DatabaseError('king_pilot.load_bt_data did not complete successfully') 
+        ## Truncate and delete 
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute("TRUNCATE bluetooth.raw_data;")
+                cur.execute("DELETE FROM king_pilot.daily_raw_bt WHERE measured_timestamp < now()::DATE;")
+                
+>>>>>>> 40b3ce0... #131 got rid of print() comments
     except DatabaseError as dberr:
         LOGGER.error(dberr)
         db.rollback()

--- a/bluetooth/api/blip_api.py
+++ b/bluetooth/api/blip_api.py
@@ -90,8 +90,13 @@ def get_data_for_config(blip, un: str, pw: str, config):
 @retry(retry=retry_if_exception_type(InternalError),
        wait=wait_exponential(multiplier=15, max=900), before_sleep=before_sleep_log(LOGGER, logging.ERROR))
 def _get_db(dbset):
+<<<<<<< HEAD
     '''Create a pygresql DB object and retry for up to 15 minutes if the connection is unsuccessful'''
     return DB(**dbset)
+=======
+    '''Create a psycopg2 DB object and retry for up to 15 minutes if the connection is unsuccessful'''
+    return connect(**dbset)
+>>>>>>> afacbcc... #131update comments from pg to psycopg2
 
 
 def insert_data(data: list, dbset: dict, live: bool):
@@ -101,7 +106,7 @@ def insert_data(data: list, dbset: dict, live: bool):
     :param data:
         List of dictionaries, gets converted to list of tuples
     :param dbset:
-        DB settings passed to Pygresql to create a connection 
+        DB settings passed to psycopg2 to create a connection 
     '''
     num_rows = len(data)
     if num_rows > 0:

--- a/bluetooth/api/blip_api.py
+++ b/bluetooth/api/blip_api.py
@@ -12,8 +12,15 @@ import datetime
 import logging
 import os
 import sys
+#from syslog import LOG_DEBUG
 import time
 import traceback
+<<<<<<< HEAD
+=======
+import json
+import psycopg2
+from psycopg2 import connect, sql, InternalError, IntegrityError, DatabaseError
+>>>>>>> d36423a... #131fix that json mess in prepping upsert row
 from datetime import date
 from itertools import product
 from typing import List
@@ -170,6 +177,10 @@ def get_wsdl_client(wsdlfile, direct=None, live=False):
             config[key] = zeep.xsd.SkipValue
     return blip, config
 
+class Object:
+    def toJSON(self):
+        return json.dumps(self, default=lambda o: o.__dict__, 
+            sort_keys=True, indent=None)
 
 def update_configs(all_analyses, dbset):
     '''
@@ -186,17 +197,27 @@ def update_configs(all_analyses, dbset):
     except RetryError as retry_err:
         LOGGER.critical('Number of retries exceeded to connect to DB with the error:')
         retry_err.reraise()
+<<<<<<< HEAD
     db.begin()
     db.query('''TRUNCATE bluetooth.all_analyses_day_old;
     INSERT INTO bluetooth.all_analyses_day_old SELECT * FROM bluetooth.all_analyses;''')
     db.commit()
+=======
+    with conn:
+        with conn.cursor() as curs:
+            curs.execute('''TRUNCATE bluetooth.all_analyses_day_old;
+                            INSERT INTO bluetooth.all_analyses_day_old 
+							SELECT * FROM bluetooth.all_analyses;''')
+        
+>>>>>>> d36423a... #131fix that json mess in prepping upsert row
     analyses_pull_data = {}
     for report in all_analyses:
-        report.outcomes = [outcome.__json__() for outcome in report.outcomes]
-        report.routePoints = [route_point.__json__()
-                              for route_point in report.routePoints]
+        outcomes_arr = json.dumps([i.__dict__ for i in report.outcomes])
+        routePoints_arr = json.dumps([i.__dict__ for i in report.routePoints])
+
         row = dict(device_class_set_name=report.deviceClassSetName,
                    analysis_id=report.id,
+<<<<<<< HEAD
 <<<<<<< HEAD
                    minimum_point_completed=db.encode_json(
                        report.minimumPointCompleted.__json__()),
@@ -204,20 +225,26 @@ def update_configs(all_analyses, dbset):
                    minimum_point_completed=json.dumps(report.minimumPointCompleted.__json__()),
 >>>>>>> c7cf1df... #131 update upsert sql
                    outcomes=report.outcomes,
+=======
+                   minimum_point_completed=json.dumps(
+                        report.minimumPointCompleted.__json__()),
+                   outcomes= outcomes_arr,
+>>>>>>> d36423a... #131fix that json mess in prepping upsert row
                    report_id=report.reportId,
                    report_name=report.reportName,
                    route_id=report.routeId,
                    route_name=report.routeName,
-                   route_points=report.routePoints)
+                   route_points=routePoints_arr)
+
         #If upsert fails, log error and continue, don't add analysis to analyses to pull
         try:
             upsert_sql = '''INSERT INTO bluetooth.all_analyses (device_class_set_name, analysis_id, 
                                                                 minimum_point_completed, outcomes, report_id, report_name, 
                                                                 route_id, route_name, route_points)
-                            VALUES (%s)
+                            VALUES (%(device_class_set_name)s, %(analysis_id)s, %(minimum_point_completed)s, %(outcomes)s, %(report_id)s, %(report_name)s, %(route_id)s, %(route_name)s, %(route_points)s)
                             ON CONFLICT (analysis_id)
                             DO UPDATE SET (device_class_set_name, minimum_point_completed, outcomes, report_id, report_name, route_id, route_name, route_points, pull_data)
-                                            = (device_class_set_name = excluded.device_class_set_name
+                                            = (device_class_set_name = excluded.device_class_set_name,
                                                minimum_point_completed = excluded.minimum_point_completed,
                                                outcomes = excluded.outcomes ,
                                                report_id = excluded.report_id,
@@ -334,7 +361,7 @@ def main(dbsetting: 'path/to/config.cfg' = None,
                     SELECT analysis_id, report_name FROM bluetooth.all_analyses INNER JOIN analyses USING(analysis_id)'''
             with conn:
                 with conn.cursor() as cur:
-                    cur.execute(sql, analysis)
+                    cur.execute(sql, (analysis,))
             routes_to_pull = {analysis_id: dict(report_name = report_name) for analysis_id, report_name in cur.fetchone()}
 >>>>>>> c7cf1df... #131 update upsert sql
         date_to_process = None

--- a/bluetooth/api/blip_api.py
+++ b/bluetooth/api/blip_api.py
@@ -258,11 +258,11 @@ def update_configs(all_analyses, dbset):
                     cur.execute(upsert_sql, row)
             with conn:
                 with conn.cursor() as cur:
-                    cur.execute('SELECT pull_data, analysis_id, report_id FROM bluetooth.all_analyses')
+                    cur.execute('SELECT pull_data, analysis_id, report_name FROM bluetooth.all_analyses')
                     upserted = cur.fetchone()
                     
-            analyses_pull_data[upserted['analysis_id']] = {'pull_data': upserted['pull_data'],
-                                                           'report_name': upserted['report_name']}
+            analyses_pull_data[upserted[1]] = {'pull_data': upserted[0],
+                                                           'report_name': upserted[2]}
         except IntegrityError as err:
             LOGGER.error(err)
 

--- a/bluetooth/api/blip_api.py
+++ b/bluetooth/api/blip_api.py
@@ -197,8 +197,12 @@ def update_configs(all_analyses, dbset):
                               for route_point in report.routePoints]
         row = dict(device_class_set_name=report.deviceClassSetName,
                    analysis_id=report.id,
+<<<<<<< HEAD
                    minimum_point_completed=db.encode_json(
                        report.minimumPointCompleted.__json__()),
+=======
+                   minimum_point_completed=json.dumps(report.minimumPointCompleted.__json__()),
+>>>>>>> c7cf1df... #131 update upsert sql
                    outcomes=report.outcomes,
                    report_id=report.reportId,
                    report_name=report.reportName,
@@ -207,8 +211,30 @@ def update_configs(all_analyses, dbset):
                    route_points=report.routePoints)
         #If upsert fails, log error and continue, don't add analysis to analyses to pull
         try:
-            upserted = db.upsert('bluetooth.all_analyses', row,
-                                 pull_data='included.pull_data')
+            upsert_sql = '''INSERT INTO bluetooth.all_analyses (device_class_set_name, analysis_id, 
+                                                                minimum_point_completed, outcomes, report_id, report_name, 
+                                                                route_id, route_name, route_points)
+                            VALUES (%s)
+                            ON CONFLICT (analysis_id)
+                            DO UPDATE SET (device_class_set_name, minimum_point_completed, outcomes, report_id, report_name, route_id, route_name, route_points, pull_data)
+                                            = (device_class_set_name = excluded.device_class_set_name
+                                               minimum_point_completed = excluded.minimum_point_completed,
+                                               outcomes = excluded.outcomes ,
+                                               report_id = excluded.report_id,
+                                               report_name = excluded.report_name,
+                                               route_id = excluded.route_id ,
+                                               route_name = excluded.route_name ,
+                                               route_points = excluded.route_points,
+                                               pull_data = included.pull_data); 
+                        '''
+            with conn:
+                with conn.cursor() as cur:  
+                    cur.execute(upsert_sql, row)
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute('SELECT pull_data, analysis_id, report_id FROM bluetooth.all_analyses')
+                    upserted = cur.fetchone()
+                    
             analyses_pull_data[upserted['analysis_id']] = {'pull_data': upserted['pull_data'],
                                                            'report_name': upserted['report_name']}
         except IntegrityError as err:
@@ -298,10 +324,19 @@ def main(dbsetting: 'path/to/config.cfg' = None,
             routes_to_pull = update_configs(all_analyses, dbset)
         else:
             LOGGER.info('Fetching info on the following analyses from the database: %s', analysis)
+<<<<<<< HEAD
             sql = '''WITH analyses AS (SELECT unnest(%(analysis)s::bigint[]) AS analysis_id)
                     SELECT analysis_id, report_name FROM bluetooth.all_analyses INNER JOIN analyses USING(analysis_id)'''
             query = db.query_formatted(sql, {'analysis':analysis})
             routes_to_pull = {analysis_id: dict(report_name = report_name) for analysis_id, report_name in query.getresult()}
+=======
+            sql = '''WITH analyses AS (SELECT unnest((%s)::bigint[]) AS analysis_id)
+                    SELECT analysis_id, report_name FROM bluetooth.all_analyses INNER JOIN analyses USING(analysis_id)'''
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(sql, analysis)
+            routes_to_pull = {analysis_id: dict(report_name = report_name) for analysis_id, report_name in cur.fetchone()}
+>>>>>>> c7cf1df... #131 update upsert sql
         date_to_process = None
 
     if years is None and live:


### PR DESCRIPTION
## What this pull request accomplishes:

- Remove the usage of pygresql package and use psycopg2 instead

## Issue(s) this solves:

- #131

## What, in particular, needs to reviewed:

- If it works
- I feel like there was something about the upsert that I had problem with, so the upsert statement
- Now that I think about it more, I think there was a problem with upsert that I haven't fixed yet
