### PR TITLE
927 add a replicator health check

### DIFF
--- a/dags/replicator_table_check.py
+++ b/dags/replicator_table_check.py
@@ -67,18 +67,14 @@ def replicator_DAG():
         #find move_staging tables with comment like "last updated on {ds}"
         updated_tables_sql = """
         WITH move_staging_comments AS (
-            SELECT
-                table_schema::text || '.' || table_name::text AS tbl_name,
-                obj_description(
-                    (table_schema::text || '.' || table_name::text)::regclass
-                ) AS table_comment
+            SELECT table_schema::text || '.' || table_name::text AS tbl_name
             FROM information_schema.tables
             WHERE table_schema = 'move_staging'
         )
 
         SELECT tbl_name
         FROM move_staging_comments
-        WHERE table_comment LIKE %s"""
+        WHERE obj_description(tbl_name::regclass) LIKE %s"""
 
         #NEED TO CHANGE THIS TO REPLICATOR_BOT!!!
         con = PostgresHook("collisions_bot").get_conn()

--- a/dags/replicator_table_check.py
+++ b/dags/replicator_table_check.py
@@ -89,7 +89,7 @@ def replicator_DAG():
             AND pgc.relkind = 'r'
             AND pgd.description ILIKE %s"""
 
-        con = PostgresHook("collisions_bot").get_conn()
+        con = PostgresHook("replicator_bot").get_conn()
         with con.cursor() as cur:
             cur.execute(updated_tables_sql, (f'%Last updated on {ds}%',))
             updated_tables = [tbl[0] for tbl in cur.fetchall()]
@@ -144,7 +144,7 @@ def replicator_DAG():
             )
             AND pgc.relkind = 'r';"""
 
-        con = PostgresHook("collisions_bot").get_conn()
+        con = PostgresHook("replicator_bot").get_conn()
         with con.cursor() as cur:
             cur.execute(outdated_tables_sql, (f'%Last updated on {ds}%',))
             failures = [tbl[0] for tbl in cur.fetchall()]

--- a/dags/replicator_table_check.py
+++ b/dags/replicator_table_check.py
@@ -1,0 +1,155 @@
+#!/data/airflow/airflow_venv/bin/python3
+# -*- coding: utf-8 -*-
+# noqa: D415
+import os
+import sys
+from datetime import timedelta
+import pendulum
+# pylint: disable=import-error
+from airflow.decorators import dag, task
+from airflow.models import Variable
+from airflow.exceptions import AirflowFailException
+
+# import custom operators and helper functions
+repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+sys.path.insert(0, repo_path)
+# pylint: disable=wrong-import-position
+from dags.dag_functions import task_fail_slack_alert, send_slack_msg
+# pylint: enable=import-error
+
+def create_replicator_dag(dag_id, short_name, tables_var, conn, doc_md, default_args): 
+    @dag(
+        dag_id=dag_id,
+        default_args=default_args,
+        catchup=False,
+        max_active_runs=5,
+        max_active_tasks=5,
+        schedule=None, #triggered externally
+        doc_md=doc_md,
+        tags=[short_name, "replicator"]
+    )
+    def replicator_DAG():
+        f"""The main function of the {short_name} DAG."""
+        from dags.common_tasks import (
+            wait_for_external_trigger, get_variable, copy_table
+        )
+
+        # Returns a list of source and destination tables stored in the given
+        # Airflow variable.
+        tables = get_variable.override(task_id="get_list_of_tables")(tables_var)
+
+        # Copies tables
+        copy_tables = copy_table.override(task_id="copy_tables", on_failure_callback = None).partial(conn_id=conn).expand(table=tables)
+
+        @task(
+            retries=0,
+            trigger_rule='all_done',
+            doc_md="""A status message to report DAG success OR any failures from the `copy_tables` task."""
+        )
+        def status_message(tables, **context):
+            ti = context["ti"]
+            failures = []
+            #iterate through mapped tasks to find any failure messages
+            for m_i in range(0, len(tables)):
+                failure_msg = ti.xcom_pull(key="extra_msg", task_ids="copy_tables", map_indexes=m_i)
+                if failure_msg is not None:
+                    failures.append(failure_msg)
+            if failures == []:
+                send_slack_msg(
+                    context=context,
+                    msg=f"`{dag_id}` DAG succeeded :white_check_mark:"
+                )
+            else: #add details of failures to task_fail_slack_alert
+                failure_extra_msg = ['One or more tables failed to copy:', failures]
+                context.get("task_instance").xcom_push(key="extra_msg", value=failure_extra_msg)
+                raise AirflowFailException('One or more tables failed to copy.')
+            
+        # Waits for an external trigger
+        wait_for_external_trigger() >> tables >> copy_tables >> status_message(tables=tables)    
+
+    generated_dag = replicator_DAG()
+
+    return generated_dag
+
+#get replicator details from airflow variable
+REPLICATORS = Variable.get('replicators', deserialize_json=True)
+
+#generate replicator DAGs from dict
+for replicator, dag_items in REPLICATORS.items():
+    DAG_NAME = dag_items['dag_name']
+    DAG_OWNERS = Variable.get("dag_owners", deserialize_json=True).get(DAG_NAME, ["Unknown"])
+
+    default_args = {
+        "owner": ",".join(DAG_OWNERS),
+        "depends_on_past": False,
+        "start_date": pendulum.datetime(2023, 10, 31, tz="America/Toronto"),
+        "email_on_failure": False,
+        "retries": 3,
+        "retry_delay": timedelta(minutes=60),
+        "on_failure_callback": task_fail_slack_alert,
+    }
+
+    doc_md = f"""### The Daily {replicator} Replicator DAG
+
+    This DAG runs daily to copy MOVE's {replicator} tables from the ``move_staging``
+    schema, which is updated by the MOVE's ``bigdata_replicator`` DAG, to the
+    ``{replicator}`` schema. This DAG runs only when it is triggered by the MOVE's
+    DAG."""
+
+    globals()[DAG_NAME] = (
+        create_replicator_dag(
+            dag_id=DAG_NAME,
+            short_name=replicator,
+            tables_var=dag_items['tables'],
+            conn=dag_items['conn'],
+            doc_md=doc_md,
+            default_args=default_args
+        )
+    )
+
+
+    #what are all tables available for copying?
+counts_table = [x[0] for x in counts_table]
+collisions_tables = [x[0] for x in collisions_tables]
+from pathlib import Path
+import configparser
+from psycopg2 import connect, sql
+
+CONFIG = configparser.ConfigParser()
+CONFIG.read(str(Path.home().joinpath('db.cfg'))) #Creates a path to your db.cfg file
+dbset = CONFIG['DBSETTINGS']
+con = connect(**dbset)
+
+updated_tables_sql = """
+WITH move_staging_comments AS (
+    SELECT
+        table_schema::text || '.' || table_name::text AS tbl_name,
+        obj_description(
+            (table_schema::text || '.' || table_name::text)::regclass
+        ) AS table_comment
+    FROM information_schema.tables
+    WHERE table_schema = 'move_staging'
+)
+
+SELECT tbl_name
+FROM move_staging_comments
+WHERE table_comment LIKE %s"""
+
+ds = '2024-04-12'
+
+with con.cursor() as cur: 
+    cur.execute(updated_tables_sql, (f'%Last updated on {ds}%',))
+    updated_tables = cur.fetchall()
+
+updated_tables = [x[0] for x in updated_tables]
+
+#values in both lists:
+[value for value in counts_table if value in updated_tables]
+
+#are we copying any extra?
+"The following tables are being copied by bigdata replicators, but are not up to date in `move_staging`:" 
+[value for value in counts_table + collisions_tables if value not in updated_tables]
+
+#are we not copying any?
+"The following tables are up to date in `move_staging` but not being copied by bigdata replicatrs:"
+[value for value in updated_tables if value not in counts_table + collisions_tables]

--- a/dags/replicator_table_check.py
+++ b/dags/replicator_table_check.py
@@ -21,12 +21,15 @@ from airflow.providers.postgres.hooks.postgres import PostgresHook
 repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 sys.path.insert(0, repo_path)
 # pylint: disable=wrong-import-position
-from dags.dag_functions import task_fail_slack_alert
+from dags.dag_functions import task_fail_slack_alert, get_readme_docmd
 from dags.common_tasks import wait_for_external_trigger
 # pylint: enable=import-error
 
 DAG_NAME = 'replicator_table_check'
 DAG_OWNERS = Variable.get("dag_owners", deserialize_json=True).get(DAG_NAME, ["Unknown"])
+
+README_PATH = os.path.join(repo_path, 'collisions/Readme.md')
+DOC_MD = get_readme_docmd(README_PATH, DAG_NAME)
 
 default_args = {
     "owner": ",".join(DAG_OWNERS),
@@ -42,8 +45,9 @@ default_args = {
     default_args=default_args,
     catchup=False,
     max_active_runs=1,
-    schedule=None, #triggered externally
-    doc_md=__doc__,
+    #loosely coupled with the two replicator DAGs which are externally triggered at 430am
+    schedule='0 4 * * *',
+    doc_md=DOC_MD,
     tags=["replicator", "data_checks"]
 )
 def replicator_DAG():

--- a/dags/replicator_table_check.py
+++ b/dags/replicator_table_check.py
@@ -22,7 +22,6 @@ repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__f
 sys.path.insert(0, repo_path)
 # pylint: disable=wrong-import-position
 from dags.dag_functions import task_fail_slack_alert, get_readme_docmd
-from dags.common_tasks import wait_for_external_trigger
 # pylint: enable=import-error
 
 DAG_NAME = 'replicator_table_check'
@@ -156,7 +155,7 @@ def replicator_DAG():
             raise AirflowFailException('There were outdated tables in bigdata `move_staging` schema.')
 
     updated_tables, tables_to_copy = updated_tables(), tables_to_copy()
-    wait_for_external_trigger() >> (
+    (
         not_copied(updated_tables, tables_to_copy),
         not_up_to_date(updated_tables, tables_to_copy),
         outdated_remove()

--- a/dags/replicator_table_check.py
+++ b/dags/replicator_table_check.py
@@ -1,155 +1,122 @@
+"""Health checks for the MOVE -> bigdata replication process.
+Checks for:
+- tables which are up to date in `move_staging` but not being copied downstream.
+- tables which are being erroneously copied from `move_staging` without being up to date.
+"""
+
 #!/data/airflow/airflow_venv/bin/python3
 # -*- coding: utf-8 -*-
 # noqa: D415
 import os
 import sys
-from datetime import timedelta
 import pendulum
 # pylint: disable=import-error
 from airflow.decorators import dag, task
 from airflow.models import Variable
 from airflow.exceptions import AirflowFailException
+from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 # import custom operators and helper functions
 repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 sys.path.insert(0, repo_path)
 # pylint: disable=wrong-import-position
-from dags.dag_functions import task_fail_slack_alert, send_slack_msg
+from dags.dag_functions import task_fail_slack_alert
+from dags.common_tasks import wait_for_external_trigger
 # pylint: enable=import-error
 
-def create_replicator_dag(dag_id, short_name, tables_var, conn, doc_md, default_args): 
-    @dag(
-        dag_id=dag_id,
-        default_args=default_args,
-        catchup=False,
-        max_active_runs=5,
-        max_active_tasks=5,
-        schedule=None, #triggered externally
-        doc_md=doc_md,
-        tags=[short_name, "replicator"]
-    )
-    def replicator_DAG():
-        f"""The main function of the {short_name} DAG."""
-        from dags.common_tasks import (
-            wait_for_external_trigger, get_variable, copy_table
-        )
+DAG_NAME = 'replicator_table_check'
+DAG_OWNERS = Variable.get("dag_owners", deserialize_json=True).get(DAG_NAME, ["Unknown"])
 
-        # Returns a list of source and destination tables stored in the given
-        # Airflow variable.
-        tables = get_variable.override(task_id="get_list_of_tables")(tables_var)
+default_args = {
+    "owner": ",".join(DAG_OWNERS),
+    "depends_on_past": False,
+    "start_date": pendulum.datetime(2024, 4, 12, tz="America/Toronto"),
+    "email_on_failure": False,
+    "retries": 0,
+    "on_failure_callback": task_fail_slack_alert,
+}
 
-        # Copies tables
-        copy_tables = copy_table.override(task_id="copy_tables", on_failure_callback = None).partial(conn_id=conn).expand(table=tables)
-
-        @task(
-            retries=0,
-            trigger_rule='all_done',
-            doc_md="""A status message to report DAG success OR any failures from the `copy_tables` task."""
-        )
-        def status_message(tables, **context):
-            ti = context["ti"]
-            failures = []
-            #iterate through mapped tasks to find any failure messages
-            for m_i in range(0, len(tables)):
-                failure_msg = ti.xcom_pull(key="extra_msg", task_ids="copy_tables", map_indexes=m_i)
-                if failure_msg is not None:
-                    failures.append(failure_msg)
-            if failures == []:
-                send_slack_msg(
-                    context=context,
-                    msg=f"`{dag_id}` DAG succeeded :white_check_mark:"
-                )
-            else: #add details of failures to task_fail_slack_alert
-                failure_extra_msg = ['One or more tables failed to copy:', failures]
-                context.get("task_instance").xcom_push(key="extra_msg", value=failure_extra_msg)
-                raise AirflowFailException('One or more tables failed to copy.')
-            
-        # Waits for an external trigger
-        wait_for_external_trigger() >> tables >> copy_tables >> status_message(tables=tables)    
-
-    generated_dag = replicator_DAG()
-
-    return generated_dag
-
-#get replicator details from airflow variable
-REPLICATORS = Variable.get('replicators', deserialize_json=True)
-
-#generate replicator DAGs from dict
-for replicator, dag_items in REPLICATORS.items():
-    DAG_NAME = dag_items['dag_name']
-    DAG_OWNERS = Variable.get("dag_owners", deserialize_json=True).get(DAG_NAME, ["Unknown"])
-
-    default_args = {
-        "owner": ",".join(DAG_OWNERS),
-        "depends_on_past": False,
-        "start_date": pendulum.datetime(2023, 10, 31, tz="America/Toronto"),
-        "email_on_failure": False,
-        "retries": 3,
-        "retry_delay": timedelta(minutes=60),
-        "on_failure_callback": task_fail_slack_alert,
-    }
-
-    doc_md = f"""### The Daily {replicator} Replicator DAG
-
-    This DAG runs daily to copy MOVE's {replicator} tables from the ``move_staging``
-    schema, which is updated by the MOVE's ``bigdata_replicator`` DAG, to the
-    ``{replicator}`` schema. This DAG runs only when it is triggered by the MOVE's
-    DAG."""
-
-    globals()[DAG_NAME] = (
-        create_replicator_dag(
-            dag_id=DAG_NAME,
-            short_name=replicator,
-            tables_var=dag_items['tables'],
-            conn=dag_items['conn'],
-            doc_md=doc_md,
-            default_args=default_args
-        )
-    )
-
-
-    #what are all tables available for copying?
-counts_table = [x[0] for x in counts_table]
-collisions_tables = [x[0] for x in collisions_tables]
-from pathlib import Path
-import configparser
-from psycopg2 import connect, sql
-
-CONFIG = configparser.ConfigParser()
-CONFIG.read(str(Path.home().joinpath('db.cfg'))) #Creates a path to your db.cfg file
-dbset = CONFIG['DBSETTINGS']
-con = connect(**dbset)
-
-updated_tables_sql = """
-WITH move_staging_comments AS (
-    SELECT
-        table_schema::text || '.' || table_name::text AS tbl_name,
-        obj_description(
-            (table_schema::text || '.' || table_name::text)::regclass
-        ) AS table_comment
-    FROM information_schema.tables
-    WHERE table_schema = 'move_staging'
+@dag(
+    dag_id=DAG_NAME,
+    default_args=default_args,
+    catchup=False,
+    max_active_runs=1,
+    schedule=None, #triggered externally
+    doc_md=__doc__,
+    tags=["replicator", "data_checks"]
 )
+def replicator_DAG():
 
-SELECT tbl_name
-FROM move_staging_comments
-WHERE table_comment LIKE %s"""
+    @task()
+    def tables_to_copy():
+        #a list of the replicators
+        replicators = Variable.get('replicators', deserialize_json=True)
+    
+        #extract source tables from airflow variables
+        tables_to_copy = []
+        for _, dag_items in replicators.items():
+            tables = Variable.get(dag_items['tables'], deserialize_json=True)
+            src_tables = [tbl[0] for tbl in tables]
+            tables_to_copy = tables_to_copy + src_tables
 
-ds = '2024-04-12'
+        #get only source table names
+        return tables_to_copy
 
-with con.cursor() as cur: 
-    cur.execute(updated_tables_sql, (f'%Last updated on {ds}%',))
-    updated_tables = cur.fetchall()
+    @task()
+    def updated_tables(ds):
+        #find move_staging tables with comment like "last updated on {ds}"
+        updated_tables_sql = """
+        WITH move_staging_comments AS (
+            SELECT
+                table_schema::text || '.' || table_name::text AS tbl_name,
+                obj_description(
+                    (table_schema::text || '.' || table_name::text)::regclass
+                ) AS table_comment
+            FROM information_schema.tables
+            WHERE table_schema = 'move_staging'
+        )
 
-updated_tables = [x[0] for x in updated_tables]
+        SELECT tbl_name
+        FROM move_staging_comments
+        WHERE table_comment LIKE %s"""
 
-#values in both lists:
-[value for value in counts_table if value in updated_tables]
+        #NEED TO CHANGE THIS TO REPLICATOR_BOT!!!
+        con = PostgresHook("collisions_bot").get_conn()
+        with con.cursor() as cur:
+            cur.execute(updated_tables_sql, (f'%Last updated on {ds}%',))
+            updated_tables = [tbl[0] for tbl in cur.fetchall()]
 
-#are we copying any extra?
-"The following tables are being copied by bigdata replicators, but are not up to date in `move_staging`:" 
-[value for value in counts_table + collisions_tables if value not in updated_tables]
+        return updated_tables
 
-#are we not copying any?
-"The following tables are up to date in `move_staging` but not being copied by bigdata replicatrs:"
-[value for value in updated_tables if value not in counts_table + collisions_tables]
+    @task()
+    def not_copied(updated_tables: list, tables_to_copy: list, **context):
+        
+        failures = [value for value in updated_tables if value not in tables_to_copy]
+        if failures != []:
+            #send message with details of failure using task_fail_slack_alert
+            failure_extra_msg = [
+                "The following tables are up to date in `move_staging` but not being copied by bigdata replicators:",
+                failures
+            ]
+            context.get("task_instance").xcom_push(key="extra_msg", value=failure_extra_msg)
+            raise AirflowFailException('There were up to date tables in `move_staging` which were not copied by bigdata replicators.')
+
+    @task()
+    def not_up_to_date(updated_tables: list, tables_to_copy: list, **context):
+        failures = [value for value in tables_to_copy if value not in updated_tables]
+        if failures != []:
+            #send message with details of failure using task_fail_slack_alert
+            failure_extra_msg = [
+                "The following tables are being copied by bigdata replicators, but are not up to date in `move_staging`:" ,
+                failures
+            ]
+            context.get("task_instance").xcom_push(key="extra_msg", value=failure_extra_msg)
+            raise AirflowFailException('There were tables copied from `move_staging` by bigdata replicators which were not up to date.')       
+
+    updated_tables, tables_to_copy = updated_tables(), tables_to_copy()
+    wait_for_external_trigger() >> (
+        not_copied(updated_tables, tables_to_copy),
+        not_up_to_date(updated_tables, tables_to_copy)
+    )
+    
+replicator_DAG()


### PR DESCRIPTION
## What this pull request accomplishes:
- Creates a new DAG (`replicator_table_check`) to monitor the MOVE -> bigdata replication process 
- This will help notify us if the list of tables being replicated is out of sync (hint: it currently is)
- See latest slack alerts for review:
https://bditto.slack.com/archives/C021YMH9BK5/p1713196079217679
https://bditto.slack.com/archives/C021YMH9BK5/p1713196079227109

## Issue(s) this solves:
- #927 

## What, in particular, needs to reviewed:
- 

## What needs to be done by a sysadmin after this PR is merged
- For @peter-lyons: we should have the MOVE replicator trigger this DAG through the API at the same time as the counts and collisions replicators.