### PR TITLE
#867 add AR notes to volumes_daily

### DIFF
--- a/volumes/miovision/sql/views/create-view-volumes_daily.sql
+++ b/volumes/miovision/sql/views/create-view-volumes_daily.sql
@@ -10,13 +10,14 @@ CREATE VIEW miovision_api.volumes_daily AS (
         v.unacceptable_gap_minutes,
         v.avg_historical_gap_vol,
         array_agg(ar.notes ORDER BY ar.range_start, ar.uid)
-            AS anomalous_range_caveats,
-        array_agg(ar.uid::text ORDER BY ar.range_start, ar.uid)
-            AS anomalous_range_uid
+        AS anomalous_range_caveats,
+        array_agg(ar.uid ORDER BY ar.range_start, ar.uid)
+        AS anomalous_range_uid
     FROM miovision_api.volumes_daily_unfiltered AS v
     --left join anomalous_ranges to get notes
     --exclude ['do-not-use', 'questionable'] in HAVING
-    LEFT JOIN miovision_api.anomalous_ranges AS ar ON
+    LEFT JOIN miovision_api.anomalous_ranges AS ar
+    ON
         (
             ar.intersection_uid = v.intersection_uid
             OR ar.intersection_uid IS NULL
@@ -39,7 +40,7 @@ CREATE VIEW miovision_api.volumes_daily AS (
         v.datetime_bins_missing,
         v.unacceptable_gap_minutes,
         v.avg_historical_gap_vol
-    HAVING NOT(array_agg(ar.problem_level) && ARRAY['do-not-use', 'questionable'])
+    HAVING NOT (array_agg(ar.problem_level) && ARRAY['do-not-use', 'questionable'])
     ORDER BY
         v.dt,
         v.intersection_uid,

--- a/volumes/miovision/sql/views/create-view-volumes_daily.sql
+++ b/volumes/miovision/sql/views/create-view-volumes_daily.sql
@@ -9,16 +9,15 @@ CREATE VIEW miovision_api.volumes_daily AS (
         v.datetime_bins_missing,
         v.unacceptable_gap_minutes,
         v.avg_historical_gap_vol,
-        array_agg(ar.notes ORDER BY ar.range_start, ar.uid)
+        array_agg(ar.notes ORDER BY ar.range_start, ar.uid) FILTER (WHERE ar.uid IS NOT NULL)
         AS anomalous_range_caveats,
-        array_agg(ar.uid ORDER BY ar.range_start, ar.uid)
-        AS anomalous_range_uid
+        array_agg(ar.uid ORDER BY ar.range_start, ar.uid) FILTER (WHERE ar.uid IS NOT NULL)
+        AS anomalous_range_uids
     FROM miovision_api.volumes_daily_unfiltered AS v
     --left join anomalous_ranges to get notes
     --exclude ['do-not-use', 'questionable'] in HAVING
     LEFT JOIN miovision_api.anomalous_ranges AS ar
-    ON
-        (
+        ON (
             ar.intersection_uid = v.intersection_uid
             OR ar.intersection_uid IS NULL
         ) AND (
@@ -68,3 +67,11 @@ IS 'Minutes with zero volumes out of a total of possible 1440 minutes per day.';
 COMMENT ON COLUMN miovision_api.volumes_daily.avg_historical_gap_vol
 IS 'Avg historical volume for that classification and gap duration 
 based on averages from a 60 day lookback in that hour.';
+
+COMMENT ON COLUMN miovision_api.volumes_daily.anomalous_range_caveats
+IS 'Notes from relelvant anomalous_ranges that are not either
+    ''do-not-use'' or ''questionable''.';
+
+COMMENT ON COLUMN miovision_api.volumes_daily.anomalous_range_uids
+IS 'The `uid`s of relelvant anomalous_ranges that are not either
+    ''do-not-use'' or ''questionable''.';

--- a/volumes/miovision/sql/views/create-view-volumes_daily.sql
+++ b/volumes/miovision/sql/views/create-view-volumes_daily.sql
@@ -8,9 +8,14 @@ CREATE VIEW miovision_api.volumes_daily AS (
         v.holiday,
         v.datetime_bins_missing,
         v.unacceptable_gap_minutes,
-        v.avg_historical_gap_vol
+        v.avg_historical_gap_vol,
+        array_agg(ar.notes ORDER BY ar.range_start, ar.uid)
+            AS anomalous_range_caveats,
+        array_agg(ar.uid::text ORDER BY ar.range_start, ar.uid)
+            AS anomalous_range_uid
     FROM miovision_api.volumes_daily_unfiltered AS v
-    --anti join anomalous_ranges
+    --left join anomalous_ranges to get notes
+    --exclude ['do-not-use', 'questionable'] in HAVING
     LEFT JOIN miovision_api.anomalous_ranges AS ar ON
         (
             ar.intersection_uid = v.intersection_uid
@@ -24,9 +29,21 @@ CREATE VIEW miovision_api.volumes_daily AS (
             v.dt < ar.range_end
             OR ar.range_end IS NULL
         )
-        AND ar.problem_level IN ('do-not-use', 'questionable')
-    WHERE
-        ar.uid IS NULL --anti join anomalous ranges
+    GROUP BY
+        v.dt,
+        v.intersection_uid,
+        v.classification_uid,
+        v.daily_volume,
+        v.isodow,
+        v.holiday,
+        v.datetime_bins_missing,
+        v.unacceptable_gap_minutes,
+        v.avg_historical_gap_vol
+    HAVING NOT(array_agg(ar.problem_level) && ARRAY['do-not-use', 'questionable'])
+    ORDER BY
+        v.dt,
+        v.intersection_uid,
+        v.classification_uid
 );
 
 ALTER TABLE miovision_api.volumes_daily OWNER TO miovision_admins;


### PR DESCRIPTION
## What this pull request accomplishes:
- Adds context from `anomalous_range` table to filtered `volumes_daily` (see sample in the comment below)
- new columns `anomalous_range_caveats` and `anomalous_range_uid` are arrays to support multiple issues per row (last row below)

## Issue(s) this solves:
- #867 

## What, in particular, needs to reviewed:
- What do you think of the formatting of the anomalous_ranges and the information contained in the extra columns? We can also consider using `string_agg` instead of `array_agg`. 
- You can see this in action at `gwolofs.volumes_daily`. Already confirmed that:
```sql
SELECT (SELECT COUNT(*) FROM gwolofs.volumes_daily) = (SELECT COUNT(*) FROM miovision_api.volumes_daily)
```

## What needs to be done by a sysadmin after this PR is merged
- DROP existing view and replace with new definition.
- After changes are approved I will update the readme.