### PR TITLE
906 add lineage to replicated table comments

### DIFF
--- a/dags/common_tasks.py
+++ b/dags/common_tasks.py
@@ -81,12 +81,14 @@ def copy_table(conn_id:str, table:Tuple[str, str], **context) -> None:
             DO $$
             DECLARE comment_ text;
             BEGIN
-                SELECT obj_description('{}.{}'::regclass) INTO comment_;
+                SELECT obj_description('{}.{}'::regclass)
+                    || chr(10) || 'Sourced from {}.{}.' INTO comment_;
                 EXECUTE format('COMMENT ON TABLE {}.{} IS %L', comment_);
             END $$;
         """
         ).format(
             sql.Identifier(src_schema), sql.Identifier(src_table),
+            sql.Literal(src_schema), sql.Literal(src_table),
             sql.Identifier(dst_schema), sql.Identifier(dst_table),
         )
     

--- a/dags/common_tasks.py
+++ b/dags/common_tasks.py
@@ -83,7 +83,7 @@ def copy_table(conn_id:str, table:Tuple[str, str], **context) -> None:
             BEGIN
                 SELECT obj_description('{}.{}'::regclass)
                     || chr(10) || 'Copied from {}.{} by bigdata repliactor DAG at '
-                    || to_char(now() AT TIME ZONE 'EST5EDT', 'yyyy-mm-dd HH24:mm') || '.' INTO comment_;
+                    || to_char(now() AT TIME ZONE 'EST5EDT', 'yyyy-mm-dd HH24:MI') || '.' INTO comment_;
                 EXECUTE format('COMMENT ON TABLE {}.{} IS %L', comment_);
             END $$;
         """


### PR DESCRIPTION
## What this pull request accomplishes:
- Adds additional detail to replicated table comments to indicate source, time copied. 
- Tested! New comment on traffic.arteries_centreline is: 
>Contains a mapping of `centreline_id` to `arterycode`. This is used for mapping studies to the Centreline. Last updated on 2024-03-21.
Copied from "move_staging"."counts_arteries_centreline" by bigdata repliactor DAG at 2024-03-21 17:32.

## Issue(s) this solves:
- #906 

## What, in particular, needs to reviewed:

## What needs to be done by a sysadmin after this PR is merged
- Update DAG in data_scripts
