### PR TITLE
#860 update join conditions for null classification case

### DIFF
--- a/volumes/miovision/sql/function/function-identify-zero-counts.sql
+++ b/volumes/miovision/sql/function/function-identify-zero-counts.sql
@@ -101,13 +101,16 @@ BEGIN
         new_gaps.intersection_uid = updated_values.intersection_uid
         AND COALESCE(new_gaps.classification_uid, 0) = COALESCE(updated_values.classification_uid, 0)
         AND new_gaps.range_start = updated_values.range_start
-    --anti join existing open ended/overlapping gaps
+    --anti join with existing open ended/overlapping gaps
     LEFT JOIN miovision_api.anomalous_ranges AS existing ON
         existing.intersection_uid = new_gaps.intersection_uid
+        --exclude if same classification_uid, or existing is null (all)
         AND (
             existing.classification_uid = new_gaps.classification_uid
             OR existing.classification_uid IS NULL
+            
         ) AND (
+            --exclude any overlapping records
             (
                 existing.range_start <= new_gaps.range_start
                 AND existing.range_end >= new_gaps.range_end

--- a/volumes/miovision/sql/function/function-identify-zero-counts.sql
+++ b/volumes/miovision/sql/function/function-identify-zero-counts.sql
@@ -98,14 +98,16 @@ BEGIN
     FROM new_gaps
     --anti join values which were already used for above updates
     LEFT JOIN updated_values ON
-        COALESCE(new_gaps.intersection_uid, 0) = COALESCE(updated_values.intersection_uid, 0)
+        new_gaps.intersection_uid = updated_values.intersection_uid
         AND COALESCE(new_gaps.classification_uid, 0) = COALESCE(updated_values.classification_uid, 0)
         AND new_gaps.range_start = updated_values.range_start
     --anti join existing open ended/overlapping gaps
     LEFT JOIN miovision_api.anomalous_ranges AS existing ON
-        COALESCE(existing.intersection_uid, 0) = COALESCE(new_gaps.intersection_uid, 0)
-        AND COALESCE(existing.classification_uid, 0) = COALESCE(new_gaps.classification_uid, 0)
+        existing.intersection_uid = new_gaps.intersection_uid
         AND (
+            existing.classification_uid = new_gaps.classification_uid
+            OR existing.classification_uid IS NULL
+        ) AND (
             (
                 existing.range_start <= new_gaps.range_start
                 AND existing.range_end >= new_gaps.range_end


### PR DESCRIPTION
## What this pull request accomplishes:
- updates the anti-join with existing anomalous ranges: when `existing` record has a null classification_uid, we want to exclude any new records from being added for that intersection. 

## Issue(s) this solves:
- #860 

## What, in particular, needs to reviewed:
- Join conditions when there are nulls classification_uid's on either side

## What needs to be done by a sysadmin after this PR is merged
- update function in database. I don't think we should backfill as Nate has been cleaning these up manually. 