### PR TITLE
Copy tables comments in replicator DAGs

### DIFF
--- a/dags/common_tasks.py
+++ b/dags/common_tasks.py
@@ -38,7 +38,7 @@ def get_variable(var_name:str) -> list:
     return Variable.get(var_name, deserialize_json=True)
 
 @task()
-def copy_table(conn_id:str, table:Tuple[str, str]) -> None:
+def copy_table(conn_id:str, table:Tuple[str, str], **context) -> None:
     """Copies ``table[0]`` table into ``table[1]`` after truncating it.
 
     Args:
@@ -47,6 +47,12 @@ def copy_table(conn_id:str, table:Tuple[str, str]) -> None:
             ``schema.table``, and the destination table in the same format
             ``schema.table``.
     """
+    # push an extra failure message to be sent to Slack in case of failing
+    context["task_instance"].xcom_push(
+        "extra_msg",
+        f"Failed to copy `{table[0]}` to `{table[1]}`."
+    )
+    # separate tables and schemas
     try:
         src_schema, src_table = table[0].split(".")
     except ValueError:

--- a/dags/dag_functions.py
+++ b/dags/dag_functions.py
@@ -75,16 +75,16 @@ def task_fail_slack_alert(
     else:
         SLACK_CONN_ID = "slack_data_pipeline"
 
+    task_instance = context["task_instance"]
     slack_ids = Variable.get("slack_member_id", deserialize_json=True)
     owners = context.get('dag').owner.split(',')
     list_names = " ".join([slack_ids.get(name, name) for name in owners])
     # get the extra message from the calling task, if provided
-    extra_msg_from_task = context.get(
-        "task_instance"
-        ).xcom_pull(
-            task_ids=context.get('task_instance').task_id,
+    extra_msg_from_task = task_instance.xcom_pull(
+            task_ids=task_instance.task_id,
+            map_indexes=task_instance.map_index,
             key="extra_msg"
-        )[0]
+        )
 
     if callable(extra_msg):
         # in case of function

--- a/dags/dag_functions.py
+++ b/dags/dag_functions.py
@@ -100,8 +100,8 @@ def task_fail_slack_alert(
     if use_proxy:
         # Temporarily accessing Airflow on Morbius through 8080 instead of Nginx
         # Its hould be eventually removed
-        log_url = context.get("task_instance").log_url.replace(
-            "localhost", context.get("task_instance").hostname + ":8080"
+        log_url = task_instance.log_url.replace(
+            "localhost", task_instance.hostname + ":8080"
         )
         # get the proxy credentials from the Airflow connection ``slack``. It
         # contains username and password to set the proxy <username>:<password>
@@ -110,13 +110,13 @@ def task_fail_slack_alert(
             f"@{json.loads(BaseHook.get_connection('slack').extra)['url']}"
         )
     else:
-        log_url = context.get("task_instance").log_url.replace(
-            "localhost", context.get("task_instance").hostname
+        log_url = task_instance.log_url.replace(
+            "localhost", task_instance.hostname
         )
         proxy = None
     slack_msg = (
-        f":red_circle: {context.get('task_instance').dag_id}."
-        f"{context.get('task_instance').task_id} "
+        f":red_circle: {task_instance.dag_id}."
+        f"{task_instance.task_id} "
         f"({context.get('ts_nodash_with_tz')}) FAILED.\n"
         f"{list_names}, please, check the <{log_url}|logs>\n"
         f"{extra_msg_str}"


### PR DESCRIPTION
## What this pull request accomplishes:

-  Copy comments on tables while copying the actual contents in replicator DAGs
- Specify which table failed to get copied in the Slack notification

## Issue(s) this solves:

- Closes #786 

## What, in particular, needs to reviewed:

- An added sql query to `copy_table`
- An extra option to send the extra failure message

## What needs to be done by a sysadmin after this PR is merged

- Deploy into data_scripts
