### PR TITLE
Handling invalid json responses in wys_api.py #501

### DIFF
--- a/wys/api/python/wys_api.py
+++ b/wys/api/python/wys_api.py
@@ -18,7 +18,7 @@ import psycopg2
 from psycopg2 import connect
 from psycopg2.extras import execute_values
 from requests import Session, exceptions
-
+import json
 
 class WYS_APIException(Exception):
     """Base class for exceptions."""
@@ -112,7 +112,7 @@ def get_statistics_hourly(location, start_date, hr, api_key):
     # Error handling
     try:
         res = response.json()
-    except Exception as err: 
+    except json.decoder.JSONDecodeError as err:
         # catching invalid json responses `json.decoder.JSONDecodeError`
         logger.error(err)
         raise
@@ -274,6 +274,8 @@ def get_data_for_date(start_date, signs_iterator, api_key):
                 except exceptions.RequestException as err:
                     logger.error(err)
                     sleep(75)
+                except Exception as err:
+                    logger.error(err)
                 else:
                    # keep track of processed intervals
                    processed_hr.append(hr) 

--- a/wys/api/python/wys_api.py
+++ b/wys/api/python/wys_api.py
@@ -110,23 +110,23 @@ def get_statistics_hourly(location, start_date, hr, api_key):
                         ':00/to/'+str(hr).zfill(2)+':59/speed_units/0', 
                         headers=headers)
     # Error handling
+    try:
+        res = response.json()
+    except Exception as err: 
+        # catching invalid json responses `json.decoder.JSONDecodeError`
+        logger.error(err)
+        raise
     if response.status_code==200:
-        statistics=response.json()
-        return statistics
+        return res
     elif response.status_code==204:
-        error=response.json()
-        logger.error('204 error    '+error['error_message'])
+        logger.error('204 error    '+res['error_message'])
     elif response.status_code==404:
-        error=response.json()
-        logger.error('404 error for location %s, ' +error['error_message']+' or request duration invalid', location)
+        logger.error('404 error for location %s, ' +res['error_message']+' or request duration invalid', location)
     elif response.status_code==401:
-        error=response.json()
-        logger.error('401 error    '+error['error_message'])
+        logger.error('401 error    '+res['error_message'])
     elif response.status_code==405:
-        error=response.json()
-        logger.error('405 error    '+error['error_message'])        
+        logger.error('405 error    '+res['error_message'])        
     elif response.status_code==504:
-        error=response.json()
         logger.error('504 timeout pulling sign %s for hour %s', 
                      location, hr)
         raise TimeoutException('Error'+str(response.status_code))


### PR DESCRIPTION
## What this pull request accomplishes:

- It handles the exception `json.decoder.JSONDecodeError` in `wys_api.py` by logging the returned error message and passing the exception back to the calling function in order to skip the failing hour 

## Issue(s) this solves:

- #501 

## What, in particular, needs to reviewed:

- function `get_statistics_hourly` in `wys/api/python/wys_api.py`
