### PR TITLE
#758 consistent join conditions for speed_bins_old + fluff

### DIFF
--- a/wys/api/sql/function-mobile-summary.sql
+++ b/wys/api/sql/function-mobile-summary.sql
@@ -107,7 +107,10 @@ JOIN wys.raw_data AS raw ON
     )
 JOIN wys.speed_bins_old AS sb ON
     raw.speed >= lower(sb.speed_bin)
-    AND raw.speed < upper(sb.speed_bin)
+    AND (
+        raw.speed < upper(sb.speed_bin)
+        OR upper(sb.speed_bin) IS NULL
+    )
 LEFT OUTER JOIN wys.sign_schedules_list AS lst ON lst.api_id = loc.api_id
 LEFT OUTER JOIN wys.sign_schedules_clean AS ssc USING (schedule_name)
 --filter necessary to exclude newer data from still active signs

--- a/wys/api/sql/function-stationary-sign-summary.sql
+++ b/wys/api/sql/function-stationary-sign-summary.sql
@@ -6,7 +6,7 @@ _mon | date | Month whose data to be aggregated
 Return: Void
 Purpose: Summarizes the data of stationary WYS signs for the given month
 */
-CREATE OR REPLACE FUNCTION wys.stationary_summary_for_month (_mon date)
+CREATE OR REPLACE FUNCTION wys.stationary_summary_for_month(_mon date)
 RETURNS void
 LANGUAGE 'sql'
 
@@ -14,7 +14,7 @@ COST 100
 VOLATILE SECURITY DEFINER
 AS $BODY$
 
-SELECT wys.clear_stationary_summary_for_month (_mon);
+SELECT wys.clear_stationary_summary_for_month(_mon);
 
 INSERT INTO wys.stationary_summary
 SELECT 
@@ -39,41 +39,56 @@ SELECT
     percentile_cont(0.85) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_85,
     percentile_cont(0.90) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_90,
     percentile_cont(0.95) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_95,
-    SUM(CASE speed_id WHEN 1 THEN "count" ELSE 0 END) AS   spd_00,
-    SUM(CASE speed_id WHEN 2 THEN "count" ELSE 0 END) AS   spd_05,
-    SUM(CASE speed_id WHEN 3 THEN "count" ELSE 0 END) AS   spd_10,
-    SUM(CASE speed_id WHEN 4 THEN "count" ELSE 0 END) AS   spd_15,
-    SUM(CASE speed_id WHEN 5 THEN "count" ELSE 0 END) AS   spd_20,
-    SUM(CASE speed_id WHEN 6 THEN "count" ELSE 0 END) AS   spd_25,
-    SUM(CASE speed_id WHEN 7 THEN "count" ELSE 0 END) AS   spd_30,
-    SUM(CASE speed_id WHEN 8 THEN "count" ELSE 0 END) AS   spd_35,
-    SUM(CASE speed_id WHEN 9 THEN "count" ELSE 0 END) AS   spd_40,
-    SUM(CASE speed_id WHEN 10 THEN "count" ELSE 0 END) AS   spd_45,
-    SUM(CASE speed_id WHEN 11 THEN "count" ELSE 0 END) AS   spd_50,
-    SUM(CASE speed_id WHEN 12 THEN "count" ELSE 0 END) AS   spd_55,
-    SUM(CASE speed_id WHEN 13 THEN "count" ELSE 0 END) AS   spd_60,
-    SUM(CASE speed_id WHEN 14 THEN "count" ELSE 0 END) AS   spd_65,
-    SUM(CASE speed_id WHEN 15 THEN "count" ELSE 0 END) AS   spd_70,
-    SUM(CASE speed_id WHEN 16 THEN "count" ELSE 0 END) AS   spd_75,
-    SUM(CASE speed_id WHEN 17 THEN "count" ELSE 0 END) AS   spd_80,
-    SUM(CASE speed_id WHEN 18 THEN "count" ELSE 0 END) AS   spd_85,
-    SUM(CASE speed_id WHEN 19 THEN "count" ELSE 0 END) AS   spd_90,
-    SUM(CASE speed_id WHEN 20 THEN "count" ELSE 0 END) AS   spd_95,
-    SUM(CASE speed_id WHEN 21 THEN "count" ELSE 0 END) AS   spd_100_and_above,
+    SUM(CASE sb.speed_id WHEN 1 THEN "count" ELSE 0 END) AS spd_00,
+    SUM(CASE sb.speed_id WHEN 2 THEN "count" ELSE 0 END) AS spd_05,
+    SUM(CASE sb.speed_id WHEN 3 THEN "count" ELSE 0 END) AS spd_10,
+    SUM(CASE sb.speed_id WHEN 4 THEN "count" ELSE 0 END) AS spd_15,
+    SUM(CASE sb.speed_id WHEN 5 THEN "count" ELSE 0 END) AS spd_20,
+    SUM(CASE sb.speed_id WHEN 6 THEN "count" ELSE 0 END) AS spd_25,
+    SUM(CASE sb.speed_id WHEN 7 THEN "count" ELSE 0 END) AS spd_30,
+    SUM(CASE sb.speed_id WHEN 8 THEN "count" ELSE 0 END) AS spd_35,
+    SUM(CASE sb.speed_id WHEN 9 THEN "count" ELSE 0 END) AS spd_40,
+    SUM(CASE sb.speed_id WHEN 10 THEN "count" ELSE 0 END) AS spd_45,
+    SUM(CASE sb.speed_id WHEN 11 THEN "count" ELSE 0 END) AS spd_50,
+    SUM(CASE sb.speed_id WHEN 12 THEN "count" ELSE 0 END) AS spd_55,
+    SUM(CASE sb.speed_id WHEN 13 THEN "count" ELSE 0 END) AS spd_60,
+    SUM(CASE sb.speed_id WHEN 14 THEN "count" ELSE 0 END) AS spd_65,
+    SUM(CASE sb.speed_id WHEN 15 THEN "count" ELSE 0 END) AS spd_70,
+    SUM(CASE sb.speed_id WHEN 16 THEN "count" ELSE 0 END) AS spd_75,
+    SUM(CASE sb.speed_id WHEN 17 THEN "count" ELSE 0 END) AS spd_80,
+    SUM(CASE sb.speed_id WHEN 18 THEN "count" ELSE 0 END) AS spd_85,
+    SUM(CASE sb.speed_id WHEN 19 THEN "count" ELSE 0 END) AS spd_90,
+    SUM(CASE sb.speed_id WHEN 20 THEN "count" ELSE 0 END) AS spd_95,
+    SUM(CASE sb.speed_id WHEN 21 THEN "count" ELSE 0 END) AS spd_100_and_above,
     SUM("count") AS volume,
     raw.api_id
 FROM wys.raw_data raw
-INNER JOIN wys.stationary_signs sign ON raw.api_id = sign.api_id
-                                     AND (prev_start IS NULL OR datetime_bin >= start_date) 
-                                     AND (next_start IS NULL OR 
-                                          datetime_bin < next_start)
-INNER JOIN wys.speed_bins_old ON speed <@ speed_bin
-WHERE datetime_bin >= _mon AND datetime_bin < _mon + INTERVAL '1 month'
-GROUP BY sign_id, mon, raw.api_id;
+INNER JOIN wys.stationary_signs sign ON
+    raw.api_id = sign.api_id
+    AND (
+        prev_start IS NULL
+        OR datetime_bin >= start_date
+    ) AND (
+        next_start IS NULL
+        OR datetime_bin < next_start
+    )
+JOIN wys.speed_bins_old AS sb ON
+    raw.speed >= lower(sb.speed_bin)
+    AND (
+        raw.speed < upper(sb.speed_bin)
+        OR upper(sb.speed_bin) IS NULL
+    )
+WHERE
+    datetime_bin >= _mon
+    AND datetime_bin < _mon + interval '1 month'
+GROUP BY
+    sign_id,
+    mon,
+    raw.api_id;
 
 $BODY$;
 
 ALTER FUNCTION wys.stationary_summary_for_month(date) OWNER TO wys_admins;
 
-REVOKE EXECUTE ON FUNCTION wys.stationary_summary_for_month (date) FROM public;
-GRANT EXECUTE ON FUNCTION wys.stationary_summary_for_month (date) TO wys_bot;
+REVOKE EXECUTE ON FUNCTION wys.stationary_summary_for_month(date) FROM public;
+GRANT EXECUTE ON FUNCTION wys.stationary_summary_for_month(date) TO wys_bot;


### PR DESCRIPTION
## What this pull request accomplishes:
- Fixes a bug in the join conditions to `wys.speed_bins_old` in `wys.mobile_summary_for_month` function.
- Unifies the join conditions in all 3 instances where we join to this table
- sql fluff 

## Issue(s) this solves:
- #758

## What, in particular, needs to reviewed:
- 

## What needs to be done by a sysadmin after this PR is merged
- [ ] Update the 3 function definitions. 
- [ ] Clear and backfill the entire `wys.mobile_summary` table (sql below) with nohup

```sql
TRUNCATE TABLE wys.mobile_summary;

WITH active_mobile_signs AS (
    SELECT location_id, api_id, installation_date, removal_date
    FROM wys.mobile_api_id
    WHERE installation_date < '2023-11-01'::date
)

INSERT INTO wys.mobile_summary
    (location_id, ward_no, location, from_street, to_street, direction, installation_date, removal_date, days_with_data, max_date, schedule, min_speed, pct_05, pct_10, pct_15, pct_20, pct_25, pct_30, pct_35, pct_40, pct_45, pct_50, pct_55, pct_60, pct_65, pct_70, pct_75, pct_80, pct_85, pct_90, pct_95, spd_00, spd_05, spd_10, spd_15, spd_20, spd_25, spd_30, spd_35, spd_40, spd_45, spd_50, spd_55, spd_60, spd_65, spd_70, spd_75, spd_80, spd_85, spd_90, spd_95, spd_100_and_above, volume)
SELECT 
    loc.location_id,
    loc.ward_no,
    loc.location,
    loc.from_street,
    loc.to_street,
    loc.direction,
    loc.installation_date,
    --if sign is removed after EOM, we are excluding that data, so we should not show 
    --removal date in the "future" with respect to Open Data month
    CASE
        WHEN loc.removal_date >= date_trunc('month', now()) THEN null
        ELSE loc.removal_date
    END AS removal_date,
    COUNT(DISTINCT raw.datetime_bin::date) AS days_with_data,
    MAX(raw.datetime_bin::date) AS max_date, 
    ssc.schedule,
    ssc.min_speed,
    percentile_cont(0.05) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_05,
    percentile_cont(0.10) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_10,
    percentile_cont(0.15) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_15,
    percentile_cont(0.20) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_20,
    percentile_cont(0.25) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_25,
    percentile_cont(0.30) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_30,
    percentile_cont(0.35) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_35,
    percentile_cont(0.40) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_40,
    percentile_cont(0.45) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_45,
    percentile_cont(0.50) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_50,
    percentile_cont(0.55) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_55,
    percentile_cont(0.60) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_60,
    percentile_cont(0.65) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_65,
    percentile_cont(0.70) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_70,
    percentile_cont(0.75) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_75,
    percentile_cont(0.80) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_80,
    percentile_cont(0.85) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_85,
    percentile_cont(0.90) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_90,
    percentile_cont(0.95) WITHIN GROUP (ORDER BY (raw.speed))::INT AS pct_95,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 1) AS spd_00,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 2) AS spd_05,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 3) AS spd_10,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 4) AS spd_15,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 5) AS spd_20,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 6) AS spd_25,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 7) AS spd_30,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 8) AS spd_35,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 9) AS spd_40,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 10) AS spd_45,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 11) AS spd_50,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 12) AS spd_55,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 13) AS spd_60,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 14) AS spd_65,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 15) AS spd_70,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 16) AS spd_75,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 17) AS spd_80,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 18) AS spd_85,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 19) AS spd_90,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 20) AS spd_95,
    SUM(raw.count) FILTER (WHERE sb.speed_id = 21) AS spd_100_and_above,
    SUM(raw.count) AS volume
FROM wys.mobile_api_id AS loc
JOIN active_mobile_signs AS ams USING (location_id, api_id, installation_date)
JOIN wys.raw_data AS raw ON
    ams.api_id = raw.api_id 
    AND raw.datetime_bin > ams.installation_date 
    AND (
        raw.datetime_bin < ams.removal_date
        OR ams.removal_date IS NULL --change to allow still active signs to be included
    )
JOIN wys.speed_bins_old AS sb ON
    raw.speed >= lower(sb.speed_bin)
    AND (
        raw.speed < upper(sb.speed_bin)
        OR upper(sb.speed_bin) IS NULL
    )
LEFT OUTER JOIN wys.sign_schedules_list AS lst ON lst.api_id = loc.api_id
LEFT OUTER JOIN wys.sign_schedules_clean AS ssc USING (schedule_name)
--filter necessary to exclude newer data from still active signs
WHERE raw.datetime_bin < date_trunc('month', now())
GROUP BY
    loc.location_id,
    loc.ward_no,
    loc.location,
    loc.from_street, 
    loc.to_street,
    loc.direction,
    loc.installation_date, 
    loc.removal_date,
    ssc.schedule,
    ssc.min_speed;
```