### PR TITLE
#906 remove new line from comment

### DIFF
--- a/dags/common_tasks.py
+++ b/dags/common_tasks.py
@@ -82,7 +82,7 @@ def copy_table(conn_id:str, table:Tuple[str, str], **context) -> None:
             DECLARE comment_ text;
             BEGIN
                 SELECT obj_description('{}.{}'::regclass)
-                    || chr(10) || 'Copied from {}.{} by bigdata repliactor DAG at '
+                    || 'Copied from {}.{} by bigdata repliactor DAG at '
                     || to_char(now() AT TIME ZONE 'EST5EDT', 'yyyy-mm-dd HH24:MI') || '.' INTO comment_;
                 EXECUTE format('COMMENT ON TABLE {}.{} IS %L', comment_);
             END $$;


### PR DESCRIPTION
## What this pull request accomplishes:
- The new line character prevents the additional comment from being seen in the preview. Remove.

Before: 
![image](https://github.com/CityofToronto/bdit_data-sources/assets/80077912/a0e055d7-3675-4b9b-a101-42a257f0f628)

After: 
![image](https://github.com/CityofToronto/bdit_data-sources/assets/80077912/dd903801-154c-4b1e-b549-b37414e0bff1)


## Issue(s) this solves:

- #906 

## What, in particular, needs to reviewed:
 

## What needs to be done by a sysadmin after this PR is merged
- Checkout common_tasks in data_scripts.