### PR TITLE
Feat/vds commdeviceconfig

### DIFF
--- a/volumes/vds/readme.md
+++ b/volumes/vds/readme.md
@@ -219,6 +219,24 @@ Row count: 10,540
 | det_group     | text              |                  | Manual field. Only defined for RESCU network. Possible values: 'DVP', 'Lakeshore', 'Gardiner', 'Allen', 'Kingston Rd', 'On-Ramp' |
 | direction     | text              |                  | Manual field. Only defined for RESCU network. Possible values: 'Eastbound','Westbound', 'Southbound', 'Northbound' |
 | expected_bins | integer           | 1                | Manual field. Expected bins per 15 minute period. Possible values: 1, 3, 5, 45 |
+| comms_desc | text | WHD - Glen Rouge | From `config_comms_device.souce_id` |
+| det_tech | text | Wavetronix | Manual field. Only defined for RESCU network. Possible values: 'Smartmicro','Wavetronix','Inductive' |
+
+### `vds.config_comms_device`
+Store raw data pulled from ITS Central `config_comms_device` table. This table is useful for determing which technology is used by a RESCU sensor.
+Join `vdsconfig.fss_id` to `config_comms_device.fss_id`. Note there may be duplicates on division_id+fss_id corresponding to updated locations/details over time.
+
+Row count: 666
+| column_name     | data_type                   | sample                     |   Comments |
+|:----------------|:----------------------------|:---------------------------|-----------:|
+| division_id     | smallint                    | 2                          | |
+| fss_id          | integer                     | 2000102                    | Field renamed to `fss_id` to match `vdsconfig` table. `deviceid` in ITSC. |
+| source_id       | character varying           | VDSFSS57                   | This text field can help identify Wavetronix/Smartmicro sensor technology. |
+| start_timestamp | timestamp without time zone | 2014-04-27 22:29:02.726812 |  |
+| end_timestamp   | timestamp without time zone | 2022-06-24 13:14:57.832010 |  |
+| has_gps_unit    | boolean                     | False                      |  |
+| device_type     | smallint                    | 10                         |  |
+| description     | character varying           |                            |  |
 
 ## Aggregate Tables
 
@@ -424,6 +442,7 @@ A daily DAG to pull [VDS data](https://github.com/CityofToronto/bdit_data-source
   These tasks to update lookup tables `vdsconfig` and `entity_locations` run before downstream pull data tasks to ensure that on-insert trigger has the latest detector information available. Also triggers other DAG (`vds_pull_vdsvehicledata`) for same reason. 
   - `pull_and_insert_detector_inventory` pulls `vdsconfig` table into RDS. On conflict, updates end_timestamp. 
   - `pull_and_insert_entitylocations` pulls `entitylocations` table into RDS. On conflict, updates end_timestamp. 
+  - `pull_and_insert_commsdeviceconfig` pulls `commdeviceconfig` table into RDS `vds.config_comms_device`. On conflict, updates end_timestamp. 
   - `done` marks `update_inventories` as done to trigger downstream data pull tasks + DAG
 
   **`check_partitions`**  

--- a/volumes/vds/sql/select/select-itsc_commdeviceconfig.sql
+++ b/volumes/vds/sql/select/select-itsc_commdeviceconfig.sql
@@ -12,6 +12,6 @@ WHERE divisionid IN (2, 8001) --only these have data in 'vdsdata' table
 
 /*columns excluded:
 managementurl, diagnosticsaddress, diagnosticsport, password, username, manufacturerserialnumber,
-networkserialnumber, phonenumber, lanmacaddress, lanipaddress, lansubnetmask, dhcpserverenabled, dmzaddress,
-keepaliveaddress, createdby, createdbystaffid
+networkserialnumber, phonenumber, lanmacaddress, lanipaddress, lansubnetmask, dhcpserverenabled,
+dmzaddress, keepaliveaddress, createdby, createdbystaffid
 */

--- a/volumes/vds/sql/select/select-itsc_commdeviceconfig.sql
+++ b/volumes/vds/sql/select/select-itsc_commdeviceconfig.sql
@@ -1,0 +1,17 @@
+SELECT
+    divisionid,
+    deviceid,
+    sourceid,
+    TIMEZONE('UTC', starttimestamputc) AT TIME ZONE 'EST5EDT' AS starttimestamp,
+    TIMEZONE('UTC', endtimestamputc) AT TIME ZONE 'EST5EDT' AS endtimestamp,
+    hasgpsunit,
+    devicetype,
+    description
+FROM public.commdeviceconfig
+WHERE divisionid IN (2, 8001) --only these have data in 'vdsdata' table
+
+/*columns excluded:
+managementurl, diagnosticsaddress, diagnosticsport, password, username, manufacturerserialnumber,
+networkserialnumber, phonenumber, lanmacaddress, lanipaddress, lansubnetmask, dhcpserverenabled, dmzaddress,
+keepaliveaddress, createdby, createdbystaffid
+*/

--- a/volumes/vds/sql/tables/create-table-config_comms_device.sql
+++ b/volumes/vds/sql/tables/create-table-config_comms_device.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS vds.config_comms_device
     CONSTRAINT commdeviceconfig_pkey PRIMARY KEY (start_timestamp, division_id, fss_id)
 )
 WITH (
-    OIDS = FALSE
+    oids = FALSE
 )
 TABLESPACE pg_default;
 
@@ -35,9 +35,9 @@ IS 'This text field can help identify Wavetronix/Smartmicro sensor technology.';
 
 CREATE INDEX IF NOT EXISTS ix_vdscommsdevice
 ON vds.config_comms_device
-USING btree(
-    division_id ASC nulls last,
-    fss_id ASC nulls last,
-    start_timestamp ASC nulls last,
-    end_timestamp ASC nulls last
+USING btree (
+    division_id ASC NULLS LAST,
+    fss_id ASC NULLS LAST,
+    start_timestamp ASC NULLS LAST,
+    end_timestamp ASC NULLS LAST
 );

--- a/volumes/vds/sql/tables/create-table-config_comms_device.sql
+++ b/volumes/vds/sql/tables/create-table-config_comms_device.sql
@@ -1,0 +1,37 @@
+-- DROP TABLE IF EXISTS vds.config_comms_device;
+
+CREATE TABLE IF NOT EXISTS vds.config_comms_device
+(
+    division_id smallint NOT NULL,
+    fss_id integer NOT NULL,
+    source_id character varying(5000) COLLATE pg_catalog."default" NOT NULL,
+    start_timestamp timestamp without time zone NOT NULL,
+    end_timestamp timestamp without time zone,
+    has_gps_unit boolean NOT NULL,
+    device_type smallint NOT NULL,
+    description character varying(10000) COLLATE pg_catalog."default" NOT NULL,
+    CONSTRAINT commdeviceconfig_pkey PRIMARY KEY (start_timestamp, division_id, fss_id)
+)
+WITH (
+    OIDS = FALSE
+)
+TABLESPACE pg_default;
+
+ALTER TABLE vds.config_comms_device OWNER TO vds_admins;
+GRANT INSERT, SELECT, UPDATE ON TABLE vds.config_comms_device TO vds_bot;
+GRANT SELECT ON TABLE vds.config_comms_device TO bdit_humans;
+
+COMMENT ON TABLE vds.config_comms_device IS
+'Store raw data pulled from ITS Central `config_comms_device` table.
+This table is useful for determing which technology is used by a RESCU sensor.
+Join `vdsconfig.fss_id` to `config_comms_device.fss_id`. 
+Note there may be duplicates on division_id+fss_id corresponding to updated locations/details over time.';
+
+CREATE INDEX IF NOT EXISTS ix_vdscommsdevice
+ON vds.config_comms_device
+USING btree(
+    division_id ASC nulls last,
+    fss_id ASC nulls last,
+    start_timestamp ASC nulls last,
+    end_timestamp ASC nulls last
+);

--- a/volumes/vds/sql/tables/create-table-config_comms_device.sql
+++ b/volumes/vds/sql/tables/create-table-config_comms_device.sql
@@ -27,6 +27,12 @@ This table is useful for determing which technology is used by a RESCU sensor.
 Join `vdsconfig.fss_id` to `config_comms_device.fss_id`. 
 Note there may be duplicates on division_id+fss_id corresponding to updated locations/details over time.';
 
+COMMENT ON COLUMN vds.config_comms_device.fss_id
+IS 'Field renamed to `fss_id` to match `vdsconfig` table. `deviceid` in ITSC.';
+
+COMMENT ON COLUMN vds.config_comms_device.source_id
+IS 'This text field can help identify Wavetronix/Smartmicro sensor technology.';
+
 CREATE INDEX IF NOT EXISTS ix_vdscommsdevice
 ON vds.config_comms_device
 USING btree(

--- a/volumes/vds/sql/views/create-view-detector_inventory.sql
+++ b/volumes/vds/sql/views/create-view-detector_inventory.sql
@@ -43,16 +43,16 @@ CREATE OR REPLACE VIEW vds.detector_inventory AS (
             WHEN dtypes.det_type = 'Blue City AI' THEN 1 --15 min bins
         END AS expected_bins,
         comms.source_id AS comms_desc,
-        CASE
-            WHEN dtypes.det_type = 'RESCU Detectors' THEN
-                CASE
-                    WHEN lower(comms.source_id) SIMILAR TO '%smartmicro%'
-                        OR lower(c.detector_id) SIMILAR TO '%smartmicro%'
-                        THEN 'Smartmicro'
-                    WHEN lower(comms.source_id) SIMILAR TO '%whd%'
-                        THEN 'Wavetronix'
-                    ELSE 'Inductive'
-                END
+        --rescu techology type, determined by communication device in some cases.
+        CASE dtypes.det_type = 'RESCU Detectors'
+            WHEN TRUE THEN CASE
+                WHEN lower(comms.source_id) SIMILAR TO '%smartmicro%'
+                    OR lower(c.detector_id) SIMILAR TO '%smartmicro%'
+                    THEN 'Smartmicro'
+                WHEN lower(comms.source_id) SIMILAR TO '%whd%'
+                    THEN 'Wavetronix'
+                ELSE 'Inductive'
+            END
         END AS det_tech
     FROM vds.vdsconfig AS c
     LEFT JOIN vds.config_comms_device AS comms

--- a/volumes/vds/sql/views/create-view-detector_inventory.sql
+++ b/volumes/vds/sql/views/create-view-detector_inventory.sql
@@ -46,9 +46,10 @@ CREATE OR REPLACE VIEW vds.detector_inventory AS (
         --rescu techology type, determined by communication device in some cases.
         CASE dtypes.det_type = 'RESCU Detectors'
             WHEN TRUE THEN CASE
-                WHEN lower(comms.source_id) SIMILAR TO '%smartmicro%'
+                WHEN
+                    lower(comms.source_id) SIMILAR TO '%smartmicro%'
                     OR lower(c.detector_id) SIMILAR TO '%smartmicro%'
-                    THEN 'Smartmicro'
+                        THEN 'Smartmicro'
                 WHEN lower(comms.source_id) SIMILAR TO '%whd%'
                     THEN 'Wavetronix'
                 ELSE 'Inductive'
@@ -59,7 +60,7 @@ CREATE OR REPLACE VIEW vds.detector_inventory AS (
         ON comms.fss_id = c.fss_id
         AND comms.division_id = c.division_id
         AND tsrange(c.start_timestamp, COALESCE(c.end_timestamp, now()::timestamp))
-            && tsrange(comms.start_timestamp, COALESCE(comms.end_timestamp, now()::timestamp)),
+        && tsrange(comms.start_timestamp, COALESCE(comms.end_timestamp, now()::timestamp)),
         LATERAL (
             SELECT CASE
                 WHEN c.division_id = 2 AND (
@@ -76,7 +77,8 @@ CREATE OR REPLACE VIEW vds.detector_inventory AS (
                 WHEN c.detector_id LIKE 'BCT%' THEN 'Blue City AI'
                 WHEN
                     c.detector_id LIKE ANY(
-                        '{"%SMARTMICRO%", "%YONGE HEATH%", "%YONGE DAVISVILLE%", "%YONGE AND ROXBOROUGH%"}'
+                        '{"%SMARTMICRO%", "%YONGE HEATH%",
+                        "%YONGE DAVISVILLE%", "%YONGE AND ROXBOROUGH%"}'
                     )
                     --new lakeshore/spadina smartmicro sensors
                     OR c.vds_id IN (
@@ -86,7 +88,7 @@ CREATE OR REPLACE VIEW vds.detector_inventory AS (
                     OR (
                         c.vds_id >= 7011490 AND c.vds_id <= 7011519
                     )
-                        THEN 'Smartmicro Sensors'
+                    THEN 'Smartmicro Sensors'
             END AS det_type
         ) AS dtypes
     ORDER BY


### PR DESCRIPTION
## What this pull request accomplishes:
- Adds a new table to the vds pipeline: `public.commdeviceconfig` (ITSC) -> `vds.config_comms_device` (Bigdata)
- Adjusts `detector_inventory` view to include the detector technology: Wavetronix/Smartmicro/Inductive
- Tested: https://morbius.corp.toronto.ca:8080/airflow/dags/vds_pull_vdsdata/grid?dag_run_id=scheduled__2024-04-29T08%3A00%3A00%2B00%3A00&task_id=update_inventories.pull_and_insert_commsdeviceconfig&tab=logs

## Issue(s) this solves:
- Closes #939 

## What, in particular, needs to reviewed:
- The columns included in `volumes/vds/sql/select/select-itsc_commdeviceconfig.sql`
- The updates to view: `volumes/vds/sql/views/create-view-detector_inventory.sql`

## What needs to be done by a sysadmin after this PR is merged
- Revert the dag link on Morbius to data_scripts