### PR TITLE
Get rid of _value_ attribute for outcome_arr and routepoint_arr

### DIFF
--- a/bluetooth/api/blip_api.py
+++ b/bluetooth/api/blip_api.py
@@ -194,8 +194,8 @@ def update_configs(all_analyses, dbset):
         
     analyses_pull_data = {}
     for report in all_analyses:
-        outcomes_arr = json.dumps([i.__dict__ for i in report.outcomes])
-        routePoints_arr = json.dumps([i.__dict__ for i in report.routePoints])
+        outcomes_arr = json.dumps([outcome.__json__() for outcome in report.outcomes])
+        routePoints_arr = json.dumps([route_point.__json__() for route_point in report.routePoints])
 
         row = dict(device_class_set_name=report.deviceClassSetName,
                    analysis_id=report.id,


### PR DESCRIPTION
## What this pull request accomplishes:

- Got rid of _value_ attribute in json for outcome and routepoint column in `bluetooth.all_analyses`
- e.g. 
```
SELECT      all_analyses.analysis_id,
             (all_analyses.route_points -> 0) ->> 'id'::text AS start_route_point_id,
             (all_analyses.route_points -> 0) ->> 'name'::text AS start_detector,
             (all_analyses.route_points -> 1) ->> 'id'::text AS end_route_point_id,
             (all_analyses.route_points -> 1) ->> 'name'::text AS end_detector
FROM       bluetooth.all_analyses 
```         
returns the below correctly
analysis_id | start_route_point_id | start_detector | end_route_point_id | end_detector
-- | -- | -- | -- | --
1387957 | 116755 | C | 116754 | B

## Issue(s) this solves:

- #131
