### PR TITLE
Replicate MOVE's collisions mat views and tables

### DIFF
--- a/dags/.airflowignore
+++ b/dags/.airflowignore
@@ -1,0 +1,3 @@
+^common_tasks.py$
+^custom_operators.py$
+^dag_functions.py$

--- a/dags/common_tasks.py
+++ b/dags/common_tasks.py
@@ -1,11 +1,15 @@
 
 from psycopg2 import sql
 from typing import Tuple
+import logging 
 # pylint: disable=import-error
 from airflow.decorators import task
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.sensors.base import PokeReturnValue
 from airflow.exceptions import AirflowFailException
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 @task.sensor(poke_interval=3600, timeout=3600*24, mode="reschedule")
 def wait_for_external_trigger(**kwargs) -> PokeReturnValue:
@@ -56,3 +60,5 @@ def copy_table(table:Tuple[str, str]) -> None:
     with con, con.cursor() as cur:
         cur.execute(truncate_query)
         cur.execute(insert_query)
+    
+    LOGGER.info(f"Successfully copied {table[0]} to {table[1]}.")

--- a/dags/common_tasks.py
+++ b/dags/common_tasks.py
@@ -24,10 +24,11 @@ def wait_for_external_trigger(**kwargs) -> PokeReturnValue:
     )
 
 @task()
-def copy_table(table:Tuple[str, str]) -> None:
+def copy_table(conn_id:str, table:Tuple[str, str]) -> None:
     """Copies ``table[0]`` table into ``table[1]`` after truncating it.
 
     Args:
+        conn_id: The name of Airflow connection to the database
         table: A tuple containing the source table to be copied in the format
             ``schema.table``, and the destination table in the same format
             ``schema.table``.
@@ -45,7 +46,7 @@ def copy_table(table:Tuple[str, str]) -> None:
             f"Invalid destination table (expected schema.table, got {table[1]})"
         )
 
-    con = PostgresHook("collisions_bot").get_conn()
+    con = PostgresHook(conn_id).get_conn()
     truncate_query = sql.SQL(
         "TRUNCATE {}.{}"
         ).format(

--- a/dags/common_tasks.py
+++ b/dags/common_tasks.py
@@ -8,8 +8,13 @@ from airflow.sensors.base import PokeReturnValue
 from airflow.exceptions import AirflowFailException
 
 @task.sensor(poke_interval=3600, timeout=3600*24, mode="reschedule")
-def wait_for_upstream(**kwargs) -> PokeReturnValue:
-    """Waits for an external trigger."""
+def wait_for_external_trigger(**kwargs) -> PokeReturnValue:
+    """Waits for an external trigger.
+    
+    A sensor waiting to be triggered by an external trigger. Its default poke
+        interval is 1 hour and timeout is 1 day. The sensor's mode is set to
+        reschedule by default to free the resources while idle.
+    """
     return PokeReturnValue(
         is_done=kwargs["task_instance"].dag_run.external_trigger
     )

--- a/dags/common_tasks.py
+++ b/dags/common_tasks.py
@@ -1,0 +1,53 @@
+
+from psycopg2 import sql
+from typing import Tuple
+# pylint: disable=import-error
+from airflow.decorators import task
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.sensors.base import PokeReturnValue
+from airflow.exceptions import AirflowFailException
+
+@task.sensor(poke_interval=3600, timeout=3600*24, mode="reschedule")
+def wait_for_upstream(**kwargs) -> PokeReturnValue:
+    """Waits for an external trigger."""
+    return PokeReturnValue(
+        is_done=kwargs["task_instance"].dag_run.external_trigger
+    )
+
+@task()
+def copy_table(table:Tuple[str, str]) -> None:
+    """Copies ``table[0]`` table into ``table[1]`` after truncating it.
+
+    Args:
+        table: A tuple containing the source table to be copied in the format
+            ``schema.table``, and the destination table in the same format
+            ``schema.table``.
+    """
+    try:
+        src_schema, src_table = table[0].split(".")
+    except ValueError:
+        raise AirflowFailException(
+            f"Invalid source table (expected schema.table, got {table[0]})"
+        )
+    try:
+        dst_schema, dst_table = table[1].split(".")
+    except ValueError:
+        raise AirflowFailException(
+            f"Invalid destination table (expected schema.table, got {table[1]})"
+        )
+
+    con = PostgresHook("collisions_bot").get_conn()
+    truncate_query = sql.SQL(
+        "TRUNCATE {}.{}"
+        ).format(
+            sql.Identifier(dst_schema), sql.Identifier(dst_table)
+        )
+    insert_query = sql.SQL(
+        "INSERT INTO {}.{} SELECT * FROM {}.{}"
+        ).format(
+            sql.Identifier(dst_schema), sql.Identifier(dst_table),
+            sql.Identifier(src_schema), sql.Identifier(src_table)
+        )
+    with con, con.cursor() as cur:
+        cur.execute(truncate_query)
+        cur.execute(insert_query)

--- a/dags/pull_collisions.py
+++ b/dags/pull_collisions.py
@@ -58,10 +58,10 @@ default_args = {
 def collisions_replicator():
     """The main function of the collisions DAG."""
     tables = [
-        ("collisions_staging.ACC", "collisions.ACC"),
-        ("collisions_staging.events", "collisions.events"),
-        ("collisions_staging.involved", "collisions.involved"),
-        ("collisions_staging.events_centreline", "collisions.events_centreline")
+        ("move_staging.ACC", "collisions.ACC"),
+        ("move_staging.events", "collisions.events"),
+        ("move_staging.involved", "collisions.involved"),
+        ("move_staging.events_centreline", "collisions.events_centreline")
     ]
     # connection to PostgreSQL
     @task()

--- a/dags/pull_collisions.py
+++ b/dags/pull_collisions.py
@@ -27,7 +27,7 @@ repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__f
 sys.path.insert(0, repo_path)
 # pylint: disable=wrong-import-position
 from dags.dag_functions import task_fail_slack_alert
-from dags.common_tasks import wait_for_upstream, copy_table
+from dags.common_tasks import wait_for_external_trigger, copy_table
 # pylint: enable=import-error
 # pylint: enable=wrong-import-position
 
@@ -63,12 +63,7 @@ def collisions_replicator():
         ("move_staging.events_centreline", "collisions.events_centreline")
     ]
     
-    external_sensor = wait_for_upstream.override(
-        task_id="wait_for_external_trigger",
-        poke_interval=3600,
-        timeout=3600*24,
-        mode="reschedule"
-    )()
+    external_sensor = wait_for_external_trigger()
     for table in tables:
         external_sensor >> copy_table.override(
             task_id=table[1].split(".")[1], retries=3

--- a/dags/pull_collisions.py
+++ b/dags/pull_collisions.py
@@ -4,7 +4,7 @@
 r"""### The Daily Collision Replicator DAG
 
 This DAG runs daily to update the following collisions tables from the tables
-staged in the database by the MOVE's BDITTO_COLLISIONS_REPLICATOR DAG:
+staged in the database by the MOVE's ``BDITTO_COLLISIONS_REPLICATOR`` DAG:
 
 1\. ACC
 
@@ -59,7 +59,7 @@ default_args = {
 def collisions_replicator():
     """The main function of the collisions DAG."""
     tables = [
-        ("move_staging.ACC", "collisions.ACC"),
+        ("move_staging.acc", "collisions.acc"),
         ("move_staging.events", "collisions.events"),
         ("move_staging.involved", "collisions.involved"),
         ("move_staging.events_centreline", "collisions.events_centreline")

--- a/dags/pull_collisions.py
+++ b/dags/pull_collisions.py
@@ -1,0 +1,95 @@
+#!/data/airflow/airflow_venv/bin/python3
+# -*- coding: utf-8 -*-
+# noqa: D415
+r"""### The Daily Collision Replicator DAG
+
+This DAG runs daily to update the following collisions tables from the tables
+staged in the database by the MOVE's BDITTO_COLLISIONS_REPLICATOR DAG:
+
+1\. ACC
+
+2\. events
+
+3\. involved
+
+4\. events_centreline
+"""
+import os
+import sys
+from datetime import timedelta
+import pendulum
+from psycopg2 import sql
+# pylint: disable=import-error
+from airflow.decorators import dag, task
+from airflow.models import Variable
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+
+# import custom operators and helper functions
+repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+sys.path.insert(0, repo_path)
+# pylint: disable=wrong-import-position
+from dags.dag_functions import task_fail_slack_alert
+# pylint: enable=import-error
+# pylint: enable=wrong-import-position
+
+DAG_NAME = 'collisions_replicator'
+DAG_OWNERS = Variable.get('dag_owners', deserialize_json=True).get(DAG_NAME, ['Unknown'])
+
+default_args = {
+    'owner': ','.join(DAG_OWNERS),
+    'depends_on_past': False,
+    'start_date': pendulum.datetime(2023, 10, 31, tz="America/Toronto"),
+    'email_on_failure': False,
+    'email_on_success': False,
+    'retries': 3,
+    'retry_delay': timedelta(minutes=5),
+    'on_failure_callback': task_fail_slack_alert,
+}
+
+@dag(
+    dag_id=DAG_NAME,
+    default_args=default_args,
+    catchup=False,
+    max_active_runs=5,
+    schedule_interval="0 7 * * *",
+    doc_md=__doc__
+)
+def collisions_replicator():
+    """The main function of the collisions DAG."""
+    tables = [
+        ("collisions_staging.ACC", "collisions.ACC"),
+        ("collisions_staging.events", "collisions.events"),
+        ("collisions_staging.involved", "collisions.involved"),
+        ("collisions_staging.events_centreline", "collisions.events_centreline")
+    ]
+    # connection to PostgreSQL
+    @task()
+    def copy_table(src:str, dst:str) -> None:
+        """Copies ``src`` table into ``dst`` after truncating it.
+
+        Args:
+            src: Source table in format ``schema.table``
+            dst: Destination table in format ``schema.table``
+        """
+        con = PostgresHook("collisions_bot").get_conn()
+        src_schema, src_table = src.split(".")
+        dst_schema, dst_table = dst.split(".")
+        truncate_query = sql.SQL(
+            "TRUNCATE {}.{}"
+            ).format(
+                sql.Identifier(dst_schema), sql.Identifier(dst_table)
+            )
+        insert_query = sql.SQL(
+            "INSERT INTO {}.{} SELECT * FROM {}.{}"
+            ).format(
+                sql.Identifier(dst_schema), sql.Identifier(dst_table),
+                sql.Identifier(src_schema), sql.Identifier(src_table)
+            )
+        with con, con.cursor() as cur:
+            cur.execute(truncate_query)
+            cur.execute(insert_query)
+
+    for src, dst in tables:
+        copy_table.override(task_id=dst.split(".")[1])(src, dst)
+
+collisions_replicator()

--- a/dags/pull_collisions.py
+++ b/dags/pull_collisions.py
@@ -98,10 +98,11 @@ def collisions_replicator():
             cur.execute(truncate_query)
             cur.execute(insert_query)
 
+    external_sensor = wait_for_upstream.override(
+        task_id="wait_for_external_trigger"
+    )()
     for src, dst in tables:
-        wait_for_upstream.override(
-            task_id="_".join([dst.split(".")[1],"sensor"])
-        )() >> copy_table.override(
+        external_sensor >> copy_table.override(
             task_id=dst.split(".")[1]
         )(src, dst)
 

--- a/dags/pull_collisions.py
+++ b/dags/pull_collisions.py
@@ -32,18 +32,18 @@ from dags.dag_functions import task_fail_slack_alert
 # pylint: enable=import-error
 # pylint: enable=wrong-import-position
 
-DAG_NAME = 'collisions_replicator'
-DAG_OWNERS = Variable.get('dag_owners', deserialize_json=True).get(DAG_NAME, ['Unknown'])
+DAG_NAME = "collisions_replicator"
+DAG_OWNERS = Variable.get("dag_owners", deserialize_json=True).get(DAG_NAME, ["Unknown"])
 
 default_args = {
-    'owner': ','.join(DAG_OWNERS),
-    'depends_on_past': False,
-    'start_date': pendulum.datetime(2023, 10, 31, tz="America/Toronto"),
-    'email_on_failure': False,
-    'email_on_success': False,
-    'retries': 3,
-    'retry_delay': timedelta(minutes=5),
-    'on_failure_callback': task_fail_slack_alert,
+    "owner": ",".join(DAG_OWNERS),
+    "depends_on_past": False,
+    "start_date": pendulum.datetime(2023, 10, 31, tz="America/Toronto"),
+    "email_on_failure": False,
+    "email_on_success": False,
+    "retries": 3,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": task_fail_slack_alert,
 }
 
 @dag(
@@ -52,7 +52,8 @@ default_args = {
     catchup=False,
     max_active_runs=5,
     schedule_interval="0 7 * * *",
-    doc_md=__doc__
+    doc_md=__doc__,
+    tags=["collisions"]
 )
 def collisions_replicator():
     """The main function of the collisions DAG."""

--- a/dags/pull_collisions.py
+++ b/dags/pull_collisions.py
@@ -17,6 +17,7 @@ staged in the database by the MOVE's ``bigdata_replicator`` DAG:
 import os
 import sys
 from datetime import timedelta
+from functools import partial
 import pendulum
 # pylint: disable=import-error
 from airflow.decorators import dag
@@ -62,6 +63,7 @@ def collisions_replicator():
         ("move_staging.events_centreline", "collisions.events_centreline")
     ]
     
-    wait_for_external_trigger() >> copy_table.expand(table=tables)
+    wait_for_external_trigger() >> copy_table.partial(
+        conn_id="collisions_bot").expand(table=tables)
 
 collisions_replicator()


### PR DESCRIPTION
## What this pull request accomplishes:

- a new DAG that truncates collision tables under `collisions` and copy new data from `move_staging` into `collisions` tables
- the new DAG is triggered externally by the upstream DAG running on one of MOVE's on-prem servers

## Issue(s) this solves:

- closes #734 

## What, in particular, needs to reviewed:

- The DAG file (the DAG was tested and ran successfully)

## What needs to be done by a sysadmin after this PR is merged

- Update the `data_scripts` folder

## Notes

I updated Airflow configurations to allow external API calls (added `airflow.api.auth.backend.basic_auth` to `api.auth_backends`), and added a new Airflow user for MOVE
