### PR TITLE
#595 Remove hardcoded references to owners, emails, slack_ids in DAGs…

### DIFF
--- a/dags/assets_pull.py
+++ b/dags/assets_pull.py
@@ -27,9 +27,12 @@ import requests
 from psycopg2.extras import execute_values
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
+from airflow.models import Variable 
 
 from dateutil.parser import parse
 from datetime import datetime
+
+dag_name = 'traffic_signals_dag'
 
 # Credentials
 from airflow.providers.postgres.hooks.postgres import PostgresHook
@@ -41,16 +44,27 @@ vz_cred = PostgresHook("vz_api_bot") # name of Conn Id defined in UI
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 
+dag_owners = Variable.get('dag_owners', deserialize_json=True)
+slack_ids = Variable.get('slack_member_id', deserialize_json=True)
+
+names = dag_owners.get(dag_name, ['Unknown']) #find dag owners w/default = Unknown    
+
+list_names = []
+for name in names:
+    list_names.append(slack_ids.get(name, '@Unknown Slack ID')) #find slack ids w/default = Unkown
+
 SLACK_CONN_ID = 'slack_data_pipeline'
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     slack_msg = """
             :red_circle: Task Failed / Tâche échouée.
+            {slack_name} please check.
             *Task*: {task}
             *Dag*: {dag}
             *Execution Time*: {exec_date}
             *Log Url*: {log_url}
             """.format(
+            slack_name=' '.join(list_names),
             task=context.get('task_instance').task_id,
             dag=context.get('task_instance').dag_id,
             ti=context.get('task_instance'),
@@ -428,7 +442,7 @@ def pull_traffic_signal():
 # ------------------------------------------------------------------------------
 # Set up the dag and task
 TRAFFIC_SIGNALS_DAG = DAG(
-    'traffic_signals_dag',
+    dag_id = dag_name,
     default_args=DEFAULT_ARGS,
     max_active_runs=1,
     template_searchpath=[os.path.join(AIRFLOW_ROOT, 'assets/rlc/airflow/tasks')],

--- a/dags/check_rescu.py
+++ b/dags/check_rescu.py
@@ -11,6 +11,8 @@ from psycopg2.extras import execute_values
 from psycopg2 import connect, Error
 import logging
 
+dag_name = 'rescu_check'
+
 LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
@@ -35,8 +37,14 @@ def check_rescu(con, date_to_pull):
             raise Exception ('There is a PROBLEM here. There is no raw data OR raw_data is less than volume_15min OR volumes_15min is less than 7000 which is way too low')
 
 SLACK_CONN_ID = 'slack_data_pipeline'
-dag_config = Variable.get('slack_member_id', deserialize_json=True)
-list_names = dag_config['raphael'] + ' ' + dag_config['islam'] + ' ' + dag_config['natalie'] 
+dag_owners = Variable.get('dag_owners', deserialize_json=True)
+slack_ids = Variable.get('slack_member_id', deserialize_json=True)
+
+names = dag_owners.get(dag_name, ['Unknown']) #find dag owners w/default = Unknown    
+
+list_names = []
+for name in names:
+    list_names.append(slack_ids.get(name, '@Unknown Slack ID')) #find slack ids w/default = Unkown
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
@@ -45,7 +53,7 @@ def task_fail_slack_alert(context):
     task_msg = """The Task {task} failed, the total volume is too low. 
         Either a lot of loop detectors are down or there's a problem in the pipeline.
         {slack_name} please fix it :thanks_japanese: """.format(
-        task=context.get('task_instance').task_id, slack_name = list_names,)    
+        task=context.get('task_instance').task_id, slack_name = ' '.join(list_names),)    
         
     # this adds the error log url at the end of the msg
     slack_msg = task_msg + """ (<{log_url}|log>)""".format(
@@ -59,10 +67,9 @@ def task_fail_slack_alert(context):
         )
     return failed_alert.execute(context=context)
 
-default_args = {'owner':'jchew',
+default_args = {'owner': names,
                 'depends_on_past':False,
                 'start_date': datetime(2020, 4, 17),
-                'email': ['joven.chew@toronto.ca'],
                 'email_on_failure': False,
                  'email_on_success': False,
                  'retries': 0,
@@ -70,7 +77,7 @@ default_args = {'owner':'jchew',
                  'on_failure_callback': task_fail_slack_alert
                 }
 
-dag = DAG('rescu_check', default_args=default_args, schedule_interval='0 6 * * *', catchup=False)
+dag = DAG(dag_id = dag_name, default_args=default_args, schedule_interval='0 6 * * *', catchup=False)
 # Run at 6 AM local time every day
 
 task1 = PythonOperator(

--- a/dags/collisions_replicator_transfer.py
+++ b/dags/collisions_replicator_transfer.py
@@ -7,7 +7,13 @@ from datetime import datetime, timedelta
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
+from airflow.models import Variable 
+
+dag_name = 'collisions_replicator_transfer'
+
 SLACK_CONN_ID = 'slack_data_pipeline'
+dag_owners = Variable.get('dag_owners', deserialize_json=True)
+slack_ids = Variable.get('slack_member_id', deserialize_json=True)
 
 #This script does things with those operators:
 #1) uses ACC to update acc_safe_copy
@@ -15,10 +21,17 @@ SLACK_CONN_ID = 'slack_data_pipeline'
 #3) update the events and involved mat views 
 #4) throws a sassy slack alert message when it fails
 
+names = dag_owners.get(dag_name, ['Unknown']) #find dag owners w/default = Unknown    
+
+list_names = []
+for name in names:
+    list_names.append(slack_ids.get(name, '@Unknown Slack ID')) #find slack ids w/default = Unkown
+
 def task_fail_sassy_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    task_msg = 'The {task} in updating collisions failed, <@U02NSCSKFEU> go fix it meow :meow_tableflip: '.format(
-            task=context.get('task_instance').task_id,) #K just gotta point out that the last 3 letters in my slack id spell FIRE in French!!!   
+    task_msg = 'The {task} in updating collisions failed, {slack_name} go fix it meow :meow_tableflip: '.format(
+            task=context.get('task_instance').task_id, 
+            slack_name = ' '.join(list_names),)
         
     slack_msg = task_msg + """(<{log_url}|log>)""".format(
             log_url=context.get('task_instance').log_url,)
@@ -31,10 +44,9 @@ def task_fail_sassy_slack_alert(context):
         )
     return failed_alert.execute(context=context)
 
-default_args = {'owner':'scannon',
+default_args = {'owner': names,
                 'depends_on_past':False,
                 'start_date': datetime(2022, 5, 26), #start this Thursday, why not?
-                'email': ['sarah.cannon@toronto.ca'],
                 'email_on_failure': False,
                  'email_on_success': False,
                  'retries': 0,
@@ -43,7 +55,7 @@ default_args = {'owner':'scannon',
                 }
 
 
-with DAG('collisions_replicator_transfer', # going waaaaaayyyyy out on a limb of the magical assumption tree here....
+with DAG(dag_id = dag_name, # going waaaaaayyyyy out on a limb of the magical assumption tree here....
          default_args = default_args,
          schedule_interval='0 3 * * *') as daily_update: #runs at 3am every day
          

--- a/dags/eoy_create_tables.py
+++ b/dags/eoy_create_tables.py
@@ -14,10 +14,18 @@ from dateutil.relativedelta import relativedelta
 from airflow.models import Variable
 import holidays
 
+dag_name = 'eoy_table_create'
 
 SLACK_CONN_ID = 'slack_data_pipeline'
-dag_config = Variable.get('slack_member_id', deserialize_json=True)
-list_names = dag_config['raphael'] + ' ' + dag_config['islam'] + ' ' + dag_config['natalie'] 
+dag_owners = Variable.get('dag_owners', deserialize_json=True)
+slack_ids = Variable.get('slack_member_id', deserialize_json=True)
+
+names = dag_owners.get(dag_name, ['Unknown']) #find dag owners w/default = Unknown    
+
+list_names = []
+for name in names:
+    list_names.append(slack_ids.get(name, '@Unknown Slack ID')) #find slack ids w/default = Unkown
+
 slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
 
 def prep_slack_message(message):
@@ -34,7 +42,8 @@ def task_fail_slack_alert(context):
     # print this task_msg and tag these users
     task_msg = """As part of End of Year table creation, {task} failed.
         {list_names} check out the """.format(
-        task=context.get('task_instance').task_id, slack_name = list_names,)    
+        task=context.get('task_instance').task_id, 
+        slack_name = ' '.join(list_names),)    
         
     # this adds the error log url at the end of the msg
     slack_msg = task_msg + """<{log_url}|log> :notes_minion: """.format(
@@ -75,10 +84,9 @@ def congestion_create_table(dt):
         cur.execute('SELECT congestion.create_yearly_tables(%s);', (year,))        
 
 
-default_args = {'owner':'rdumas',
+default_args = {'owner': names, 
                 'depends_on_past':False,
                 'start_date': datetime(2021, 12, 1),
-                'email': ['raphael.dumas@toronto.ca'],
                 'email_on_failure': False,
                 'email_on_success': False,
                 'retries': 0,
@@ -119,8 +127,9 @@ except Exception as exc:
     err_msg = "Error importing functions for end of year WYS maintenance \n" + str(exc)
     raise ImportError(err_msg)
 
-dag = DAG('eoy_table_create', default_args=default_args,
-        schedule_interval='5 9 1 12 *') #9:05 on December 1st of every year
+dag = DAG(dag_id = dag_name, 
+          default_args=default_args,
+          schedule_interval='5 9 1 12 *') #9:05 on December 1st of every year
 
 here_create_tables = PythonOperator(task_id='here_create_tables',
                                     python_callable = create_here_ta_tables,

--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -19,10 +19,18 @@ bigdata_cred = PostgresHook("gcc_bot_bigdata")
 # On-prem server connection credentials
 ptc_cred = PostgresHook("gcc_bot")
 
+dag_name = 'pull_gcc_layers'
+
 SLACK_CONN_ID = 'slack_data_pipeline'
 # Slack IDs of data pipeline admins
-dag_config = Variable.get('slack_member_id', deserialize_json=True)
-list_names = dag_config['raphael'] + ' ' + dag_config['islam'] + ' ' + dag_config['natalie'] 
+dag_owners = Variable.get('dag_owners', deserialize_json=True)
+slack_ids = Variable.get('slack_member_id', deserialize_json=True)
+
+names = dag_owners.get(dag_name, ['Unknown']) #find dag owners w/default = Unknown    
+
+list_names = []
+for name in names:
+    list_names.append(slack_ids.get(name, '@Unknown Slack ID')) #find slack ids w/default = Unkown
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
@@ -41,7 +49,7 @@ def task_fail_slack_alert(context):
             ti=context.get('task_instance'),
             exec_date=context.get('execution_date'),
             log_url=context.get('task_instance').log_url,
-            slack_name=list_names
+            slack_name=' '.join(list_names),
         )
     failed_alert = SlackWebhookOperator(
         task_id='slack_test',
@@ -53,11 +61,10 @@ def task_fail_slack_alert(context):
     return failed_alert.execute(context=context)
 
 DEFAULT_ARGS = {
- 'owner': 'natalie',
+ 'owner': names,
  'depends_on_past': False,
  'start_date': datetime(2022, 11, 3),
  'email_on_failure': False, 
- 'email': ['natalie.chan@toronto.ca'], 
  'retries': 0,
  'on_failure_callback': task_fail_slack_alert
 }
@@ -120,7 +127,7 @@ ptc_layers = {"city_ward": [0, 0, 'gis', True],
 
 # the DAG runs at 7 am on the first day of March, June, September, and December
 with DAG(
-    'pull_gcc_layers',
+    dag_id = dag_name,
     default_args=DEFAULT_ARGS,
     schedule_interval='0 7 1 */3 *' #'@quarterly'
 ) as gcc_layers_dag:

--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -11,15 +11,24 @@ from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperato
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.models import Variable 
 
+dag_name = 'pull_here'
+
 SLACK_CONN_ID = 'slack_data_pipeline'
-dag_config = Variable.get('slack_member_id', deserialize_json=True)
-list_names = dag_config['raphael'] + ' ' + dag_config['islam'] + ' ' + dag_config['natalie'] 
+dag_owners = Variable.get('dag_owners', deserialize_json=True)
+slack_ids = Variable.get('slack_member_id', deserialize_json=True)
+
+names = dag_owners.get(dag_name, ['Unknown']) #find dag owners w/default = Unknown    
+
+list_names = []
+for name in names:
+    list_names.append(slack_ids.get(name, '@Unknown Slack ID')) #find slack ids w/default = Unkown
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     # print this task_msg and tag these users
     task_msg = """The Task {task} failed :here: :blob_fail:. {slack_name} please fix it """.format(
-        task=context.get('task_instance').task_id, slack_name = list_names,) 
+        task=context.get('task_instance').task_id, 
+        slack_name = ' '.join(list_names),) 
     # this adds the error log url at the end of the msg
     slack_msg = task_msg + """ (<{log_url}|log>)""".format(
             log_url=context.get('task_instance').log_url,)
@@ -35,10 +44,9 @@ def task_fail_slack_alert(context):
 here_postgres = PostgresHook("here_bot")
 rds_con = here_postgres.get_uri()
 
-default_args = {'owner':'rdumas',
+default_args = {'owner': names,
                 'depends_on_past':False,
                 'start_date': datetime(2020, 1, 5),
-                'email': ['raphael.dumas@toronto.ca'],
                 'email_on_failure': False,
                 'email_on_success': False,
                 'retries': 3, #Retry 3 times
@@ -50,7 +58,7 @@ default_args = {'owner':'rdumas',
                        'LANG':'C.UTF-8'}
                 }
 
-dag = DAG('pull_here',default_args=default_args, schedule_interval=' 30 16 * * * ')
+dag = DAG(dag_id = dag_name, default_args = default_args, schedule_interval = ' 30 16 * * * ')
 #Every day at 1630
 
 # Execution date seems to be the day before this was run, so yesterday_ds_nodash

--- a/dags/pull_interventions_dag.py
+++ b/dags/pull_interventions_dag.py
@@ -10,15 +10,24 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 from airflow.models import Variable 
 
+dag_name = 'automate_interventions'
+
 SLACK_CONN_ID = 'slack_data_pipeline'
-dag_config = Variable.get('slack_member_id', deserialize_json=True)
-list_names = dag_config['raphael'] + ' ' + dag_config['islam'] + ' ' + dag_config['natalie'] 
+dag_owners = Variable.get('dag_owners', deserialize_json=True)
+slack_ids = Variable.get('slack_member_id', deserialize_json=True)
+
+names = dag_owners.get(dag_name, ['Unknown']) #find dag owners w/default = Unknown    
+
+list_names = []
+for name in names:
+    list_names.append(slack_ids.get(name, '@Unknown Slack ID')) #find slack ids w/default = Unkown
 
 def task_fail_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
     # print this task_msg and tag these users
     task_msg = """The Task {task} failed :meow_dio: {slack_name} please fix it """.format(
-        task=context.get('task_instance').task_id, slack_name = list_names,) 
+        task=context.get('task_instance').task_id, 
+        slack_name = ' '.join(list_names),) 
     # this adds the error log url at the end of the msg
     slack_msg = task_msg + """ (<{log_url}|log>)""".format(
             log_url=context.get('task_instance').log_url,)
@@ -31,10 +40,9 @@ def task_fail_slack_alert(context):
         )
     return failed_alert.execute(context=context)
 
-default_args = {'owner':'natalie',
+default_args = {'owner':names,
                 'depends_on_past':False,
                 'start_date': datetime(2020, 5, 26),
-                'email': ['natalie.chan@toronto.ca'],
                 'email_on_failure': False,
                 'email_on_success': False,
                 'retries': 0,
@@ -42,7 +50,7 @@ default_args = {'owner':'natalie',
                 'on_failure_callback': task_fail_slack_alert
                 }
 
-dag = DAG('automate_interventions',default_args=default_args, schedule_interval='0 0 * * *')
+dag = DAG(dag_id = dag_name, default_args = default_args, schedule_interval = '0 0 * * *')
 
 
 t1 = BashOperator(

--- a/dags/traffic_transfer.py
+++ b/dags/traffic_transfer.py
@@ -6,16 +6,29 @@ from datetime import datetime, timedelta
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
+from airflow.models import Variable 
 SLACK_CONN_ID = 'slack_data_pipeline'
 
 #This script does things with those operators:
 #1) does 9 upsert queries to update data in arc_link, arterydata, category, cnt_det, cnt_spd, countinfo, countinfomics, det, node
 #2) throws a nattery slack alert message when it fails
 
+dag_name = 'traffic_transfer'
+
+dag_owners = Variable.get('dag_owners', deserialize_json=True)
+slack_ids = Variable.get('slack_member_id', deserialize_json=True)
+
+names = dag_owners.get(dag_name, ['Unknown']) #find dag owners w/default = Unknown    
+
+list_names = []
+for name in names:
+    list_names.append(slack_ids.get(name, '@Unknown Slack ID')) #find slack ids w/default = Unkown
+
 def task_fail_nattery_slack_alert(context):
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
-    task_msg = 'The {task} in updating traffic failed, <@U02NSCSKFEU> go fix it meow :meow_notlike: '.format(
-            task=context.get('task_instance').task_id,) #K just gotta point out that the last 3 letters in my slack id spell FIRE in French!!!   
+    task_msg = 'The {task} in updating traffic failed, {slack_name} go fix it meow :meow_notlike: '.format(
+            task=context.get('task_instance').task_id,
+            slack_name = ' '.join(list_names))
         
     slack_msg = task_msg + """(<{log_url}|log>)""".format(
             log_url=context.get('task_instance').log_url,)
@@ -28,10 +41,9 @@ def task_fail_nattery_slack_alert(context):
         )
     return failed_alert.execute(context=context)
 
-default_args = {'owner':'scannon',
+default_args = {'owner': names,
                 'depends_on_past':False,
                 'start_date': datetime(2022, 6, 16), #start this Thursday, why not?
-                'email': ['sarah.cannon@toronto.ca'],
                 'email_on_failure': False,
                  'email_on_success': False,
                  'retries': 0,
@@ -40,7 +52,7 @@ default_args = {'owner':'scannon',
                 }
 
 
-with DAG('traffic_transfer', 
+with DAG(dag_id = dag_name, 
          default_args = default_args,
          schedule_interval='0 2 * * *') as daily_update: #runs at 2am every day
          

--- a/dags/vz_google_sheets.py
+++ b/dags/vz_google_sheets.py
@@ -12,13 +12,19 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 from airflow.models import Variable
 import os
-
 import sys
 
-SLACK_CONN_ID = 'slack_data_pipeline'
-dag_config = Variable.get('slack_member_id', deserialize_json=True)
-list_names = dag_config['raphael'] + ' ' + dag_config['islam'] + ' ' + dag_config['natalie'] 
+dag_name = 'vz_google_sheets'
 
+SLACK_CONN_ID = 'slack_data_pipeline'
+dag_owners = Variable.get('dag_owners', deserialize_json=True)
+slack_ids = Variable.get('slack_member_id', deserialize_json=True)
+
+names = dag_owners.get(dag_name, ['Unknown']) #find dag owners w/default = Unknown    
+
+list_names = []
+for name in names:
+    list_names.append(slack_ids.get(name, '@Unknown Slack ID')) #find slack ids w/default = Unkown
 
 dag_config = Variable.get('ssz_spreadsheet_ids', deserialize_json=True)
 ssz2018 = dag_config['ssz2018']
@@ -63,10 +69,12 @@ def task_fail_slack_alert(context):
     if invalid_rows:
         task_msg = """The Task vz_google_sheets (ssz):{task} failed.
                     Found one or more invalid records. {slack_name} please email David Tang """.format(
-            task=context.get('task_instance').task_id, slack_name = list_names,) 
+            task=context.get('task_instance').task_id, 
+            slack_name = ' '.join(list_names),) 
     else:
         task_msg = """The Task vz_google_sheets (ssz):{task} failed. {slack_name} please fix it """.format(
-            task=context.get('task_instance').task_id, slack_name = list_names,) 
+            task=context.get('task_instance').task_id, 
+            slack_name = ' '.join(list_names),) 
     
     # this adds the error log url at the end of the msg
     slack_msg = task_msg + """ (<{log_url}|log>)""".format(
@@ -100,11 +108,10 @@ vz_api_bot = PostgresHook("vz_api_bot")
 con = vz_api_bot.get_conn()
 
 DEFAULT_ARGS = {
-    'owner': 'itaha',
+    'owner': names,
     'depends_on_past' : False,
-    'email': ['islam.taha@toronto.ca'],
-    'email_on_failure': True,
-    'email_on_retry': True,
+    'email_on_failure': False,
+    'email_on_retry': False,
     'start_date': datetime(2019, 9, 30),
     'retries': 0,
     'retry_delay': timedelta(minutes=5),
@@ -112,7 +119,7 @@ DEFAULT_ARGS = {
     'on_failure_callback': task_fail_slack_alert
 }
 
-dag = DAG('vz_google_sheets', default_args=DEFAULT_ARGS, schedule_interval='@daily', catchup=False)
+dag = DAG(dag_id = dag_name, default_args = DEFAULT_ARGS, schedule_interval = '@daily', catchup = False)
 
 task1 = PythonOperator(
     task_id='2018',


### PR DESCRIPTION
… and refer to Airflow var instead.

## What this pull request accomplishes:
-Removes hardcoded references to users (Raph, Islam, Natalie) in DAGs. 
-Refer to new `dag_owner` var in Airflow to identify DAG Owner and also identify their slack ids for Slack failure notifications. 
-Removes emails from dag default parameters. 

## Issue(s) this solves:
#595 

## What, in particular, needs to reviewed:

- 
