### PR TITLE
Bug/clear wys summaries

### DIFF
--- a/wys/api/sql/function-clear_mobile-summary.sql
+++ b/wys/api/sql/function-clear_mobile-summary.sql
@@ -1,0 +1,25 @@
+/*
+Parameters:
+Name | Type | Description
+_mon | DATE | Month to clear
+
+Return: Void
+Purpose: Clear mobile summary for the given month
+*/
+CREATE OR REPLACE FUNCTION wys.clear_mobile_summary_for_month ( -- noqa: PRS
+    _mon DATE
+)
+RETURNS void
+LANGUAGE 'sql'
+
+COST 100
+VOLATILE SECURITY DEFINER
+AS $BODY$
+
+DELETE FROM wys.mobile_summary
+WHERE removal_date >= _mon AND removal_date < _mon + INTERVAL '1 month';
+
+$BODY$;
+
+REVOKE EXECUTE ON FUNCTION wys.clear_stationary_summary_for_month (DATE) FROM public;
+GRANT EXECUTE ON FUNCTION wys.clear_stationary_summary_for_month (DATE) TO wys_bot;

--- a/wys/api/sql/function-clear_stationary-sign-summary.sql
+++ b/wys/api/sql/function-clear_stationary-sign-summary.sql
@@ -1,0 +1,24 @@
+/*
+Parameters:
+Name | Type | Description
+_mon | DATE | Month to clear
+
+Return: Void
+Purpose: Clear stationary summary for the given month
+*/
+CREATE OR REPLACE FUNCTION wys.clear_stationary_summary_for_month ( -- noqa: PRS
+    _mon DATE
+)
+RETURNS void
+LANGUAGE 'sql'
+
+COST 100
+VOLATILE SECURITY DEFINER
+AS $BODY$
+
+DELETE FROM wys.stationary_summary
+WHERE mon = _mon;
+$BODY$;
+
+REVOKE EXECUTE ON FUNCTION wys.clear_stationary_summary_for_month (DATE)FROM public;
+GRANT EXECUTE ON FUNCTION wys.clear_stationary_summary_for_month (DATE) TO wys_bot;

--- a/wys/api/sql/function-mobile-summary.sql
+++ b/wys/api/sql/function-mobile-summary.sql
@@ -6,6 +6,8 @@ RETURNS void
     VOLATILE SECURITY DEFINER 
 AS $BODY$
 
+SELECT wys.clear_mobile_summary_for_month (_mon);
+
 INSERT INTO wys.mobile_summary
 SELECT 
     location_id,

--- a/wys/api/sql/function-stationary-sign-summary.sql
+++ b/wys/api/sql/function-stationary-sign-summary.sql
@@ -6,6 +6,8 @@ RETURNS void
     VOLATILE SECURITY DEFINER 
 AS $BODY$
 
+SELECT wys.clear_stationary_summary_for_month (_mon);
+
 INSERT INTO wys.stationary_summary
 SELECT 
     sign_id,


### PR DESCRIPTION
## What this pull request accomplishes:

- Clear WYS summaries of specific months (if they exist) before any start summarizing data

## Issue(s) this solves:

- Resolves #663 

## What, in particular, needs to reviewed:

- Two new sql functions and two other functions were updated

## What needs to be done by a sysadmin after this PR is merged

- Execute the four updated sql files
