### PR TITLE
GCC Puller Primary Key

### DIFF
--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -189,7 +189,7 @@ def create_audited_table(output_table, return_json, schema_name, primary_key, co
             create_sql = sql.SQL("CREATE TABLE IF NOT EXISTS {schema_table} ({columns}, CONSTRAINT {pk_name} PRIMARY KEY ({pk}))").format(
                 schema_table = sql.Identifier(schema_name, temp_table_name),
                 columns = col_list_string,
-                pk_name = pk_name,
+                pk_name = sql.Identifier(pk_name),
                 pk = sql.Identifier(primary_key)
                 )
             LOGGER.info(create_sql.as_string(con))


### PR DESCRIPTION
## What this pull request accomplishes:

- modify `create_audited_table()` to only create a primary key when a new table is created
- fixes the issue of creating multiple primary keys for a table 

## Issue(s) this solves:

- #900 

## What, in particular, needs to reviewed:
- `gcc_puller_functions.py`

## What needs to be done by a sysadmin after this PR is merged
- testing of the new code 
