### PR TITLE
Add primary keys to miovision `classifications` and `intersections` tables

### DIFF
--- a/volumes/miovision/sql/create-table-intersections.sql
+++ b/volumes/miovision/sql/create-table-intersections.sql
@@ -1,6 +1,6 @@
 ﻿CREATE TABLE miovision_api.intersections
 (
-    intersection_uid integer,
+    intersection_uid integer PRIMARY KEY,
     id text COLLATE pg_catalog."default",
     intersection_name text COLLATE pg_catalog."default",
     date_installed date,


### PR DESCRIPTION
## What this pull request accomplishes:

- adds a primary key to the `miovision_api.intersections` table
- points out that `miovision_api.classifications` is defined here as using `classification_uid` as a primary key but does in fact not do that. 

## Issue(s) this solves:

- NA

## What, in particular, needs to reviewed:

- definitions here match reality in the database
