### PR TITLE
Choose the failure alerts' slack channel based on the running DAG's location

### DIFF
--- a/dags/dag_functions.py
+++ b/dags/dag_functions.py
@@ -11,8 +11,8 @@ def is_prod_mode() -> bool:
     """Returns True if the code is running from the PROD ENV directory."""
     PROD_ENV_PATH = Variable.get("prod_env_path")
     dags_folder = os.path.dirname(os.path.realpath(__file__))
-    repo_folder = os.path.abspath(os.path.dirname(dags_folder))
-    return os.path.normpath(repo_folder) == os.path.normpath(PROD_ENV_PATH)
+    repo_folder = os.path.basename(os.path.dirname(dags_folder))
+    return repo_folder == PROD_ENV_PATH
 
 def task_fail_slack_alert(
     context: dict,

--- a/dags/dag_functions.py
+++ b/dags/dag_functions.py
@@ -1,16 +1,24 @@
 #!
 # -*- coding: utf-8 -*-
 """Common functions used in most of the DAGs."""
+import os
 from typing import Optional, Callable, Any, Union
 from airflow.models import Variable
 from airflow.hooks.base import BaseHook
 from airflow.providers.slack.operators.slack_webhook import SlackWebhookOperator
 
+def is_prod_mode() -> bool:
+    """Returns True if the code is running from the PROD ENV directory."""
+    PROD_ENV_PATH = Variable.get("prod_env_path")
+    dags_folder = os.path.dirname(os.path.realpath(__file__))
+    repo_folder = os.path.abspath(os.path.dirname(dags_folder))
+    return os.path.normpath(repo_folder) == os.path.normpath(PROD_ENV_PATH)
+
 def task_fail_slack_alert(
     context: dict,
     extra_msg: Optional[Union[str, Callable[..., str]]] = "",
     use_proxy: Optional[bool] = False,
-    dev_mode: Optional[bool] = False
+    dev_mode: Optional[bool] = None
 ) -> Any:
     """Sends Slack task-failure notifications.
 
@@ -54,12 +62,13 @@ def task_fail_slack_alert(
             servers (default False).
         dev_mode: A boolean to indicate if working in development mode to send
             Slack alerts to data_pipeline_dev instead of the regular 
-            data_pipeline (default False).
+            data_pipeline (default None, to be determined based on the location
+            of the file).
     
     Returns:
         Any: The result of executing the SlackWebhookOperator.
     """
-    if dev_mode:
+    if dev_mode or (dev_mode is None and not is_prod_mode()):
         SLACK_CONN_ID = "slack_data_pipeline_dev"
     else:
         SLACK_CONN_ID = "slack_data_pipeline"


### PR DESCRIPTION
## What this pull request accomplishes:

- Choose the correct Slack channel for failure alerts based on the location of the running DAG. If a DAG is running from the path saved in the Airflow's variable `prod_env_path`, all its failure alerts will be directed to channel `data_pipelines` (also saved in Airflow as `slack_data_pipeline`). All other DAGs under development and running from other locations will send their failure alerts to channel `data_pipelines_dev` (also saved in Airflow as `slack_data_pipeline_dev`).
- You can still override the above rule by setting the argument `dev_mode` while calling the function `dags.dag_functions.task_fail_slack_alert`.
- The ultimate goal is to protect the main Slack channel used to receive failure alerts, `data_pipelines`, from getting flooded with alerts from DAGs under development or being tested.

## Issue(s) this solves:

- closes #750 

## What, in particular, needs to reviewed:

- The file `dags.dag_functions`

## What needs to be done by a sysadmin after this PR is merged

- Update the `data_scripts` folder
