### PR TITLE
#699 remove personal schema dependency on the miovision tcl conflation table

### DIFF
--- a/volumes/miovision/sql/create-mv-mio_cent.sql
+++ b/volumes/miovision/sql/create-mv-mio_cent.sql
@@ -1,0 +1,140 @@
+--this is a bit of a convoluded process... here are the steps I took. I'm happy to make it more efficient
+--1. wrote code to find the centreline_ids that correspond to the segments that touch miovision intersections; put these in a table
+--2. did some error checking to see if that code worked (there were 9 situations where it didn't)...
+--3. manually investigated and fixed the centrelines that needed to be fixed (in the table)
+
+--1. Here is the code that finds centreline_ids that touch miovision intersections:
+CREATE TABLE miovision_api.centerline_miovision AS (
+
+    --find all the nodes in the centreline file that touch miovision intersections. You have to match with "from" and "to" nodes to get all the segments
+    WITH cent_int AS (
+        SELECT DISTINCT
+            intersection_uid,
+            lat,
+            lng,
+            centreline_id,
+            latitude,
+            longitude
+        FROM miovision_api.intersections ter
+        LEFT JOIN prj_volume.centreline cent ON ter.int_id = cent.to_intersection_id
+        LEFT JOIN prj_volume.centreline_intersections ci ON cent.from_intersection_id = ci.intersection_id
+        WHERE feature_code_desc NOT IN ('Trail')
+
+        UNION ALL
+
+        SELECT DISTINCT
+            intersection_uid,
+            lat,
+            lng,
+            centreline_id,
+            latitude,
+            longitude
+        FROM miovision_api.intersections ter
+        LEFT JOIN prj_volume.centreline cent ON ter.int_id = cent.from_intersection_id
+        LEFT JOIN prj_volume.centreline_intersections ci ON cent.to_intersection_id = ci.intersection_id
+        WHERE feature_code_desc NOT IN ('Trail')
+    ),
+
+    --determine difference in the "non-miovision node" co-ordinates - figure out if we're dealing with the north-south or east-west street in the intersection
+    ll_diff AS (
+        SELECT
+            intersection_uid,
+            lat,
+            lng,
+            centreline_id,
+            latitude,
+            longitude,
+            latitude - lat AS lat_diff,
+            longitude - lng AS lng_diff,
+            CASE
+                WHEN abs(latitude - lat) > abs(longitude - lng) THEN 'NS'
+                WHEN abs(longitude - lng) > abs(latitude - lat) THEN 'EW'
+            END AS nsew
+        FROM cent_int
+    ),
+
+    --determine which segments are N, S, E, W so that we can match with miovision leg + intersection_uid
+    cent_leg AS (
+        SELECT
+            intersection_uid,
+            lat,
+            lng,
+            centreline_id,
+            latitude,
+            longitude,
+            nsew,
+            CASE
+                WHEN nsew = 'NS' AND latitude > lat THEN 'N'
+                WHEN nsew = 'NS' AND latitude < lat THEN 'S'
+                WHEN nsew = 'EW' AND longitude > lng THEN 'E'
+                WHEN nsew = 'EW' AND longitude < lng THEN 'W'
+            END AS leg
+        FROM ll_diff
+    )
+
+    --yeah there's a ton of fluff in those earlier tables but we just need:
+    SELECT
+        centreline_id,
+        intersection_uid,
+        leg
+    FROM cent_leg);
+
+--2. It's important that the centreline to miovision file has the right combination of intersection_uids and legs. Here's how I checked that:
+WITH data_legs AS (
+    SELECT DISTINCT
+        intersection_uid,
+        leg
+    FROM miovision_api.volumes_15min --this gets me all the distinct intersection_uid and leg combos in the actual dataset
+)
+
+SELECT
+    centreline_id,
+    cm.intersection_uid,
+    cm.leg,
+    dl.intersection_uid data_int,
+    dl.leg data_leg
+FROM data_legs dl
+FULL JOIN miovision_api.centerline_miovision cm ON cm.intersection_uid = dl.intersection_uid AND cm.leg = dl.leg -- full join means I can see what's in each pile
+ORDER BY dl.intersection_uid;
+
+-- When you run this, it will look as though two intersections, in addition to the 9 listed below, have data but no corresponding centreline_id. They are:
+    -- 5W (Front + Bathurst - Front ends at Bathurst) has no volumes over 0 
+    -- 37N (Danforth + Jones) - Jones ends at a strip mall on Danforth but there's nothing on the centreline to map to
+
+--3. There were 9 cases where there was data for an intersection+leg combo that wasn't in my look up table, so I did some investigations and manually updated accordingly.
+--of the 9 missing intersection+leg combos, two were for non-streets, so there's nothing to map them to in the centreline.
+--the first two digits in forthcoming comments represent intersection_uid and leg
+
+-- 1 W Adelaide jogs at Bathurst, the miovision node doesn't capture that so I added it
+INSERT INTO miovision_api.centerline_miovision
+VALUES (14073511, 1, 'W');
+
+-- 24 N Queen and Curvy Bay, there were two W, made Bay N 
+UPDATE miovision_api.centerline_miovision
+SET leg = 'N'
+WHERE centreline_id = 1145090;
+
+-- 45 N Eglinton and Kingston, two W, so I made Eglinton N and it felt so wrong
+UPDATE miovision_api.centerline_miovision
+SET leg = 'N'
+WHERE centreline_id = 110384;
+
+-- 50 E Kingston and Morningside, two sets of NS, so I made Kingston EW
+UPDATE miovision_api.centerline_miovision
+SET leg = 'E'
+WHERE centreline_id = 107942;
+
+-- 50 W Kingston and Morningside, two sets of NS, so I made Kingston EW
+UPDATE miovision_api.centerline_miovision
+SET leg = 'W'
+WHERE centreline_id = 8087359;
+
+-- 52 N Sheppard and some curvy streets you've never heard of, two W, made the north one N
+UPDATE miovision_api.centerline_miovision
+SET leg = 'N'
+WHERE centreline_id = 440997;
+
+-- 65 W River and Bayview, two S legs so I made River W
+UPDATE miovision_api.centerline_miovision
+SET leg = 'W'
+WHERE centreline_id = 5070833;

--- a/volumes/miovision/sql/create-mv-mio_cent.sql
+++ b/volumes/miovision/sql/create-mv-mio_cent.sql
@@ -1,10 +1,10 @@
---this is a bit of a convoluded process... here are the steps I took. I'm happy to make it more efficient
---1. wrote code to find the centreline_ids that correspond to the segments that touch miovision intersections; put these in a table
---2. did some error checking to see if that code worked (there were 9 situations where it didn't)...
---3. manually investigated and fixed the centrelines that needed to be fixed (in the table)
+-- this is a bit of a convoluded process... here are the steps I took. I'm happy to make it more efficient
+-- 1. wrote code to find the centreline_ids that correspond to the segments that touch miovision intersections; put these in a table
+-- 2. did some error checking to see if that code worked (there were 9 situations where it didn't)...
+-- 3. manually investigated and fixed the centrelines that needed to be fixed (in the table)
 
---1. Here is the code that finds centreline_ids that touch miovision intersections:
-CREATE TABLE miovision_api.centerline_miovision AS (
+-- 1. Here is the code that finds centreline_ids that touch miovision intersections:
+CREATE TABLE miovision_api.centreline_miovision AS (
 
     --find all the nodes in the centreline file that touch miovision intersections. You have to match with "from" and "to" nodes to get all the segments
     WITH cent_int AS (
@@ -12,13 +12,26 @@ CREATE TABLE miovision_api.centerline_miovision AS (
             ter.intersection_uid,
             ter.lat,
             ter.lng,
-            cent.centreline_id,
+            cent.geo_id,
             ci.latitude,
             ci.longitude
         FROM miovision_api.intersections AS ter
-        LEFT JOIN prj_volume.centreline AS cent ON ter.int_id = cent.to_intersection_id
-        LEFT JOIN prj_volume.centreline_intersections AS ci ON cent.from_intersection_id = ci.intersection_id
-        WHERE cent.feature_code_desc NOT IN ('Trail')
+        LEFT JOIN gis.centreline AS cent ON ter.int_id = cent.tnode
+        LEFT JOIN gis.centreline_intersection AS ci ON cent.fnode = ci.int_id
+        WHERE cent.fcode_desc NOT IN (
+            'Trail', 
+            'Geostatistical line', 
+            'Other', 
+            'River', 
+            'Major Railway', 
+            'Hydro Line', 
+            'Walkway',
+            'Major Shoreline',
+            'Creek/Tributary',
+            'Ferry Route',
+            'Minor Railway',
+            'Minor Shoreline (Land locked)'
+        )
 
         UNION ALL
 
@@ -26,13 +39,26 @@ CREATE TABLE miovision_api.centerline_miovision AS (
             ter.intersection_uid,
             ter.lat,
             ter.lng,
-            cent.centreline_id,
+            cent.geo_id,
             ci.latitude,
             ci.longitude
         FROM miovision_api.intersections AS ter
-        LEFT JOIN prj_volume.centreline AS cent ON ter.int_id = cent.from_intersection_id
-        LEFT JOIN prj_volume.centreline_intersections AS ci ON cent.to_intersection_id = ci.intersection_id
-        WHERE cent.feature_code_desc NOT IN ('Trail')
+        LEFT JOIN gis.centreline AS cent ON ter.int_id = cent.fnode
+        LEFT JOIN gis.centreline_intersection AS ci ON cent.tnode = ci.int_id
+        WHERE cent.fcode_desc NOT IN (
+            'Trail', 
+            'Geostatistical line', 
+            'Other', 
+            'River', 
+            'Major Railway', 
+            'Hydro Line', 
+            'Walkway',
+            'Major Shoreline',
+            'Creek/Tributary',
+            'Ferry Route',
+            'Minor Railway',
+            'Minor Shoreline (Land locked)'
+        )
     ),
 
     --determine difference in the "non-miovision node" co-ordinates - figure out if we're dealing with the north-south or east-west street in the intersection
@@ -41,7 +67,7 @@ CREATE TABLE miovision_api.centerline_miovision AS (
             ci.intersection_uid,
             ci.lat,
             ci.lng,
-            ci.centreline_id,
+            ci.geo_id,
             ci.latitude,
             ci.longitude,
             ci.latitude - ci.lat AS lat_diff,
@@ -51,33 +77,19 @@ CREATE TABLE miovision_api.centerline_miovision AS (
                 WHEN abs(ci.longitude - ci.lng) > abs(ci.latitude - ci.lat) THEN 'EW'
             END AS nsew
         FROM cent_int AS ci
-    ),
-
-    --determine which segments are N, S, E, W so that we can match with miovision leg + intersection_uid
-    cent_leg AS (
-        SELECT
-            ld.intersection_uid,
-            ld.lat,
-            ld.lng,
-            ld.centreline_id,
-            ld.latitude,
-            ld.longitude,
-            ld.nsew,
-            CASE
-                WHEN ld.nsew = 'NS' AND ld.latitude > ld.lat THEN 'N'
-                WHEN ld.nsew = 'NS' AND ld.latitude < ld.lat THEN 'S'
-                WHEN ld.nsew = 'EW' AND ld.longitude > ld.lng THEN 'E'
-                WHEN ld.nsew = 'EW' AND ld.longitude < ld.lng THEN 'W'
-            END AS leg
-        FROM ll_diff AS ld
     )
 
-    --yeah there's a ton of stuff we needed for calculations in those earlier tables but now we just need:
+    --determine which segments are N, S, E, W so that we can match with miovision leg + intersection_uid
     SELECT
-        cl.centreline_id,
-        cl.intersection_uid,
-        cl.leg
-    FROM cent_leg AS cl
+        ld.geo_id AS centreline_id,
+        ld.intersection_uid,
+        CASE
+            WHEN ld.nsew = 'NS' AND ld.latitude > ld.lat THEN 'N'
+            WHEN ld.nsew = 'NS' AND ld.latitude < ld.lat THEN 'S'
+            WHEN ld.nsew = 'EW' AND ld.longitude > ld.lng THEN 'E'
+            WHEN ld.nsew = 'EW' AND ld.longitude < ld.lng THEN 'W'
+        END AS leg
+    FROM ll_diff AS ld
 );
 
 --2. It's important that the centreline to miovision file has the right combination of intersection_uids and legs. Here's how I checked that:
@@ -101,41 +113,46 @@ ORDER BY dl.intersection_uid;
 -- When you run this, it will look as though two intersections, in addition to the 9 listed below, have data but no corresponding centreline_id. They are:
     -- 5W (Front + Bathurst - Front ends at Bathurst) has no volumes over 0 
     -- 37N (Danforth + Jones) - Jones ends at a strip mall on Danforth but there's nothing on the centreline to map to
+-- This is not such a great method given all of the data gaps. Back it up with a visual inspection.
 
 --3. There were 9 cases where there was data for an intersection+leg combo that wasn't in my look up table, so I did some investigations and manually updated accordingly.
 --of the 9 missing intersection+leg combos, two were for non-streets, so there's nothing to map them to in the centreline.
 --the first two digits in forthcoming comments represent intersection_uid and leg
 
 -- 1 W Adelaide jogs at Bathurst, the miovision node doesn't capture that so I added it
-INSERT INTO miovision_api.centerline_miovision
+INSERT INTO miovision_api.centreline_miovision
 VALUES (14073511, 1, 'W');
 
 -- 24 N Queen and Curvy Bay, there were two W, made Bay N 
-UPDATE miovision_api.centerline_miovision
+UPDATE miovision_api.centreline_miovision
 SET leg = 'N'
 WHERE centreline_id = 1145090;
 
 -- 45 N Eglinton and Kingston, two W, so I made Eglinton N and it felt so wrong
-UPDATE miovision_api.centerline_miovision
+UPDATE miovision_api.centreline_miovision
 SET leg = 'N'
 WHERE centreline_id = 110384;
 
 -- 50 E Kingston and Morningside, two sets of NS, so I made Kingston EW
-UPDATE miovision_api.centerline_miovision
+UPDATE miovision_api.centreline_miovision
 SET leg = 'E'
 WHERE centreline_id = 107942;
 
 -- 50 W Kingston and Morningside, two sets of NS, so I made Kingston EW
-UPDATE miovision_api.centerline_miovision
+UPDATE miovision_api.centreline_miovision
 SET leg = 'W'
 WHERE centreline_id = 8087359;
 
 -- 52 N Sheppard and some curvy streets you've never heard of, two W, made the north one N
-UPDATE miovision_api.centerline_miovision
+UPDATE miovision_api.centreline_miovision
 SET leg = 'N'
 WHERE centreline_id = 440997;
 
 -- 65 W River and Bayview, two S legs so I made River W
-UPDATE miovision_api.centerline_miovision
+UPDATE miovision_api.centreline_miovision
 SET leg = 'W'
 WHERE centreline_id = 5070833;
+
+-- 1 W Adelaide and Bathurst, shouldn't exist because this intersection jogs
+DELETE FROM miovision_api.centreline_miovision
+WHERE intersection_uid = 1 AND leg = 'W';

--- a/volumes/miovision/sql/create-mv-mio_cent.sql
+++ b/volumes/miovision/sql/create-mv-mio_cent.sql
@@ -19,12 +19,12 @@ CREATE TABLE miovision_api.centreline_miovision AS (
         LEFT JOIN gis.centreline AS cent ON ter.int_id = cent.tnode
         LEFT JOIN gis.centreline_intersection AS ci ON cent.fnode = ci.int_id
         WHERE cent.fcode_desc NOT IN (
-            'Trail', 
-            'Geostatistical line', 
-            'Other', 
-            'River', 
-            'Major Railway', 
-            'Hydro Line', 
+            'Trail',
+            'Geostatistical line',
+            'Other',
+            'River',
+            'Major Railway',
+            'Hydro Line',
             'Walkway',
             'Major Shoreline',
             'Creek/Tributary',
@@ -46,12 +46,12 @@ CREATE TABLE miovision_api.centreline_miovision AS (
         LEFT JOIN gis.centreline AS cent ON ter.int_id = cent.fnode
         LEFT JOIN gis.centreline_intersection AS ci ON cent.tnode = ci.int_id
         WHERE cent.fcode_desc NOT IN (
-            'Trail', 
-            'Geostatistical line', 
-            'Other', 
-            'River', 
-            'Major Railway', 
-            'Hydro Line', 
+            'Trail',
+            'Geostatistical line',
+            'Other',
+            'River',
+            'Major Railway',
+            'Hydro Line',
             'Walkway',
             'Major Shoreline',
             'Creek/Tributary',

--- a/volumes/miovision/sql/create-mv-mio_cent.sql
+++ b/volumes/miovision/sql/create-mv-mio_cent.sql
@@ -44,8 +44,8 @@ CREATE TABLE miovision_api.centerline_miovision AS (
             ci.centreline_id,
             ci.latitude,
             ci.longitude,
-            ci.latitude - lat AS lat_diff,
-            ci.longitude - lng AS lng_diff,
+            ci.latitude - ci.lat AS lat_diff,
+            ci.longitude - ci.lng AS lng_diff,
             CASE
                 WHEN abs(ci.latitude - ci.lat) > abs(ci.longitude - ci.lng) THEN 'NS'
                 WHEN abs(ci.longitude - ci.lng) > abs(ci.latitude - ci.lat) THEN 'EW'
@@ -92,8 +92,8 @@ SELECT
     cm.centreline_id,
     cm.intersection_uid,
     cm.leg,
-    dl.intersection_uid data_int,
-    dl.leg data_leg
+    dl.intersection_uid AS data_int,
+    dl.leg AS data_leg
 FROM data_legs AS dl
 FULL JOIN miovision_api.centerline_miovision AS cm ON cm.intersection_uid = dl.intersection_uid AND cm.leg = dl.leg -- full join means I can see what's in each pile
 ORDER BY dl.intersection_uid;


### PR DESCRIPTION
## What this pull request accomplishes:

- removes the `scannon` dependency from the `prj_volume.mio_cent` table (aka the table that conflates `centreline_ids` with Miovision intersection legs
- moves the table from `prj_volume` to `miovision_api`

## Issue(s) this solves:

- #699 

## What, in particular, needs to reviewed:

- Make sure the code runs; I tested it in my `scannon` schema but I don't have permissions for the `miovision_api` schema

## What needs to be done by a sysadmin after this PR is merged

- Someone who has create privileges on `miovision_api` should run the code
