### PR TITLE
I0702 monitor vds count

### DIFF
--- a/dags/custom_operators.py
+++ b/dags/custom_operators.py
@@ -1,0 +1,31 @@
+from airflow.providers.common.sql.operators.sql import SQLCheckOperator
+from airflow.exceptions import AirflowException
+
+
+class SQLCheckOperatorWithReturnValue(SQLCheckOperator):
+    """
+    Overrides the `execute` function of `SQLCheckOperator` to:
+    1. Only fail if the first element (not any element) in the returning result is False
+    2. return the result of the final query
+    3. enable autocommit
+    """
+
+    def execute(self, context=None):
+        self.log.info("Executing SQL check: %s", self.sql)
+        # Fetch the first row of the sql's output and commit changes
+        hook = self.get_db_hook()
+        records = hook.run(
+            sql=self.sql, handler=lambda cursor: cursor.fetchone(), autocommit=True
+        )
+        # records = self.get_db_hook().get_first(self.sql)
+
+        self.log.info("Record: %s", records)
+        if not records:
+            raise AirflowException("The query returned None")
+        elif not bool(records[0]):  # checking first element only
+            raise AirflowException(
+                f"Test failed.\nQuery:\n{self.sql}\nResults:\n{records!s}"
+            )
+
+        self.log.info("Success.")
+        return records

--- a/dags/vds_pull_vdsdata.py
+++ b/dags/vds_pull_vdsdata.py
@@ -38,7 +38,9 @@ try:
     from dags.dag_functions import task_fail_slack_alert
 except:
     raise ImportError("Cannot import task_fail_slack_alert.")  
-   
+
+from dags.custom_operators import SQLCheckOperatorWithReturnValue
+
 default_args = {
     'owner': ','.join(names),
     'depends_on_past': False,
@@ -137,4 +139,20 @@ with DAG(dag_name,
         summarize_v15_task
         summarize_v15_bylane_task
 
-    update_inventories >> check_partitions >> vdsdata >> v15data #pull then summarize
+    with TaskGroup(group_id='sql_checks') as sql_checks:
+        divisions = [2, 8001]
+        for divid in divisions:
+            check_avg_rows = SQLCheckOperatorWithReturnValue(
+                task_id=f"check_rows_vdsdata_div{divid}",
+                sql="select/select-row_count_lookback.sql",
+                conn_id='vds_bot',
+                params={"table": 'vds.raw_vdsdata',
+                        "lookback": '60 days',
+                        "dt_col": 'dt',
+                        "div_id": divid,
+                        "threshold": 0.7},
+                retries=2
+            )
+            check_avg_rows
+
+    update_inventories >> check_partitions >> vdsdata >> v15data >> sql_checks #pull then summarize

--- a/dags/vds_pull_vdsdata.py
+++ b/dags/vds_pull_vdsdata.py
@@ -139,7 +139,7 @@ with DAG(dag_name,
         summarize_v15_task
         summarize_v15_bylane_task
 
-    with TaskGroup(group_id='sql_checks') as sql_checks:
+    with TaskGroup(group_id='data_checks') as data_checks:
         divisions = [2, 8001]
         for divid in divisions:
             check_avg_rows = SQLCheckOperatorWithReturnValue(
@@ -155,4 +155,4 @@ with DAG(dag_name,
             )
             check_avg_rows
 
-    update_inventories >> check_partitions >> vdsdata >> v15data >> sql_checks #pull then summarize
+    update_inventories >> check_partitions >> vdsdata >> v15data >> data_checks #pull then summarize

--- a/dags/vds_pull_vdsvehicledata.py
+++ b/dags/vds_pull_vdsvehicledata.py
@@ -126,7 +126,7 @@ with DAG(dag_id='vds_pull_vdsvehicledata',
         summarize_speeds_task
         summarize_lengths_task
 
-    with TaskGroup(group_id='sql_checks') as sql_checks:
+    with TaskGroup(group_id='data_checks') as data_checks:
         check_avg_rows = SQLCheckOperatorWithReturnValue(
             task_id=f"check_rows_vdsvehicledata_div2",
             sql="select/select-row_count_lookback.sql",
@@ -140,4 +140,4 @@ with DAG(dag_id='vds_pull_vdsvehicledata',
         )
         check_avg_rows
 
-    t_upstream_done >> check_partitions >> pull_vdsvehicledata >> summarize_vdsvehicledata >> sql_checks
+    t_upstream_done >> check_partitions >> pull_vdsvehicledata >> summarize_vdsvehicledata >> data_checks

--- a/volumes/vds/sql/select/select-row_count_lookback.sql
+++ b/volumes/vds/sql/select/select-row_count_lookback.sql
@@ -2,16 +2,17 @@
 --row count to average over lookback period.
 --noqa: disable=TMP, PRS
 
-WITH lookback AS (
+WITH lookback AS ( --noqa: L045
     SELECT
-        date_trunc('day', {{ params.dt_col }}), --noqa: L039
+        date_trunc('day', {{ params.dt_col }}) AS _dt, --noqa: L039
         COUNT(*) AS lookback_count
     FROM {{ params.table }}
     WHERE
         {{ params.dt_col }} >= '{{ ds }} 00:00:00'::timestamp - interval '{{ params.lookback }}'
         AND {{ params.dt_col }} < '{{ ds }} 00:00:00'::timestamp
         AND division_id = {{ params.div_id }}::int
-    GROUP BY date_trunc('day', {{ params.dt_col }}) --noqa: L003, L039
+    --group by day then avg excludes missing days.
+    GROUP BY _dt --noqa: L003
 )
 
 SELECT

--- a/volumes/vds/sql/select/select-row_count_lookback.sql
+++ b/volumes/vds/sql/select/select-row_count_lookback.sql
@@ -1,0 +1,27 @@
+--query to be used in `check_row_count` tasks to compare
+--row count to average over lookback period.
+
+WITH lookback AS (
+    SELECT
+        date_trunc('day', {{ params.dt_col }}),
+        COUNT(*) AS lookback_count
+    FROM {{ params.table }}
+    WHERE
+        {{ params.dt_col }} >= '{{ ds }} 00:00:00'::timestamp - interval '{{ params.lookback }}'
+        AND {{ params.dt_col }} < '{{ ds }} 00:00:00'::timestamp
+        AND division_id = {{ params.div_id }}::int
+    GROUP BY date_trunc('day', {{ params.dt_col }})
+)
+
+SELECT
+    COUNT(*) >= {{ params.threshold }}::numeric *
+        (SELECT AVG(lookback_count) FROM lookback) AS check, 
+    COUNT(*) AS ds_count,
+    (SELECT AVG(lookback_count) FROM lookback) AS lookback_avg,
+    {{ params.threshold }}::numeric *
+        (SELECT AVG(lookback_count) FROM lookback) AS passing_value
+FROM {{ params.table }}
+WHERE
+    {{ params.dt_col }} >= '{{ ds }} 00:00:00'::timestamp
+    AND {{ params.dt_col }} < '{{ ds }} 00:00:00'::timestamp + interval '1 day'
+    AND division_id = {{ params.div_id }}::int

--- a/volumes/vds/sql/select/select-row_count_lookback.sql
+++ b/volumes/vds/sql/select/select-row_count_lookback.sql
@@ -1,16 +1,17 @@
 --query to be used in `check_row_count` tasks to compare
 --row count to average over lookback period.
+--noqa: disable=TMP, PRS
 
 WITH lookback AS (
     SELECT
-        date_trunc('day', {{ params.dt_col }}),
+        date_trunc('day', {{ params.dt_col }}), --noqa: L039
         COUNT(*) AS lookback_count
     FROM {{ params.table }}
     WHERE
         {{ params.dt_col }} >= '{{ ds }} 00:00:00'::timestamp - interval '{{ params.lookback }}'
         AND {{ params.dt_col }} < '{{ ds }} 00:00:00'::timestamp
         AND division_id = {{ params.div_id }}::int
-    GROUP BY date_trunc('day', {{ params.dt_col }})
+    GROUP BY date_trunc('day', {{ params.dt_col }}) --noqa: L003, L039
 )
 
 SELECT


### PR DESCRIPTION
## What this pull request accomplishes:
- Adds a basic row count check to VDS DAGs, similar to existing `check_rescu`
- passing value for checks calculated based on average row count over lookback period. 

## Issue(s) this solves:
- Closes #702

## What, in particular, needs to reviewed:
- Is there a way to utilize `/vfh_data_mgmt/custom_operators/sql.py` without copying to bdit_data-souces? 
- Thoughts on sql with so many params (meant to be reusable)?
- Thoughts on reusing SQLCheckOperatorWithReturnValue for this? I also considered a modified SQLValue/SQLInterval CheckOperator but this was least effort.

## What needs to be done by a sysadmin after this PR is merged
- Update vds_* DAGs. 
- Gabe to update DAG section of VDS readme