### PR TITLE
835 add agg param to miovision run api

### DIFF
--- a/dags/miovision_pull.py
+++ b/dags/miovision_pull.py
@@ -110,7 +110,7 @@ def pull_miovision_dag():
         mio_postgres = PostgresHook("miovision_api_bot")
 
         with mio_postgres.get_conn() as conn:
-            pull_data(conn, start_time, end_time, INTERSECTION, True, key)
+            pull_data(conn, start_time, end_time, INTERSECTION, key)
 
     @task_group(tooltip="Tasks to aggregate newly pulled Miovision data.")
     def miovision_agg():

--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -92,10 +92,10 @@ def run_api(start_date, end_date, path, intersection, pull, agg):
 
     start_time = dateutil.parser.parse(str(start_date))
     end_time = dateutil.parser.parse(str(end_date))
-    logger.info('Pulling from %s to %s' %(start_time, end_time))
 
     if pull:
         try:
+            logger.info('Pulling from %s to %s' %(start_time, end_time))
             pull_data(conn, start_time, end_time, intersection, key)
         except Exception as e:
             logger.critical(traceback.format_exc())
@@ -104,7 +104,9 @@ def run_api(start_date, end_date, path, intersection, pull, agg):
         logger.info('Skipping pulling volume data.')
 
     if agg:
-        process_data(conn, start_time, end_time, intersections=intersection)
+        logger.info('Aggregating data from %s to %s' %(start_time, end_time))
+        intersections = get_intersection_info(conn, intersection)
+        process_data(conn, start_time, end_time, intersections=intersections)
     else:
         logger.info('Skipping aggregating and processing volume data')
 


### PR DESCRIPTION
## What this pull request accomplishes:

- changed the cli params to: `pull` (flag to pull data) and `agg` (flag to aggregate data).
- this will help when adding new intersections (easily run all the clear/aggregate commands in one line, separate from pulling).

Tested this successfully for multiple dates/intersections: 

```
(airflow_venv) XXX@ip-XXX:~/bdit_data-sources/volumes/miovision/api$ python3 intersection_tmc.py run-api --path='/data/airflow/data_scripts/volumes/miovision/api/config.cfg' --agg --intersection=71 --intersection=72 --start_date=2024-01-01 --end_date=2024-01-10
01 Feb 2024 14:00:08            INFO    Skipping pulling volume data.
01 Feb 2024 14:00:08            INFO    Aggregating data from 2024-01-01 00:00:00 to 2024-01-10 00:00:00
01 Feb 2024 14:02:15            INFO    NOTICE:  Found a total of 934 gaps that are unacceptable

01 Feb 2024 14:02:15            INFO    Updated gapsize table and found gaps exceeding allowable size
01 Feb 2024 14:02:26            INFO    Aggregated intersections [71, 72] to 15 minute movement bins
01 Feb 2024 14:02:32            INFO    Completed aggregating intersections [71, 72] into miovision_api.volumes_15min for 2024-01-01 00:00:00 to 2024-01-10 00:00:00
01 Feb 2024 14:02:35            INFO    Aggregation into miovision_api.volumes_daily table complete for 2024-01-01 00:00:00 to 2024-01-10 00:00:00
01 Feb 2024 14:02:35            INFO    report_dates done
```

## Issue(s) this solves:
- #835 

## What, in particular, needs to reviewed:
- 

## What needs to be done by a sysadmin after this PR is merged
- will update the readme for run_api as part of #836 because I already made extensive changes to that section in that PR.
