### PR TITLE
833 regtype bug in publicsummarize gaps data check

### DIFF
--- a/dags/miovision_check.py
+++ b/dags/miovision_check.py
@@ -87,8 +87,7 @@ def miovision_check_dag():
                 sch_name := 'miovision_api'::text,
                 tbl_name := 'volumes'::text,
                 gap_threshold := '4 hours'::interval,
-                default_bin := '1 minute'::interval,
-                id_col_dtype := null::int
+                default_bin := '1 minute'::interval
             )""",
         conn_id="miovision_api_bot"
     )

--- a/dags/sql/create-function-summarize_gaps_data_check.sql
+++ b/dags/sql/create-function-summarize_gaps_data_check.sql
@@ -7,8 +7,7 @@ CREATE OR REPLACE FUNCTION public.summarize_gaps_data_check(
     sch_name text,
     tbl_name text,
     gap_threshold interval,
-    default_bin interval,
-    id_col_dtype anyelement DEFAULT NULL::text
+    default_bin interval
 )
 RETURNS TABLE (
     _check boolean, summ text, gaps text []
@@ -31,7 +30,7 @@ BEGIN
                 %L::text, --tbl_name
                 %L::interval, --gap_threshold
                 %L::interval, --default_bin
-                %L::regtype --id_col_dtype
+                null::text --id_col_dtype
             )
         )
 
@@ -44,8 +43,7 @@ BEGIN
             array_agg(summarized_gaps || chr(10)) AS gaps
         FROM summarized_gaps
     $$,
-    start_date, end_date, id_col, dt_col, sch_name, tbl_name, gap_threshold, default_bin, id_col_dtype,
-        gap_threshold
+    start_date, end_date, id_col, dt_col, sch_name, tbl_name, gap_threshold, default_bin, gap_threshold
     );
 END;
 $BODY$;


### PR DESCRIPTION
## What this pull request accomplishes:
- removes `id_col_dtype` param from `public.summarize_gaps_data_check`. Replace with always passing `null::text` to `generic_find_gaps` when summarizing.  

## Issue(s) this solves:
- #833 

## What, in particular, needs to reviewed:
- Tested in gwolofs schema. Working! 

## What needs to be done by a sysadmin after this PR is merged
- DELETE FUNCTION public.summarize_gaps_data_check;
- replace with new function from: dags/sql/create-function-summarize_gaps_data_check.sql
- update `miovision_check` DAG