### PR TITLE
Quick Fix for Airflow Google Cloud Hook Credentials

### DIFF
--- a/dags/pull_wys.py
+++ b/dags/pull_wys.py
@@ -66,7 +66,7 @@ def task_fail_slack_alert(context):
 
 #to get credentials to access google sheets
 wys_api_hook = GoogleCloudBaseHook('vz_api_google')
-cred = wys_api_hook._get_credentials()
+cred = wys_api_hook.get_credentials()
 service = build('sheets', 'v4', credentials=cred, cache_discovery=False)
 
 #to connect to pgadmin bot

--- a/dags/vz_google_sheets.py
+++ b/dags/vz_google_sheets.py
@@ -100,7 +100,7 @@ except:
 
 #to get credentials to access google sheets
 vz_api_hook = GoogleCloudBaseHook('vz_api_google')
-cred = vz_api_hook._get_credentials()
+cred = vz_api_hook.get_credentials()
 service = build('sheets', 'v4', credentials=cred, cache_discovery=False)
 
 #To connect to pgadmin bot


### PR DESCRIPTION
## What this pull request accomplishes:

- Update two DAGs to use the new name of the function `_get_credentials()` of `GoogleCloudBaseHook` to match its name in Airflow 2.7.0

## Issue(s) this solves:

- resolves #681 

## What, in particular, needs to reviewed:

- Two DAGs: `dags/pull_wys.py` and `dags/vz_google_sheets.py`

## What needs to be done by a sysadmin after this PR is merged

- After merging into `master`, update the repo at `data_scripts`
