### PR TITLE
#856 change trigger rules of create_month_partition

### DIFF
--- a/dags/miovision_pull.py
+++ b/dags/miovision_pull.py
@@ -87,7 +87,8 @@ def pull_miovision_dag():
             task_id='create_month_partition',
             sql="""SELECT miovision_api.create_mm_nested_volumes_partitions('volumes'::text, '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, '{{ macros.ds_format(ds, '%Y-%m-%d', '%m') }}'::int)""",
             postgres_conn_id='miovision_api_bot',
-            autocommit=True
+            autocommit=True,
+            trigger_rule='none_failed_min_one_success'
         )
 
         check_jan_1st.override(task_id="check_annual_partition")() >> create_annual_partition >> (

--- a/dags/pull_wys.py
+++ b/dags/pull_wys.py
@@ -94,6 +94,7 @@ def pull_wys_dag():
         
         create_month_partition = PostgresOperator(
             task_id='create_month_partition',
+            trigger_rule='none_failed_min_one_success',
             sql="SELECT wys.create_mm_nested_raw_data_partitions('{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, '{{ macros.ds_format(ds, '%Y-%m-%d', '%m') }}'::int)",
             postgres_conn_id='wys_bot',
             autocommit=True


### PR DESCRIPTION
## What this pull request accomplishes:
Fixes the trigger rules of `create_month_partition` task in `pull_wys` and `miovision_check` by changing to `none_failed_min_one_success`. 

## Issue(s) this solves:

- #856 

## What, in particular, needs to reviewed:

- We should test this change before merging.

## What needs to be done by a sysadmin after this PR is merged
