### PR TITLE
#843 revise data check to report ongoing outages

### DIFF
--- a/dags/miovision_check.py
+++ b/dags/miovision_check.py
@@ -44,7 +44,10 @@ default_args = {
     default_args=default_args,
     schedule='0 4 * * *', # Run at 4 AM local time every day
     catchup=False,
-    template_searchpath=os.path.join(repo_path,'dags/sql'),
+    template_searchpath=[
+        os.path.join(repo_path,'volumes/miovision/sql/data_checks'),
+        os.path.join(repo_path,'dags/sql')
+    ],
     tags=["miovision", "data_checks"],
     doc_md=__doc__
 )
@@ -61,15 +64,12 @@ def miovision_check_dag():
     )
 
     check_distinct_intersection_uid = SQLCheckOperatorWithReturnValue(
-        task_id="check_distinct_intersection_uid",
-        sql="select-sensor_id_count_lookback.sql",
+        task_id="check_intersection_outages",
+        sql="select-ongoing_intersection_outages.sql",
         conn_id="miovision_api_bot",
         params={
-            "table": "miovision_api.volumes_15min_mvt",
             "lookback": '60 days',
-            "dt_col": 'datetime_bin',
-            "id_col": "intersection_uid",
-            "threshold": 0.999 #dif is floored, so this will catch a dif of 1.
+            "min_duration": '0 days'
         }
     )
     check_distinct_intersection_uid.doc_md = '''

--- a/volumes/miovision/sql/data_checks/select-ongoing_intersection_outages.sql
+++ b/volumes/miovision/sql/data_checks/select-ongoing_intersection_outages.sql
@@ -1,0 +1,23 @@
+WITH ongoing_outages AS (
+    SELECT
+        i.intersection_name || ' (uid: ' || i.intersection_uid || ') - data last received: '
+            || MAX(v.datetime_bin::date) || ' (' || '{{ ds }} 00:00:00'::timestamp - MAX(v.datetime_bin::date) || ')' AS description
+    FROM miovision_api.volumes AS v
+    JOIN miovision_api.intersections AS i USING (intersection_uid)
+    WHERE
+        v.datetime_bin >= '{{ ds }} 00:00:00'::timestamp - interval '{{ params.lookback }}'
+        AND v.datetime_bin < '{{ ds }} 00:00:00'::timestamp + interval '1 day'
+    GROUP BY
+        i.intersection_uid,
+        i.intersection_name
+    HAVING MAX(v.datetime_bin::date) < '{{ ds }} 00:00:00'::timestamp - interval '{{ params.min_duration }}'
+)
+
+SELECT
+    COUNT(ongoing_outages.*) > 1 AS check,
+    CASE WHEN COUNT(ongoing_outages.*) = 1 THEN 'There is ' ELSE 'There are ' END ||
+        COALESCE(COUNT(ongoing_outages.*), 0) ||
+        CASE WHEN COUNT(ongoing_outages.*) = 1 THEN ' ongoing outage.' ELSE ' ongoing outages.'
+    END AS summ, --gap_threshold
+    array_agg(ongoing_outages.description || chr(10)) AS gaps
+FROM ongoing_outages

--- a/volumes/miovision/sql/data_checks/select-ongoing_intersection_outages.sql
+++ b/volumes/miovision/sql/data_checks/select-ongoing_intersection_outages.sql
@@ -14,7 +14,7 @@ WITH ongoing_outages AS (
 )
 
 SELECT
-    COUNT(ongoing_outages.*) > 1 AS check,
+    COUNT(ongoing_outages.*) < 1 AS check,
     CASE WHEN COUNT(ongoing_outages.*) = 1 THEN 'There is ' ELSE 'There are ' END ||
         COALESCE(COUNT(ongoing_outages.*), 0) ||
         CASE WHEN COUNT(ongoing_outages.*) = 1 THEN ' ongoing outage.' ELSE ' ongoing outages.'


### PR DESCRIPTION
## What this pull request accomplishes:

- Revises distinct Miovision intersection data check to provide more detail (name, duration, last received), eg: 

```
{"Front / Spadina (uid: 6) - data last received: 2024-01-22 (1 day)",
"Front / Bay (uid: 7) - data last received: 2023-12-30 (24 days)", 
"Jane Street and Wilson Avenue (uid: 62) - data last received: 2023-12-28 (26 days)"
}
```

## Issue(s) this solves:
- #843

## What, in particular, needs to reviewed:
- Should we add adjust `min_duration` param to 1 day so we don't hear about outages until 2nd day?

## What needs to be done by a sysadmin after this PR is merged

