### PR TITLE
838 missing uid defaults in miovision aggregate tables

### DIFF
--- a/volumes/miovision/README.md
+++ b/volumes/miovision/README.md
@@ -172,7 +172,7 @@ The [`aggregate_15_min_mvt()`](sql/function/function-aggregate-volumes_15min_mvt
 
 **Field Name**|**Data Type**|**Description**|**Example**|
 :-----|:-----|:-----|:-----|
-volume_15min_mvt_uid|serial|Unique identifier for table|14524|
+volume_15min_mvt_uid|integer|Unique identifier for table from sequence `miovision_api.volumes_15min_mvt_volume_15min_mvt_uid_seq`. |14524|
 intersection_uid|integer|Identifier linking to specific intersection stored in `intersections`|31|
 datetime_bin|timestamp without time zone|Start of 15-minute time bin in EDT|2017-12-11 14:15:00|
 classification_uid|text|Identifier linking to specific mode class stored in `classifications`|1|
@@ -207,7 +207,7 @@ diagram](getting_started.md#From-Movement-Counts-to-Segment-Counts).
 
 **Field Name**|**Data Type**|**Description**|**Example**|
 :-----|:-----|:-----|:-----|
-volume_15min_uid|serial|Unique identifier for table|12412|
+volume_15min_uid|integer|Unique identifier for table from sequence `miovision_api.volumes_15min_volume_15min_uid_seq`. |12412|
 intersection_uid|integer|Identifier linking to specific intersection stored in `intersections`|31|
 datetime_bin|timestamp without time zone|Start of 15-minute time bin in EDT|2017-12-11 14:15:00|
 classification_uid|text|Identifier linking to specific mode class stored in `classifications`|1|

--- a/volumes/miovision/sql/table/create-table-volumes_15min.sql
+++ b/volumes/miovision/sql/table/create-table-volumes_15min.sql
@@ -3,7 +3,7 @@
 -- DROP TABLE miovision_api.volumes_15min;
 CREATE TABLE miovision_api.volumes_15min
 (
-    volume_15min_uid serial NOT NULL,
+    volume_15min_uid integer NOT NULL DEFAULT nextval('miovision_api.volumes_15min_volume_15min_uid_seq'::regclass),
     intersection_uid integer,
     datetime_bin timestamp without time zone,
     classification_uid integer,

--- a/volumes/miovision/sql/table/create-table-volumes_15min_mvt.sql
+++ b/volumes/miovision/sql/table/create-table-volumes_15min_mvt.sql
@@ -1,6 +1,6 @@
 ﻿CREATE TABLE miovision_api.volumes_15min_mvt
 (
-    volume_15min_mvt_uid serial NOT NULL,
+    volume_15min_mvt_uid integer NOT NULL DEFAULT nextval('miovision_api.volumes_15min_mvt_volume_15min_mvt_uid_seq'::regclass),
     intersection_uid integer,
     datetime_bin timestamp without time zone,
     classification_uid integer,
@@ -55,6 +55,12 @@ USING btree (
 CREATE INDEX volumes_15min_mvt_volume_15min_mvt_uid_idx
 ON miovision_api.volumes_15min_mvt
 USING btree (volume_15min_mvt_uid ASC NULLS LAST);
+
+-- Index: volumes_15min_mvt_processed_idx
+-- DROP INDEX IF EXISTS miovision_api.volumes_15min_mvt_processed_idx;
+CREATE INDEX IF NOT EXISTS volumes_15min_mvt_processed_idx
+ON miovision_api.volumes_15min_mvt USING btree (processed ASC NULLS LAST)
+WHERE processed IS NULL;
 
 --create yearly partitions
 SELECT miovision_api.create_yyyy_volumes_15min_partition('volumes_15min_mvt', 2019::int);


### PR DESCRIPTION
## What this pull request accomplishes:
- Adds missing uid defaults to `miovision_api.volumes_15min`  and `miovision_api.volumes_15min_mvt`
- Add to github definition missing index on `miovision_api.volumes_15min_mvt` column `processed`.

## Issue(s) this solves:
- #838 

## What, in particular, needs to reviewed:


## What needs to be done by a sysadmin after this PR is merged
Nothing - changes are to reflect what exists in bigdata.