### PR TITLE
I0713 wys get schedules failing with typeerror

### DIFF
--- a/dags/pull_wys.py
+++ b/dags/pull_wys.py
@@ -112,8 +112,7 @@ def pull_wys_dag():
         cred = wys_api_hook.get_credentials()
         service = build('sheets', 'v4', credentials=cred, cache_discovery=False)
 
-        with wys_postgres.get_conn() as con:
-            read_masterlist(con, service)
+        read_masterlist(wys_postgres.get_conn(), service)
 
     pull_wys()
     pull_schedules()

--- a/dags/pull_wys.py
+++ b/dags/pull_wys.py
@@ -74,7 +74,7 @@ default_args = {'owner': ','.join(names),
 def pull_wys_dag():
 
     @task
-    def pull_wys(**kwargs):
+    def pull_wys(ds=None):
         #to connect to pgadmin bot
         wys_postgres = PostgresHook("wys_bot")
         
@@ -83,8 +83,8 @@ def pull_wys_dag():
         api_key = api_conn.password
 
         with wys_postgres.get_conn() as conn:
-            api_main(start_date = kwargs['ds'],
-                     end_date = kwargs['ds'],
+            api_main(start_date = ds,
+                     end_date = ds,
                      conn = conn,
                      api_key=api_key)
 

--- a/wys/api/python/wys_api.py
+++ b/wys/api/python/wys_api.py
@@ -375,19 +375,8 @@ def api_main(start_date=default_start,
         sys.exit(1)
 
     conn.commit()
-
-    try:
-        get_schedules(conn, api_key)
-        logger.info('Updated wys.sign_schedules_list')
-    except psycopg2.Error as exc:
-        logger.critical('Error updating schedules')
-        logger.critical(exc)
-        conn.close()
-        sys.exit(1)
-
-    conn.commit()
-
     conn.close()
+
     logger.info('Done')
 
 def update_locations(conn, loc_table):

--- a/wys/api/python/wys_api.py
+++ b/wys/api/python/wys_api.py
@@ -461,8 +461,7 @@ def update_locations(conn, loc_table):
         """
         cur.execute(update_locations_sql)
 
-def get_schedules(conn, api_connection):
-    api_key = api_connection.password
+def get_schedules(conn, api_key):
     headers={'Content-Type':'application/json','x-api-key':api_key}
     
     try: 
@@ -483,7 +482,7 @@ def get_schedules(conn, api_connection):
         logger.critical('Return value: %s', schedule_list)
         raise WYS_APIException(e)
 
-    with conn.get_conn() as con, con.cursor() as cur:
+    with conn.cursor() as cur:
         logger.debug('Inserting '+str(len(rows))+' rows of schedules')
         schedule_sql = '''
             INSERT INTO wys.sign_schedules_list (schedule_name, api_id) VALUES %s

--- a/wys/api/python/wys_api.py
+++ b/wys/api/python/wys_api.py
@@ -461,7 +461,8 @@ def update_locations(conn, loc_table):
         """
         cur.execute(update_locations_sql)
 
-def get_schedules(conn, api_key):
+def get_schedules(conn, api_connection):
+    api_key = api_connection.password
     headers={'Content-Type':'application/json','x-api-key':api_key}
     
     try: 
@@ -472,7 +473,6 @@ def get_schedules(conn, api_key):
     except RequestException as exc: 
         logger.critical('Error querying API, %s', exc)
         logger.critical('Response: %s', exc.response)                        
-        sys.exit(2)
 
     try:
         rows = [(schedule['name'], api_id)
@@ -483,7 +483,7 @@ def get_schedules(conn, api_key):
         logger.critical('Return value: %s', schedule_list)
         raise WYS_APIException(e)
 
-    with conn.cursor() as cur:
+    with conn.get_conn() as con, con.cursor() as cur:
         logger.debug('Inserting '+str(len(rows))+' rows of schedules')
         schedule_sql = '''
             INSERT INTO wys.sign_schedules_list (schedule_name, api_id) VALUES %s

--- a/wys/api/python/wys_api.py
+++ b/wys/api/python/wys_api.py
@@ -467,9 +467,15 @@ def get_schedules(conn, api_key):
                          headers=headers)
     schedule_list = response.json()
     
-    rows = [(schedule['name'], api_id) for schedule in schedule_list if schedule['assigned_on_locations'] 
-            for api_id in schedule['assigned_on_locations'] if api_id]
-       
+    try:
+        rows = [(schedule['name'], api_id)
+                    for schedule in schedule_list if schedule['assigned_on_locations']
+                        for api_id in schedule['assigned_on_locations'] if api_id]
+    except TypeError as e:
+        logger.critical('Failed to pull sign schedules.')
+        logger.critical('Return value: ', schedule_list)
+        raise WYS_APIException(e)
+
     with conn.cursor() as cur:
         logger.debug('Inserting '+str(len(rows))+' rows of schedules')
         schedule_sql = '''

--- a/wys/api/python/wys_api.py
+++ b/wys/api/python/wys_api.py
@@ -470,7 +470,8 @@ def get_schedules(conn, api_key):
         response.raise_for_status()
         schedule_list = response.json()
     except RequestException as exc: 
-        logger.critical('Error querying API, %s', exc) 
+        logger.critical('Error querying API, %s', exc)
+        logger.critical('Response: %s', exc.response)                        
         sys.exit(2)
 
     try:
@@ -479,7 +480,7 @@ def get_schedules(conn, api_key):
                         for api_id in schedule['assigned_on_locations'] if api_id]
     except TypeError as e:
         logger.critical('Error converting schedules response to values list.')
-        logger.critical('Return value: ', schedule_list)
+        logger.critical('Return value: %s', schedule_list)
         raise WYS_APIException(e)
 
     with conn.cursor() as cur:


### PR DESCRIPTION
## What this pull request accomplishes:
- Separates `get_schedules` into a separate Airflow task to prevent failure from impacting rest of `pull_wys` task.
- Adds try except block to `get_schedules` to catch TypeError
- Change all tasks to taskflow api format
- Move connections out of top level to improve DAG parsing performance

## Issue(s) this solves:
- Closes #713 

## What, in particular, needs to reviewed:
- First time using TaskFlow API!
- See error in #713

## What needs to be done by a sysadmin after this PR is merged
- I haven't tested parsing the changes to the DAG