### PR TITLE
Correct docs regarding miovision streetcar classification

### DIFF
--- a/volumes/miovision/README.md
+++ b/volumes/miovision/README.md
@@ -63,21 +63,22 @@ classification|text|Textual description of mode|Bicycles|
 location_only|boolean|If TRUE, represents movement on crosswalk (as opposed to road)|FALSE|
 class_type|text|General class category (Vehicles, Pedestrians, or Cyclists)|Cyclists|
 
-Here is a description of the `classification_uid`s and corresponding types. For more information, see [Miovision's documentation on this topic](https://help.miovision.com/s/article/North-American-Classification-Guide). Note that bicycles are available at both a turning movement level and at an approach level. Approach level bicycle counts should be used for the large majority of applications as the data is considered more accurate.
+Here is a description of the `classification_uid`s and corresponding types. For more information, see [Miovision's documentation on this topic](https://help.miovision.com/s/article/North-American-Classification-Guide). **Note:** Some classifications have changed over time, see notes related to this below the table and see progress on determining when these changes happened in [Issue 634](https://github.com/CityofToronto/bdit_data-sources/issues/634).
 
 | classification_uid | classification | definition |
 | ------------------ | -------------- | ---------- |
 1 | Light | Cars and other passenger vehicles (like vans, SUVs or pick-up trucks)|
-2 | Bicycle | A bicycle - this classification_uid is used to track bicycle turning movements |
-3<sup>1</sup> | Bus | A large vehicle that provides transportation for many humans. This currently includes buses *and streetcars*, though this wasn't always the case. |
+2<sup>1</sup> | Bicycle | A bicycle - this classification_uid is used to track bicycle turning movements |
+3<sup>2</sup> | Bus | A large vehicle that provides transportation for many humans. This currently includes buses *and streetcars*, though this wasn't always the case. |
 4 | SingleUnitTruck | A truck that has a non-detachable cab and trailer system |
 5 | ArticulatedTruck | A truck that has a detachable cab and trailer system |
 6 | Pedestrian | A walker. May or may not include zombies... |
 8 | WorkVan | A van used for commercial purposes |
-9<sup>1</sup> | MotorizedVehicle | Miscellaneous vehicles. This category originally included streetcars but now does not. |
-10 | Bicycle | A bicycle - this classification_uid is used to track bicycle approaches (entrances and exits) |
+9<sup>2</sup> | MotorizedVehicle | Miscellaneous vehicles. This category originally included streetcars but now does not. |
+10<sup>1</sup> | Bicycle | A bicycle - this classification_uid is used to track bicycle approaches (entrances and exits) |
 
-1. Streetcars were for some time classified as MotorizedVehicle, though they now fall in the Bus category. The suspected date for this change is circa 2019-08-01 though this has not been fully confirmed and may vary betseen intersections.
+1. Note that bicycles are available at both a turning movement level and at an approach level. Approach level bicycle counts should be used for the large majority of applications as the data is considered more accurate.
+2. Streetcars were for some time classified as MotorizedVehicle, though they now fall in the Bus category. The suspected date for this change is circa 2019-08-01 though this has not been fully confirmed and may vary betseen intersections.
 
 #### `intersections`
 

--- a/volumes/miovision/README.md
+++ b/volumes/miovision/README.md
@@ -69,13 +69,15 @@ Here is a description of the `classification_uid`s and corresponding types. For 
 | ------------------ | -------------- | ---------- |
 1 | Light | Cars and other passenger vehicles (like vans, SUVs or pick-up trucks)|
 2 | Bicycle | A bicycle - this classification_uid is used to track bicycle turning movements |
-3 | Bus | A large vehicle that provides transportation for many humans. This includes buses *and streetcars* |
+3<sup>1</sup> | Bus | A large vehicle that provides transportation for many humans. This currently includes buses *and streetcars*, though this wasn't always the case. |
 4 | SingleUnitTruck | A truck that has a non-detachable cab and trailer system |
 5 | ArticulatedTruck | A truck that has a detachable cab and trailer system |
 6 | Pedestrian | A walker. May or may not include zombies... |
 8 | WorkVan | A van used for commercial purposes |
-9 | MotorizedVehicle | miscellaneous vehicles |
+9<sup>1</sup> | MotorizedVehicle | Miscellaneous vehicles. This category originally included streetcars but now does not. |
 10 | Bicycle | A bicycle - this classification_uid is used to track bicycle approaches (entrances and exits) |
+
+1. Streetcars were for some time classified as MotorizedVehicle, though they now fall in the Bus category. The suspected date for this change is circa 2019-08-01 though this has not been fully confirmed and may vary betseen intersections.
 
 #### `intersections`
 

--- a/volumes/miovision/README.md
+++ b/volumes/miovision/README.md
@@ -63,20 +63,19 @@ classification|text|Textual description of mode|Bicycles|
 location_only|boolean|If TRUE, represents movement on crosswalk (as opposed to road)|FALSE|
 class_type|text|General class category (Vehicles, Pedestrians, or Cyclists)|Cyclists|
 
-Here is a description of the classification_uids and corresponding types. 
-Note that bicycles are available at both a turning movement level and at an approach level. Approach level bicycle counts should be used for the large majority of applications as the data is considered more accurate.
+Here is a description of the `classification_uid`s and corresponding types. For more information, see [Miovision's documentation on this topic](https://help.miovision.com/s/article/North-American-Classification-Guide). Note that bicycles are available at both a turning movement level and at an approach level. Approach level bicycle counts should be used for the large majority of applications as the data is considered more accurate.
 
-**classification_uid**|**classification**|**definition**|
-:-----|:-----|:-----|
-1|Light|Cars and other passenger vehicles (like vans, SUVs or pick-up trucks)|
-2|Bicycle|A bicycle - this classification_uid is used to track bicycle turning movements|
-3|Bus|A large vehicle that provides transportation for many humans|
-4|SingleUnitTruck|A truck that has a non-detachable cab and trailer system|
-5|ArticulatedTruck|A truck that has a detachable cab and trailer system|
-6|Pedestrian|A walker. May or may not include zombies...|
-8|WorkVan|A van used for commercial purposes|
-9|MotorizedVehicle|Streetcars and miscellaneous vehicles|
-10|Bicycle|A bicycle - this classification_uid is used to track bicycle approaches (entrances and exits)|
+| classification_uid | classification | definition |
+| ------------------ | -------------- | ---------- |
+1 | Light | Cars and other passenger vehicles (like vans, SUVs or pick-up trucks)|
+2 | Bicycle | A bicycle - this classification_uid is used to track bicycle turning movements |
+3 | Bus | A large vehicle that provides transportation for many humans. This includes buses *and streetcars* |
+4 | SingleUnitTruck | A truck that has a non-detachable cab and trailer system |
+5 | ArticulatedTruck | A truck that has a detachable cab and trailer system |
+6 | Pedestrian | A walker. May or may not include zombies... |
+8 | WorkVan | A van used for commercial purposes |
+9 | MotorizedVehicle | miscellaneous vehicles |
+10 | Bicycle | A bicycle - this classification_uid is used to track bicycle approaches (entrances and exits) |
 
 #### `intersections`
 


### PR DESCRIPTION
## What this pull request accomplishes:

- reclassifies streetcars as "buses"
- adds link to Miovision's documentation of this
- applies more standard formatting to that markdown table for readability

## What, in particular, needs to reviewed:

- That streetcars are in fact classified as buses
