### PR TITLE
simplify check_partition to only check if Jan 1

### DIFF
--- a/volumes/vds/py/vds_functions.py
+++ b/volumes/vds/py/vds_functions.py
@@ -297,91 +297,9 @@ def transform_raw_data(df):
     
     return raw_20sec
 
-#these check functions were a bit overkill and would be nice to replace 
-#with a simpler shortcircut + postgresoperator combo to run partition tasks once a year on Jan 1. 
-def check_vdsdata_partitions(rds_conn, start_date):
-    y = datetime.strptime(start_date, '%Y-%m-%d').year
-
-    sql_check = sql.SQL("""
-        WITH target_tables(tablename) AS (
-            VALUES (%s), (%s), (%s), (%s)
-        )
-
-        SELECT COUNT(tt.*) = COUNT(pt.*) --if false, create new partitions
-        FROM target_tables AS tt
-        LEFT JOIN pg_tables AS pt ON pt.schemaname||'.'||pt.tablename = 'vds.'||tt.tablename;
-        """)
-    
-    try: 
-        with rds_conn.get_conn() as con, con.cursor() as cur:
-            LOGGER.info(f"Checking if necessary vdsdata partitions exist.")
-            cur.execute(sql_check, [
-                f"raw_vdsdata_div2_{y}",
-                f"raw_vdsdata_div8001_{y}",
-                f"counts_15min_div2_{y}",
-                f"counts_15min_bylane_div2_{y}",
-                ])
-            table_check = cur.fetchone()[0]
-    except Error as exc:
-        LOGGER.critical(f"Error checking vdsdata partitions.")
-        LOGGER.critical(exc)
-        raise Exception()
-
-    if table_check:  
-        LOGGER.info(f"No need to create new partition tables. Exiting.")
-    elif not table_check:
-        try:
-            with rds_conn.get_conn() as con, con.cursor() as cur:
-                LOGGER.info(f"Creating partition tables.")
-                #these tables partitioned by year and month:
-                partition_yyyymm = sql.SQL("SELECT vds.partition_vds_yyyymm(%s, %s, %s);")
-                cur.execute(partition_yyyymm, ('raw_vdsdata_div8001', int(y), str('dt')))
-                cur.execute(partition_yyyymm, ('raw_vdsdata_div2', int(y), str('dt')))
-                #this tables partitioned by year only:
-                partition_yyyy = sql.SQL("SELECT vds.partition_vds_yyyy(%s, %s, %s);")
-                cur.execute(partition_yyyy, ('counts_15min_div2', int(y), str('datetime_15min')))
-                cur.execute(partition_yyyy, ('counts_15min_bylane_div2', int(y), str('datetime_15min')))
-                LOGGER.critical(f"Finished creating vdsdata partition tables.")
-        except Error as exc:
-            LOGGER.critical(f"Error creating vdsdata partitions.")
-            LOGGER.critical(exc)
-            raise Exception()
-
-def check_vdsvehicledata_partitions(rds_conn, start_date):
-    y = datetime.strptime(start_date, '%Y-%m-%d').year
-
-    sql_check = sql.SQL("""
-        WITH target_tables(tablename) AS (
-            VALUES (%s)
-        )
-
-        SELECT COUNT(tt.*) = COUNT(pt.*) --if false, create new partitions
-        FROM target_tables AS tt
-        LEFT JOIN pg_tables AS pt ON pt.schemaname||'.'||pt.tablename = 'vds.'||tt.tablename;
-        """)
-    
-    try: 
-        with rds_conn.get_conn() as con, con.cursor() as cur:
-            LOGGER.info(f"Checking if necessary vdsvehicledata partitions exist.")
-            cur.execute(sql_check, [
-                f"raw_vdsvehicledata_{y}",
-                ])
-            table_check = cur.fetchone()[0]
-    except Error as exc:
-        LOGGER.critical(f"Error checking vdsvehicledata partitions.")
-        LOGGER.critical(exc)
-        raise Exception()
-
-    if table_check:  
-        LOGGER.info(f"No need to create new partition tables. Exiting.")
-    elif not table_check:
-        try:
-            with rds_conn.get_conn() as con, con.cursor() as cur:
-                LOGGER.info(f"Creating partition tables.")
-                partition_yyyymm = sql.SQL("SELECT vds.partition_vds_yyyymm(%s, %s, %s);")
-                cur.execute(partition_yyyymm, ('raw_vdsvehicledata', int(y), str('dt')))
-                LOGGER.critical(f"Finished creating vdsvehicledata partition tables.")
-        except Error as exc:
-            LOGGER.critical(f"Error creating vdsvehicledata partitions.")
-            LOGGER.critical(exc)
-            raise Exception()
+#check if Jan 1 to trigger partition creates. 
+def check_new_year(start_date):
+    start_datetime = datetime.strptime(start_date, '%Y-%m-%d')
+    if start_datetime.month == 1 and start_datetime.day == 1:
+        return True
+    return False


### PR DESCRIPTION
## What this pull request accomplishes:
- @tahaislam this is a small, non urgent PR. In a final review, I realized it would be much more elegant to simply create the partitions on Jan 1 than to query the database every day seeing if new partitions were needed. Reduced codebase by about 60 lines and I get to use a new operator 🥳 

## Issue(s) this solves:
- I was bad an did not create an issue #. 

## What, in particular, needs to reviewed:
- Is 4 sql statements in one PostgresOperator OK or do you think I need to split this into 4 tasks?

## What needs to be done by a sysadmin after this PR is merged
Pull updated branch into airflow. 