### PR TITLE
949 missing leg in miovisionopen issues join

### DIFF
--- a/volumes/miovision/sql/data_checks/select-open_issues.sql
+++ b/volumes/miovision/sql/data_checks/select-open_issues.sql
@@ -6,6 +6,7 @@ WITH ars AS (
             classification || ' (' || classification_uid || ')',
             'All classifications'
         ) AS classification,
+        leg,
         last_week_volume,
         notes
     FROM miovision_api.open_issues
@@ -21,7 +22,8 @@ SELECT
     array_agg(
         'uid: `' || ars.uid || '`, `'
         || ars.intersection || '`, `'
-        || ars.classification || '`, '
+        || ars.classification || '`, `'
+        || CASE WHEN ars.leg IS NOT NULL THEN ars.leg || ' leg`, ' ELSE '' END
         || 'volume: `' || ars.last_week_volume || '`, '
         || 'notes: `' || LEFT(ars.notes, 80)
         || CASE WHEN LENGTH(ars.notes) > 80 THEN '...' ELSE '' END || '`'

--- a/volumes/miovision/sql/data_checks/select-open_issues.sql
+++ b/volumes/miovision/sql/data_checks/select-open_issues.sql
@@ -22,9 +22,9 @@ SELECT
     array_agg(
         'uid: `' || ars.uid || '`, `'
         || ars.intersection || '`, `'
-        || ars.classification || '`, `'
-        || CASE WHEN ars.leg IS NOT NULL THEN ars.leg || ' leg`, ' ELSE '' END
-        || 'volume: `' || ars.last_week_volume || '`, '
+        || ars.classification || '`, '
+        || CASE WHEN ars.leg IS NOT NULL THEN '`' || ars.leg || ' leg`, ' ELSE '' END
+        || 'volume: `' || to_char(ars.last_week_volume, 'FM9,999,999') || '`, '
         || 'notes: `' || LEFT(ars.notes, 80)
         || CASE WHEN LENGTH(ars.notes) > 80 THEN '...' ELSE '' END || '`'
     ) AS gaps

--- a/volumes/miovision/sql/views/create-view-volumes_daily.sql
+++ b/volumes/miovision/sql/views/create-view-volumes_daily.sql
@@ -24,6 +24,8 @@ CREATE VIEW miovision_api.volumes_daily AS (
             ar.classification_uid = v.classification_uid
             OR ar.classification_uid IS NULL
         )
+        --omitting join to ar.leg implies that a single leg outage is
+        --sufficient to exclude entire intersection.
         AND v.dt >= ar.range_start
         AND (
             v.dt < ar.range_end


### PR DESCRIPTION
## What this pull request accomplishes:
- The addition of leg to anomalous_ranges broke the open_issues view + data check. 
- Other minor improvements include: fixing the `last_week_volume` to only look at dates within the AR + formatting that number with commas

## Issue(s) this solves:

- Closes #949 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged
- nothing
