### PR TITLE
Run bigdata GCC puller tasks on the dev server only

### DIFF
--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -124,13 +124,15 @@ with DAG(
     default_args=DEFAULT_ARGS,
     schedule_interval='0 7 1 */3 *' #'@quarterly'
 ) as gcc_layers_dag:
+    deployment = os.environ.get("DEPLOYMENT", "PROD")
 
-    for layer in bigdata_layers:
-        pull_bigdata_layer = PythonOperator(
-            task_id = 'bigdata_task_'+ str(layer),
-            python_callable = get_layer,
-            op_args = bigdata_layers[layer] + [bigdata_cred]
-        )
+    if deployment == "DEV":
+        for layer in bigdata_layers:
+            pull_bigdata_layer = PythonOperator(
+                task_id = 'bigdata_task_'+ str(layer),
+                python_callable = get_layer,
+                op_args = bigdata_layers[layer] + [bigdata_cred]
+            )
 
     for layer in ptc_layers:
         pull_ptc_layer = PythonOperator(


### PR DESCRIPTION
## What this pull request accomplishes:

- Updated the DAG to include specific tasks based on the environment variable `DEPLOYMENT`, which should be set in `/etc/systemd/system/airflow-webserver.service` and `/etc/systemd/system/airflow-scheduler.service` as follows:
```
[Service]
Environment="DEPLOYMENT=DEV" # PROD for prod servers
```

## Issue(s) this solves:

- #572 

## What, in particular, needs to reviewed:

- The `pull_gcc_layers` DAG file: `gcc_layers_pull.py`
