### PR TITLE
788 `pull_miovision.check_partitions.create_month_partition` jinja templating bug

### DIFF
--- a/dags/pull_miovision.py
+++ b/dags/pull_miovision.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from airflow.operators.bash_operator import BashOperator
 from airflow.models import Variable 
 from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.macros import ds_format
 
 repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 sys.path.insert(0, repo_path)
@@ -41,9 +42,9 @@ def pull_miovision_dag():
 
     #this task group checks if necessary to create new partitions and if so, exexcute.
     @task_group
-    def check_partitions():
-        YEAR = '''{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'''
-        MONTH = '''{{ macros.ds_format(ds, '%Y-%m-%d', '%m') }}'''
+    def check_partitions(ds=None):
+        YEAR = ds_format(ds, '%Y-%m-%d', '%Y')
+        MONTH = ds_format(ds, '%Y-%m-%d', '%m')
 
         @task.short_circuit(ignore_downstream_trigger_rules=False) #only skip immediately downstream task
         def check_annual_partition(ds=None): #check if Jan 1 to trigger partition creates. 

--- a/dags/pull_miovision.py
+++ b/dags/pull_miovision.py
@@ -42,8 +42,8 @@ def pull_miovision_dag():
     #this task group checks if necessary to create new partitions and if so, exexcute.
     @task_group
     def check_partitions():
-        YEAR = '{{ macros.ds_format(ds, "%Y-%m-%d", "%Y") }}'
-        MONTH = '{{ macros.ds_format(ds, "%Y-%m-%d", "%m") }}'
+        YEAR = '''{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'''
+        MONTH = '''{{ macros.ds_format(ds, '%Y-%m-%d', '%m') }}'''
 
         @task.short_circuit(ignore_downstream_trigger_rules=False) #only skip immediately downstream task
         def check_annual_partition(ds=None): #check if Jan 1 to trigger partition creates. 

--- a/dags/pull_miovision.py
+++ b/dags/pull_miovision.py
@@ -54,9 +54,9 @@ def pull_miovision_dag():
       
         create_annual_partition = PostgresOperator(
             task_id='create_annual_partitions',
-            sql=["SELECT miovision_api.create_yyyy_volumes_partition('volumes', {{ params.year }}::int, 'datetime_bin')",
-                 "SELECT miovision_api.create_yyyy_volumes_15min_partition('volumes_15min', {{ params.year }}::int)",
-                 "SELECT miovision_api.create_yyyy_volumes_15min_partition('volumes_15min_mvt', {{ params.year }}::int)"],
+            sql=["SELECT miovision_api.create_yyyy_volumes_partition('volumes', '{{ params.year }}'::int, 'datetime_bin')",
+                 "SELECT miovision_api.create_yyyy_volumes_15min_partition('volumes_15min', '{{ params.year }}'::int)",
+                 "SELECT miovision_api.create_yyyy_volumes_15min_partition('volumes_15min_mvt', '{{ params.year }}'::int)"],
             postgres_conn_id='miovision_api_bot',
             params={"year": YEAR},
             autocommit=True
@@ -71,7 +71,7 @@ def pull_miovision_dag():
         
         create_month_partition = PostgresOperator(
             task_id='create_month_partition',
-            sql="SELECT miovision_api.create_mm_nested_volumes_partition('volumes', {{ params.year }}::int, {{ params.month }}::int)",
+            sql="SELECT miovision_api.create_mm_nested_volumes_partition('volumes', '{{ params.year }}'::int, '{{ params.month }}'::int)",
             postgres_conn_id='miovision_api_bot',
             params={"year": YEAR,
                     "month": MONTH},

--- a/dags/vds_pull_vdsdata.py
+++ b/dags/vds_pull_vdsdata.py
@@ -96,11 +96,11 @@ with DAG(dag_name,
         create_partitions = PostgresOperator(
             task_id='create_partitions',
             sql=[#partition by year and month:
-                "SELECT vds.partition_vds_yyyymm('raw_vdsdata_div8001', {{ params.year }}::int, 'dt')",
-                "SELECT vds.partition_vds_yyyymm('raw_vdsdata_div2', {{ params.year }}::int, 'dt')",
+                "SELECT vds.partition_vds_yyyymm('raw_vdsdata_div8001', '{{ params.year }}'::int, 'dt')",
+                "SELECT vds.partition_vds_yyyymm('raw_vdsdata_div2', '{{ params.year }}'::int, 'dt')",
                 #partition by year only: 
-                "SELECT vds.partition_vds_yyyy('counts_15min_div2', {{ params.year }}::int, 'datetime_15min')",
-                "SELECT vds.partition_vds_yyyy('counts_15min_bylane_div2', {{ params.year }}::int, 'datetime_15min')"],
+                "SELECT vds.partition_vds_yyyy('counts_15min_div2', '{{ params.year }}'::int, 'datetime_15min')",
+                "SELECT vds.partition_vds_yyyy('counts_15min_bylane_div2', '{{ params.year }}'::int, 'datetime_15min')"],
             postgres_conn_id='vds_bot',
             params={"year": YEAR},
             autocommit=True

--- a/dags/vds_pull_vdsdata.py
+++ b/dags/vds_pull_vdsdata.py
@@ -90,19 +90,16 @@ with DAG(dag_name,
             if start_date.month == 1 and start_date.day == 1:
                 return True
             return False
-
-        YEAR = '{{ macros.ds_format(ds, "%Y-%m-%d", "%Y") }}'
         
         create_partitions = PostgresOperator(
             task_id='create_partitions',
             sql=[#partition by year and month:
-                "SELECT vds.partition_vds_yyyymm('raw_vdsdata_div8001', '{{ params.year }}'::int, 'dt')",
-                "SELECT vds.partition_vds_yyyymm('raw_vdsdata_div2', '{{ params.year }}'::int, 'dt')",
+                "SELECT vds.partition_vds_yyyymm('raw_vdsdata_div8001', '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, 'dt')",
+                "SELECT vds.partition_vds_yyyymm('raw_vdsdata_div2', '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, 'dt')",
                 #partition by year only: 
-                "SELECT vds.partition_vds_yyyy('counts_15min_div2', '{{ params.year }}'::int, 'datetime_15min')",
-                "SELECT vds.partition_vds_yyyy('counts_15min_bylane_div2', '{{ params.year }}'::int, 'datetime_15min')"],
+                "SELECT vds.partition_vds_yyyy('counts_15min_div2', '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, 'datetime_15min')",
+                "SELECT vds.partition_vds_yyyy('counts_15min_bylane_div2', '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, 'datetime_15min')"],
             postgres_conn_id='vds_bot',
-            params={"year": YEAR},
             autocommit=True
         )
 

--- a/dags/vds_pull_vdsvehicledata.py
+++ b/dags/vds_pull_vdsvehicledata.py
@@ -82,7 +82,7 @@ with DAG(dag_id='vds_pull_vdsvehicledata',
 
         create_partitions = PostgresOperator(
             task_id='create_partitions',
-            sql="SELECT vds.partition_vds_yyyymm('raw_vdsvehicledata', {{ params.year }}::int, 'dt')",
+            sql="SELECT vds.partition_vds_yyyymm('raw_vdsvehicledata', '{{ params.year }}'::int, 'dt')",
             postgres_conn_id='vds_bot',
             params={"year": YEAR},
             autocommit=True

--- a/dags/vds_pull_vdsvehicledata.py
+++ b/dags/vds_pull_vdsvehicledata.py
@@ -78,13 +78,10 @@ with DAG(dag_id='vds_pull_vdsvehicledata',
                 return True
             return False
 
-        YEAR = '{{ macros.ds_format(ds, "%Y-%m-%d", "%Y") }}'
-
         create_partitions = PostgresOperator(
             task_id='create_partitions',
-            sql="SELECT vds.partition_vds_yyyymm('raw_vdsvehicledata', '{{ params.year }}'::int, 'dt')",
+            sql="SELECT vds.partition_vds_yyyymm('raw_vdsvehicledata', '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, 'dt')",
             postgres_conn_id='vds_bot',
-            params={"year": YEAR},
             autocommit=True
         )
 


### PR DESCRIPTION
## What this pull request accomplishes:
- Small bug fix across 3 DAGs with new partitioning tasks: jinja templating doesn't work in params of PostgresOperator. 

## Issue(s) this solves:
- #788

## What, in particular, needs to reviewed:


## What needs to be done by a sysadmin after this PR is merged
- [Tested](https://trans-bdit.intra.prod-toronto.ca/airflow/dags/pull_miovision/grid?dag_run_id=scheduled__2023-12-01T08%3A00%3A00%2B00%3A00&task_id=check_partitions.create_month_partition&tab=logs) ~~We should test `pull_miovision` before merging (the other ones will only run on 2024/1/1).~~