### PR TITLE
Bug/i0706 wys read google sheets task is failing for certain wards trying to insert duplicate rows

### DIFF
--- a/wys/api/python/wys_google_sheet.py
+++ b/wys/api/python/wys_google_sheet.py
@@ -137,6 +137,8 @@ def pull_from_sheet(
             ON CONFLICT (location, from_street, to_street, direction, 
                         installation_date, removal_date, new_sign_number, 
                         comments)
+            /*do update required here because do nothing does not return dupes
+            on conflict. */
             DO UPDATE SET 
                 location=EXCLUDED.location,
                 from_street=EXCLUDED.from_street,

--- a/wys/api/python/wys_google_sheet.py
+++ b/wys/api/python/wys_google_sheet.py
@@ -142,7 +142,7 @@ def pull_from_sheet(
             DO UPDATE SET 
                 location=EXCLUDED.location,
                 from_street=EXCLUDED.from_street,
-                to_street=EXCLUDED.to_street
+                to_street=EXCLUDED.to_street,
                 direction=EXCLUDED.direction,
                 removal_date=EXCLUDED.removal_date,
                 comments=EXCLUDED.comments

--- a/wys/api/python/wys_google_sheet.py
+++ b/wys/api/python/wys_google_sheet.py
@@ -134,10 +134,16 @@ def pull_from_sheet(
                     FROM new_data
                     GROUP BY new_sign_number, installation_date
                     HAVING COUNT(*)> 1) dupes
-            ON CONFLICT ( location, from_street, to_street, direction, 
+            ON CONFLICT (location, from_street, to_street, direction, 
                         installation_date, removal_date, new_sign_number, 
                         comments)
-            DO NOTHING
+            DO UPDATE SET 
+                location=EXCLUDED.location,
+                from_street=EXCLUDED.from_street,
+                to_street=EXCLUDED.to_street
+                direction=EXCLUDED.direction,
+                removal_date=EXCLUDED.removal_date,
+                comments=EXCLUDED.comments
             RETURNING new_sign_number, installation_date
         )
         INSERT INTO {}.{} AS existing (ward_no, location, from_street, to_street, 


### PR DESCRIPTION
## What this pull request accomplishes:
- The task `read_google_sheets` of `pull_wys` was failing because certain duplicates were already present in the duplicates table, causing them to not be returned by `ON CONFLICT DO NOTHING` and then not be removed prior to the insert on wards tables. Changing to `ON CONFLICT DO UPDATE` should eliminate this issue. 

## Issue(s) this solves:
- #706 

## What, in particular, needs to reviewed:
- ON CONFLICT DO UPDATE logic

## What needs to be done by a sysadmin after this PR is merged
@radumas linked `pull_wys` to @gabrielwol home folder for testing purposes. We should revert that change. 