### PR TITLE
I530 wys signs outside to

### DIFF
--- a/dags/refresh_wys_monthly.py
+++ b/dags/refresh_wys_monthly.py
@@ -55,36 +55,48 @@ with DAG('wys_monthly_summary',
             'last_month' : last_month
           },
          schedule_interval='0 3 2 * *') as monthly_summary:
-    wys_view_stat_signs = PostgresOperator(sql='SELECT wys.refresh_mat_view_stationary_signs()',
+    wys_view_stat_signs = PostgresOperator(
+                            #sql in bdit_data-sources/wys/api/sql/mat-view-stationary-signs.sql
+                            sql='SELECT wys.refresh_mat_view_stationary_signs()',
                             task_id='wys_view_stat_signs',
                             postgres_conn_id='wys_bot',
                             autocommit=True,
                             retries = 0,
                             dag=monthly_summary)
-    wys_view_mobile_api_id = PostgresOperator(sql='SELECT wys.refresh_mat_view_mobile_api_id()',
+    wys_view_mobile_api_id = PostgresOperator(
+                            #sql in bdit_data-sources/wys/api/sql/function-refresh_mat_view_mobile_api_id.sql
+                            #sql in bdit_data-sources/wys/api/sql/create-view-mobile_api_id.sql
+                            sql='SELECT wys.refresh_mat_view_mobile_api_id()', 
                             task_id='wys_view_mobile_api_id',
                             postgres_conn_id='wys_bot',
                             autocommit=True,
                             retries = 0,
                             dag=monthly_summary)
-    od_wys_view = PostgresOperator(sql='SELECT wys.refresh_od_mat_view()',
+    od_wys_view = PostgresOperator(
+                            #sql in bdit_data-sources/wys/api/sql/open_data/mat-view-stationary-locations.sql
+                            sql='SELECT wys.refresh_od_mat_view()',
                             task_id='od_wys_view',
                             postgres_conn_id='wys_bot',
                             autocommit=True,
                             retries = 0,
                             dag=monthly_summary)
-    wys_mobile_summary = PostgresOperator(sql="SELECT wys.mobile_summary_for_month('{{ last_month(ds) }}')",
+    wys_mobile_summary = PostgresOperator(
+                            #sql in bdit_data-sources/wys/api/sql/function-mobile-summary.sql
+                            sql="SELECT wys.mobile_summary_for_month('{{ last_month(ds) }}')",
                             task_id='wys_mobile_summary',
                             postgres_conn_id='wys_bot',
                             autocommit=True,
                             retries = 0,
                             dag=monthly_summary)
-    wys_stat_summary = PostgresOperator(sql="SELECT wys.stationary_summary_for_month('{{ last_month(ds) }}')",
+    wys_stat_summary = PostgresOperator(
+                            #sql in bdit_data-sources/wys/api/sql/function-stationary-sign-summary.sql
+                            sql="SELECT wys.stationary_summary_for_month('{{ last_month(ds) }}')", 
                             task_id='wys_stat_summary',
                             postgres_conn_id='wys_bot',
                             autocommit=True,
                             retries = 0,
                             dag=monthly_summary)
+
     # Stationary signs
     wys_view_stat_signs >> [wys_stat_summary, od_wys_view]
     # Mobile signs

--- a/wys/api/sql/create-view-mobile_api_id.sql
+++ b/wys/api/sql/create-view-mobile_api_id.sql
@@ -2,27 +2,56 @@ DROP VIEW wys.mobile_api_id CASCADE;
 
 CREATE MATERIALIZED VIEW wys.mobile_api_id AS
 
-SELECT id AS location_id,
-a.ward_no, a.location, a.from_street, a.to_street, a.direction, 
-a.installation_date, a.removal_date, a.comments, a.combined,
-b.api_id
+SELECT 
+    id AS location_id,
+    a.ward_no,
+    a.location,
+    a.from_street,
+    a.to_street,
+    a.direction,
+    a.installation_date,
+    a.removal_date,
+    a.comments,
+    a.combined,
+    b.api_id
 FROM (
-SELECT *, 
- CASE WHEN new_sign_number NOT LIKE 'W%' THEN 'Ward ' || ward_no || ' - S' || new_sign_number 
- WHEN new_sign_number LIKE 'W%' AND new_sign_number LIKE '% - S%' THEN 'Ward ' || SUBSTRING(new_sign_number, 2, 10)
- WHEN new_sign_number LIKE 'W%' AND new_sign_number NOT LIKE '% - S%' THEN 'Ward ' || SUBSTRING(new_sign_number, 2, POSITION(' - ' IN new_sign_number) + 1 ) || 'S' || RIGHT(new_sign_number, 1)
- END AS combined
-FROM wys.mobile_sign_installations
-) a 
-LEFT JOIN 
-(SELECT DISTINCT api_id, sign_name, start_date,
-                 lead(start_date) OVER w AS next_start,
-                 lag(start_date) OVER w AS prev_start
-FROM wys.locations
-WHERE sign_name LIKE 'Ward%'
-WINDOW w AS (PARTITION BY sign_name ORDER BY start_date)) b
-ON a.combined = b.sign_name
+    SELECT
+        msi.ward_no,
+        msi.location,
+        msi.from_street,
+        msi.to_street,
+        msi.direction,
+        msi.installation_date,
+        msi.removal_date,
+        msi.new_sign_number,
+        msi.comments,
+        msi.id, 
+        CASE WHEN new_sign_number NOT LIKE 'W%' 
+            THEN 'Ward ' || ward_no || ' - S' || new_sign_number 
+        WHEN new_sign_number LIKE 'W%' AND new_sign_number LIKE '% - S%' 
+            THEN 'Ward ' || 
+            SUBSTRING(new_sign_number, 2, 10)
+        WHEN new_sign_number LIKE 'W%' AND new_sign_number NOT LIKE '% - S%' 
+            THEN 'Ward ' || 
+            SUBSTRING(new_sign_number, 2, POSITION(' - ' IN new_sign_number) + 1 ) || 
+            'S' || RIGHT(new_sign_number, 1)
+        END AS combined
+    FROM wys.mobile_sign_installations AS msi
+) AS a 
+LEFT JOIN (
+    SELECT DISTINCT 
+        api_id,
+        sign_name,
+        start_date,
+        lead(start_date) OVER w AS next_start,
+        lag(start_date) OVER w AS prev_start
+    FROM wys.locations
+    WHERE sign_name LIKE 'Ward %'
+    WINDOW w AS (PARTITION BY sign_name ORDER BY start_date)
+) AS b
+ON a.combined = b.sign_name 
    AND (b.prev_start IS NULL OR installation_date >= b.prev_start)
    AND (b.next_start IS NULL OR installation_date < b.start_date);
+)
 
 CREATE UNIQUE INDEX ON  wys.mobile_api_id (location_id);

--- a/wys/api/sql/create-view-mobile_api_id.sql
+++ b/wys/api/sql/create-view-mobile_api_id.sql
@@ -54,7 +54,7 @@ SELECT
 FROM mobile_installations AS msi
 LEFT JOIN sign_locations AS b
     ON msi.combined = b.sign_name
-   AND (b.prev_start IS NULL OR msi.installation_date >= b.prev_start)
-   AND (b.next_start IS NULL OR msi.installation_date < b.start_date);
+    AND (b.prev_start IS NULL OR msi.installation_date >= b.prev_start)
+    AND (b.next_start IS NULL OR msi.installation_date < b.start_date);
 
 CREATE UNIQUE INDEX ON wys.mobile_api_id (location_id);

--- a/wys/api/sql/create-view-mobile_api_id.sql
+++ b/wys/api/sql/create-view-mobile_api_id.sql
@@ -2,8 +2,20 @@ DROP VIEW wys.mobile_api_id CASCADE;
 
 CREATE MATERIALIZED VIEW wys.mobile_api_id AS
 
+WITH sign_locations AS (
+    SELECT DISTINCT 
+        api_id,
+        sign_name,
+        start_date,
+        lead(start_date) OVER w AS next_start,
+        lag(start_date) OVER w AS prev_start
+    FROM wys.locations
+    WHERE sign_name LIKE 'Ward %'
+    WINDOW w AS (PARTITION BY sign_name ORDER BY start_date)
+)
+
 SELECT 
-    id AS location_id,
+    a.id AS location_id,
     a.ward_no,
     a.location,
     a.from_street,
@@ -26,32 +38,20 @@ FROM (
         msi.new_sign_number,
         msi.comments,
         msi.id, 
-        CASE WHEN new_sign_number NOT LIKE 'W%' 
-            THEN 'Ward ' || ward_no || ' - S' || new_sign_number 
-        WHEN new_sign_number LIKE 'W%' AND new_sign_number LIKE '% - S%' 
-            THEN 'Ward ' || 
-            SUBSTRING(new_sign_number, 2, 10)
-        WHEN new_sign_number LIKE 'W%' AND new_sign_number NOT LIKE '% - S%' 
-            THEN 'Ward ' || 
-            SUBSTRING(new_sign_number, 2, POSITION(' - ' IN new_sign_number) + 1 ) || 
-            'S' || RIGHT(new_sign_number, 1)
+        CASE WHEN msi.new_sign_number NOT LIKE 'W%'
+            THEN 'Ward ' || msi.ward_no || ' - S' || msi.new_sign_number
+            WHEN msi.new_sign_number LIKE 'W%' AND msi.new_sign_number LIKE '% - S%'
+            THEN 'Ward ' || SUBSTRING(msi.new_sign_number, 2, 10)
+        WHEN msi.new_sign_number LIKE 'W%' AND msi.new_sign_number NOT LIKE '% - S%' 
+            THEN 'Ward '
+            || SUBSTRING(msi.new_sign_number, 2, POSITION(' - ' IN msi.new_sign_number) + 1)
+            || 'S' || RIGHT(msi.new_sign_number, 1)
         END AS combined
     FROM wys.mobile_sign_installations AS msi
 ) AS a 
-LEFT JOIN (
-    SELECT DISTINCT 
-        api_id,
-        sign_name,
-        start_date,
-        lead(start_date) OVER w AS next_start,
-        lag(start_date) OVER w AS prev_start
-    FROM wys.locations
-    WHERE sign_name LIKE 'Ward %'
-    WINDOW w AS (PARTITION BY sign_name ORDER BY start_date)
-) AS b
-ON a.combined = b.sign_name 
-   AND (b.prev_start IS NULL OR installation_date >= b.prev_start)
-   AND (b.next_start IS NULL OR installation_date < b.start_date);
-)
+LEFT JOIN sign_locations AS b
+ON a.combined = b.sign_name
+   AND (b.prev_start IS NULL OR msi.installation_date >= b.prev_start)
+   AND (b.next_start IS NULL OR msi.installation_date < b.start_date);
 
 CREATE UNIQUE INDEX ON  wys.mobile_api_id (location_id);

--- a/wys/api/sql/create-view-mobile_api_id.sql
+++ b/wys/api/sql/create-view-mobile_api_id.sql
@@ -12,46 +12,49 @@ WITH sign_locations AS (
     FROM wys.locations
     WHERE sign_name LIKE 'Ward %'
     WINDOW w AS (PARTITION BY sign_name ORDER BY start_date)
+),
+
+mobile_installations AS (
+    SELECT
+        ward_no,
+        location,
+        from_street,
+        to_street,
+        direction,
+        installation_date,
+        removal_date,
+        new_sign_number,
+        comments,
+        id, 
+        CASE WHEN new_sign_number NOT LIKE 'W%'
+            THEN 'Ward ' || ward_no || ' - S' || new_sign_number
+            WHEN new_sign_number LIKE 'W%' AND new_sign_number LIKE '% - S%'
+                THEN 'Ward ' || SUBSTRING(new_sign_number, 2, 10)
+            WHEN new_sign_number LIKE 'W%' AND new_sign_number NOT LIKE '% - S%'
+                THEN 'Ward '
+                || SUBSTRING(new_sign_number, 2, POSITION(' - ' IN new_sign_number) + 1)
+                || 'S' || RIGHT(new_sign_number, 1)
+        END AS combined
+    FROM wys.mobile_sign_installations
 )
 
+
 SELECT 
-    a.id AS location_id,
-    a.ward_no,
-    a.location,
-    a.from_street,
-    a.to_street,
-    a.direction,
-    a.installation_date,
-    a.removal_date,
-    a.comments,
-    a.combined,
+    msi.id AS location_id,
+    msi.ward_no,
+    msi.location,
+    msi.from_street,
+    msi.to_street,
+    msi.direction,
+    msi.installation_date,
+    msi.removal_date,
+    msi.comments,
+    msi.combined,
     b.api_id
-FROM (
-    SELECT
-        msi.ward_no,
-        msi.location,
-        msi.from_street,
-        msi.to_street,
-        msi.direction,
-        msi.installation_date,
-        msi.removal_date,
-        msi.new_sign_number,
-        msi.comments,
-        msi.id, 
-        CASE WHEN msi.new_sign_number NOT LIKE 'W%'
-            THEN 'Ward ' || msi.ward_no || ' - S' || msi.new_sign_number
-            WHEN msi.new_sign_number LIKE 'W%' AND msi.new_sign_number LIKE '% - S%'
-            THEN 'Ward ' || SUBSTRING(msi.new_sign_number, 2, 10)
-        WHEN msi.new_sign_number LIKE 'W%' AND msi.new_sign_number NOT LIKE '% - S%' 
-            THEN 'Ward '
-            || SUBSTRING(msi.new_sign_number, 2, POSITION(' - ' IN msi.new_sign_number) + 1)
-            || 'S' || RIGHT(msi.new_sign_number, 1)
-        END AS combined
-    FROM wys.mobile_sign_installations AS msi
-) AS a 
+FROM mobile_installations AS msi
 LEFT JOIN sign_locations AS b
-ON a.combined = b.sign_name
+    ON msi.combined = b.sign_name
    AND (b.prev_start IS NULL OR msi.installation_date >= b.prev_start)
    AND (b.next_start IS NULL OR msi.installation_date < b.start_date);
 
-CREATE UNIQUE INDEX ON  wys.mobile_api_id (location_id);
+CREATE UNIQUE INDEX ON wys.mobile_api_id (location_id);

--- a/wys/api/sql/mat-view-stationary-signs.sql
+++ b/wys/api/sql/mat-view-stationary-signs.sql
@@ -45,6 +45,10 @@ SELECT
     lag(loc.start_date) OVER w AS prev_start,
     loc.geom
 FROM distinctish_signs loc
+JOIN gis.toronto_boundary AS tor ON 
+    st_intersects(
+        st_buffer(tor.geom::geography, 20), 
+        loc.geom::geography)
 WINDOW w AS (
     PARTITION BY loc.api_id 
     ORDER BY start_date);

--- a/wys/api/sql/mat-view-stationary-signs.sql
+++ b/wys/api/sql/mat-view-stationary-signs.sql
@@ -3,32 +3,51 @@ DROP MATERIALIZED VIEW wys.stationary_signs CASCADE;
 CREATE MATERIALIZED VIEW wys.stationary_signs
 TABLESPACE pg_default
 AS
- WITH distinctish_signs AS (
-         SELECT DISTINCT ON (api_id, (regexp_replace(sign_name, '([0-9]{5,8})'::text, ''::text))) api_id,
-            address,
-            regexp_replace(sign_name, '([0-9]{5,8})'::text, ''::text) AS sign_name,
-	 		id as sign_id,
-            dir,
-            start_date,
-	 		substring(sign_name from '([0-9]{5,8})'::text) as serial_num,
-            st_setsrid(st_makepoint(split_part(regexp_replace(loc, '[()]'::text, ''::text, 'g'::text), ','::text, 2)::double precision, split_part(regexp_replace(loc, '[()]'::text, ''::text, 'g'::text), ','::text, 1)::double precision), 4326) AS geom
-           FROM wys.locations
-          WHERE length("substring"(reverse(sign_name), '([0-9]{1,8})'::text)) > 3
-          ORDER BY api_id, (regexp_replace(sign_name, '([0-9]{5,8})'::text, ''::text)),
-	  				start_date
-        )
- SELECT api_id,
-     sign_id,
-    address,
-    sign_name,
-    dir,
-    start_date,
-	serial_num,
-    lead(start_date) OVER w AS next_start,
-    lag(start_date) OVER w AS prev_start,
-    geom
-   FROM distinctish_signs
-   WINDOW w as (PARTITION BY api_id order by start_date);
+WITH distinctish_signs AS (
+    SELECT DISTINCT ON (
+        loc.api_id, 
+        (regexp_replace(loc.sign_name, '([0-9]{5,8})'::text, ''::text))
+    ) 
+        loc.api_id,
+        loc.address,
+        regexp_replace(loc.sign_name, '([0-9]{5,8})'::text, ''::text) AS sign_name,
+        loc.id AS sign_id,
+        loc.dir,
+        loc.start_date,
+        substring(loc.sign_name from '([0-9]{5,8})'::text) AS serial_num,
+        st_setsrid(
+            st_makepoint(
+                split_part(
+                    regexp_replace(loc.loc, '[()]'::text, ''::text, 'g'::text), 
+                    ','::text, 2)::double precision, 
+                split_part(
+                    regexp_replace(loc.loc, '[()]'::text, ''::text, 'g'::text), 
+                    ','::text, 1)::double precision
+            ), 
+            4326) AS geom
+    FROM wys.locations loc
+    WHERE length("substring"(reverse(loc.sign_name), '([0-9]{1,8})'::text)) > 3
+    ORDER BY 
+        loc.api_id, 
+        (regexp_replace(loc.sign_name, '([0-9]{5,8})'::text, ''::text)),
+        loc.start_date
+)
+ 
+SELECT 
+    loc.api_id,
+    loc.sign_id,
+    loc.address,
+    loc.sign_name,
+    loc.dir,
+    loc.start_date,
+	loc.serial_num,
+    lead(loc.start_date) OVER w AS next_start,
+    lag(loc.start_date) OVER w AS prev_start,
+    loc.geom
+FROM distinctish_signs loc
+WINDOW w AS (
+    PARTITION BY loc.api_id 
+    ORDER BY start_date);
 
 CREATE INDEX ON wys.stationary_signs USING gist(geom);
 ANALYZE wys.stationary_signs;

--- a/wys/api/sql/mat-view-stationary-signs.sql
+++ b/wys/api/sql/mat-view-stationary-signs.sql
@@ -43,7 +43,7 @@ SELECT
     loc.serial_num,
     loc.geom,
     lead(loc.start_date) OVER w AS next_start,
-    lag(loc.start_date) OVER w AS prev_start,
+    lag(loc.start_date) OVER w AS prev_start
 FROM distinctish_signs AS loc
 JOIN gis.toronto_boundary AS tor ON 
     st_intersects(

--- a/wys/api/sql/mat-view-stationary-signs.sql
+++ b/wys/api/sql/mat-view-stationary-signs.sql
@@ -41,7 +41,7 @@ SELECT
     loc.dir,
     loc.start_date,
     loc.serial_num,
-    loc.geom
+    loc.geom,
     lead(loc.start_date) OVER w AS next_start,
     lag(loc.start_date) OVER w AS prev_start,
 FROM distinctish_signs AS loc

--- a/wys/api/sql/mat-view-stationary-signs.sql
+++ b/wys/api/sql/mat-view-stationary-signs.sql
@@ -47,11 +47,13 @@ SELECT
 FROM distinctish_signs loc
 JOIN gis.toronto_boundary AS tor ON 
     st_intersects(
+        --20m buffer around toronto boundary to include signs on border (eg. Steeles)
         st_buffer(tor.geom::geography, 20), 
         loc.geom::geography)
 WINDOW w AS (
     PARTITION BY loc.api_id 
-    ORDER BY start_date);
+    ORDER BY start_date
+);
 
 CREATE INDEX ON wys.stationary_signs USING gist(geom);
 ANALYZE wys.stationary_signs;

--- a/wys/api/sql/open_data/mat-view-stationary-locations.sql
+++ b/wys/api/sql/open_data/mat-view-stationary-locations.sql
@@ -18,8 +18,8 @@ SELECT
         ELSE MIN(agg.datetime_bin)
     END AS start_date,
     CASE
-        WHEN MAX(agg.datetime_bin) < date_trunc('month'::text, now()) - INTERVAL '1 day'
-        THEN LEAST(ss.next_start::timestamp without time zone, MAX(agg.datetime_bin))
+        WHEN MAX(agg.datetime_bin) < date_trunc('month'::text, now()) - interval '1 day'
+            THEN LEAST(ss.next_start::timestamp without time zone, MAX(agg.datetime_bin))
     END AS end_date
 FROM wys.stationary_signs AS ss
 --JOIN wys.sign_schedules_list AS ssl USING (api_id) --never used in SELECT statement

--- a/wys/api/sql/open_data/mat-view-stationary-locations.sql
+++ b/wys/api/sql/open_data/mat-view-stationary-locations.sql
@@ -2,7 +2,6 @@ DROP MATERIALIZED VIEW open_data.wys_stationary_locations CASCADE;
 CREATE MATERIALIZED VIEW open_data.wys_stationary_locations AS
 
 SELECT 
-    wrd.area_short::INT as ward_no, 
     ss.sign_id,
     ss.address,
     ss.sign_name,
@@ -10,22 +9,23 @@ SELECT
     ssc.schedule,
     ssc.min_speed,
     ssc.speed_limit,
-    ssc.flash_speed, 
+    ssc.flash_speed,
     ssc.strobe_speed,
-	CASE
+    ss.geom,
+    wrd.area_short::int AS ward_no,
+    CASE
         WHEN ss.prev_start IS NOT NULL THEN ss.start_date 
-        ELSE MIN(agg.datetime_bin) 
+        ELSE MIN(agg.datetime_bin)
     END AS start_date,
-	CASE 
+    CASE
         WHEN MAX(agg.datetime_bin) < date_trunc('month'::text, now()) - INTERVAL '1 day'
-		    THEN LEAST(next_start::timestamp without time zone, MAX(agg.datetime_bin))
-	END AS end_date,
-	ss.geom
+        THEN LEAST(ss.next_start::timestamp without time zone, MAX(agg.datetime_bin))
+    END AS end_date
 FROM wys.stationary_signs AS ss
-JOIN wys.sign_schedules_list AS ssl USING (api_id)
+--JOIN wys.sign_schedules_list AS ssl USING (api_id) --never used in SELECT statement
 LEFT JOIN wys.sign_schedules_clean AS ssc USING (schedule_name)
 JOIN wys.speed_counts_agg_5kph AS agg USING (api_id)
-LEFT JOIN gis.wards2018 wrd ON ST_Contains(wrd.wkb_geometry, ss.geom)
+LEFT JOIN gis.wards2018 AS wrd ON ST_Contains(wrd.wkb_geometry, ss.geom)
 GROUP BY
     wrd.area_short,
     ss.sign_id, 
@@ -44,14 +44,13 @@ GROUP BY
     
 CREATE UNIQUE INDEX ON open_data.wys_stationary_locations (sign_id);
 
-CREATE FUNCTION wys.refresh_od_mat_view() 
+CREATE FUNCTION wys.refresh_od_mat_view()
 RETURNS void
-    LANGUAGE 'sql'
-
-    COST 100
-    VOLATILE SECURITY DEFINER 
+LANGUAGE 'sql'
+COST 100
+VOLATILE SECURITY DEFINER 
 AS $BODY$
     REFRESH MATERIALIZED VIEW CONCURRENTLY open_data.wys_stationary_locations WITH DATA ;
 $BODY$;
-REVOKE EXECUTE ON FUNCTION wys.refresh_od_mat_view()FROM public;
-GRANT EXECUTE ON FUNCTION wys.refresh_od_mat_view()TO wys_bot;
+REVOKE EXECUTE ON FUNCTION wys.refresh_od_mat_view() FROM public;
+GRANT EXECUTE ON FUNCTION wys.refresh_od_mat_view() TO wys_bot;

--- a/wys/api/sql/open_data/mat-view-stationary-locations.sql
+++ b/wys/api/sql/open_data/mat-view-stationary-locations.sql
@@ -1,27 +1,47 @@
 DROP MATERIALIZED VIEW open_data.wys_stationary_locations CASCADE;
 CREATE MATERIALIZED VIEW open_data.wys_stationary_locations AS
 
-SELECT area_short::INT as ward_no, sign_id, address, sign_name, dir, schedule, 
-    min_speed, 
-    speed_limit, 
-    flash_speed, 
-    strobe_speed, 
-	CASE WHEN prev_start IS NOT NULL THEN start_date ELSE MIN(datetime_bin) END AS start_date,
-	CASE WHEN max(datetime_bin) < date_trunc('month'::text, now()) - INTERVAL '1 day'
-		 THEN LEAST(next_start::timestamp without time zone, 
-		            max(datetime_bin))
-		END AS end_date,
-	geom
-	FROM wys.stationary_signs
-	LEFT JOIN wys.sign_schedules_list USING (api_id)
-        LEFT JOIN wys.sign_schedules_clean USING (schedule_name)
-	 JOIN wys.speed_counts_agg_5kph USING (api_id) 
-     LEFT JOIN gis.wards2018 ON ST_Contains(wkb_geometry, geom)
-	 GROUP BY ward_no, sign_id, address, sign_name, dir, schedule, 
-            min_speed, 
-            speed_limit, prev_start,next_start, start_date,
-            flash_speed, 
-            strobe_speed, geom;
+SELECT 
+    wrd.area_short::INT as ward_no, 
+    ss.sign_id,
+    ss.address,
+    ss.sign_name,
+    ss.dir,
+    ssc.schedule,
+    ssc.min_speed,
+    ssc.speed_limit,
+    ssc.flash_speed, 
+    ssc.strobe_speed,
+	CASE
+        WHEN ss.prev_start IS NOT NULL THEN ss.start_date 
+        ELSE MIN(agg.datetime_bin) 
+    END AS start_date,
+	CASE 
+        WHEN MAX(agg.datetime_bin) < date_trunc('month'::text, now()) - INTERVAL '1 day'
+		    THEN LEAST(next_start::timestamp without time zone, MAX(agg.datetime_bin))
+	END AS end_date,
+	ss.geom
+FROM wys.stationary_signs AS ss
+JOIN wys.sign_schedules_list AS ssl USING (api_id)
+LEFT JOIN wys.sign_schedules_clean AS ssc USING (schedule_name)
+JOIN wys.speed_counts_agg_5kph AS agg USING (api_id)
+LEFT JOIN gis.wards2018 wrd ON ST_Contains(wrd.wkb_geometry, ss.geom)
+GROUP BY
+    wrd.area_short,
+    ss.sign_id, 
+    ss.address,
+    ss.sign_name,
+    ss.dir,
+    ssc.schedule,
+    ssc.min_speed,
+    ssc.speed_limit,
+    ss.prev_start,
+    ss.next_start,
+    ss.start_date,
+    ssc.flash_speed,
+    ssc.strobe_speed,
+    ss.geom;
+    
 CREATE UNIQUE INDEX ON open_data.wys_stationary_locations (sign_id);
 
 CREATE FUNCTION wys.refresh_od_mat_view() 

--- a/wys/readme.md
+++ b/wys/readme.md
@@ -17,7 +17,7 @@ The city has installed [Watch Your Speed Signs](https://www.toronto.ca/services-
 
 ## Open Data
 
-Semi-aggregated and monthly summary data are available for the two programs (Stationary School Safety Zone signs and Mobile Signs) and are updated monthly. Because the mobile signs are moved frequently, they do not have accurate locations beyond a text description, and are therefore presented as a separate dataset. See [WYS documentation](wys/api/README.md) for more information on how the datasets are processed.
+Semi-aggregated and monthly summary data are available for the two programs (Stationary School Safety Zone signs and Mobile Signs) and are updated monthly. Because the mobile signs are moved frequently, they do not have accurate locations beyond a text description, and are therefore presented as a separate dataset. See [WYS documentation](api/README.md) for more information on how the datasets are processed.
 
   - [School Safety Zone Watch Your Speed Program – Locations](https://open.toronto.ca/dataset/school-safety-zone-watch-your-speed-program-locations/): The locations and operating parameters for each location where a permanent Watch Your Speed Program Sign was installed.
   - [School Safety Zone Watch Your Speed Program – Detailed Speed Counts](https://open.toronto.ca/dataset/school-safety-zone-watch-your-speed-program-detailed-speed-counts/): An hourly aggregation of observed speeds for each location where a Watch Your Speed Program Sign was installed in 5 km/hr speed range increments.


### PR DESCRIPTION
## What this pull request accomplishes:
- Filters out signs outside of Toronto. 20m buffer applied to Toronto boundary to include signs on border (in particular 1 sign on Steeles). 
- formatting changes. 

## Issue(s) this solves:
- #530 

## What, in particular, needs to reviewed:
bdit_data-sources/wys/api/sql/mat-view-stationary-signs.sql 
contains the edits to filter out signs outside of Toronto. 

## What needs to be done by a sysadmin after this PR is merged
Run these scripts in RDS:
bdit_data-sources/wys/api/sql/create-view-mobile_api_id.sql
bdit_data-sources/wys/api/sql/mat-view-stationary-signs.sql
bdit_data-sources/wys/api/sql/open_data/mat-view-stationary-locations.sql

_E.g.: these tables need to be migrated/created in the production schema._
