### PR TITLE
#966 add centreline_id to ecocounter.sites and sites_unfiltered

### DIFF
--- a/volumes/ecocounter/readme.md
+++ b/volumes/ecocounter/readme.md
@@ -146,6 +146,7 @@ Key tables `ecocounter.sites_unfiltered`, `ecocounter.flows_unfiltered`, `ecocou
 
 ### `ecocounter.sites_unfiltered`
 CAUTION: Use VIEW `ecocounter.sites` which includes only sites verified by a human. Sites or "locations" of separate ecocounter installations. Each site may have one or more flows.
+When you want to update new rows with missing `centreline_id`s, use [this script](./updates/ecocounter_centreline_updates.sql).  
 
 | column_name | data_type | sample | comments |
 |:------------|:----------|:-------|:---------|

--- a/volumes/ecocounter/readme.md
+++ b/volumes/ecocounter/readme.md
@@ -157,7 +157,7 @@ When you want to update new rows with missing `centreline_id`s, use [this script
 | facility_description | text | | description of bike-specific infrastructure which the sensor is installed within |
 | notes | text | | |
 | replaced_by_site_id  | numeric | | Several sites had their sensors replaced and show up now as "new" sites though we should ideally treat the data as continuous with the replaced site. This field indicates the site_id of the new replacement site, if any. |
-| centreline_id | integer | | Join to gis_core.centreline_latest USING (centreline_id) |
+| centreline_id | integer | | The nearest street centreline_id, noting that ecocounter sensors are only configured to count bike like objects on a portion of the roadway ie. cycletrack or multi-use-path. Join using `JOIN gis_core.centreline_latest USING (centreline_id)`. |
 
 ### `ecocounter.counts_unfiltered`
 CAUTION: Use VIEW `ecocounter.counts` instead to see data only for sites verified by a human.

--- a/volumes/ecocounter/readme.md
+++ b/volumes/ecocounter/readme.md
@@ -156,6 +156,7 @@ CAUTION: Use VIEW `ecocounter.sites` which includes only sites verified by a hum
 | facility_description | text | | description of bike-specific infrastructure which the sensor is installed within |
 | notes | text | | |
 | replaced_by_site_id  | numeric | | Several sites had their sensors replaced and show up now as "new" sites though we should ideally treat the data as continuous with the replaced site. This field indicates the site_id of the new replacement site, if any. |
+| centreline_id | integer | | Join to gis_core.centreline_latest USING (centreline_id) |
 
 ### `ecocounter.counts_unfiltered`
 CAUTION: Use VIEW `ecocounter.counts` instead to see data only for sites verified by a human.

--- a/volumes/ecocounter/tables/sites_unfiltered.sql
+++ b/volumes/ecocounter/tables/sites_unfiltered.sql
@@ -6,6 +6,7 @@ CREATE TABLE ecocounter.sites (
     notes text COLLATE pg_catalog."default",
     replaced_by_site_id numeric,
     validated boolean,
+    centreline_id integer,
     CONSTRAINT sites_pkey PRIMARY KEY (site_id),
     CONSTRAINT sites_replaced_by_fkey FOREIGN KEY (replaced_by_site_id)
     REFERENCES ecocounter.sites_unfiltered (site_id) MATCH SIMPLE

--- a/volumes/ecocounter/tables/sites_unfiltered.sql
+++ b/volumes/ecocounter/tables/sites_unfiltered.sql
@@ -1,4 +1,4 @@
-CREATE TABLE ecocounter.sites (
+CREATE TABLE ecocounter.sites_unfiltered (
     site_id numeric NOT NULL,
     site_description text COLLATE pg_catalog."default" NOT NULL,
     geom GEOMETRY (POINT, 4326),
@@ -16,28 +16,30 @@ CREATE TABLE ecocounter.sites (
 
 TABLESPACE pg_default;
 
-ALTER TABLE ecocounter.sites OWNER TO ecocounter_admins;
+ALTER TABLE ecocounter.sites_unfiltered OWNER TO ecocounter_admins;
 
-REVOKE ALL ON TABLE ecocounter.sites FROM bdit_humans;
-REVOKE ALL ON TABLE ecocounter.sites FROM ecocounter_bot;
+REVOKE ALL ON TABLE ecocounter.sites_unfiltered FROM bdit_humans;
+REVOKE ALL ON TABLE ecocounter.sites_unfiltered FROM ecocounter_bot;
 
-GRANT ALL ON TABLE ecocounter.sites TO ecocounter_admins;
-GRANT SELECT, INSERT ON TABLE ecocounter.sites TO ecocounter_bot;
+GRANT ALL ON TABLE ecocounter.sites_unfiltered TO ecocounter_admins;
+GRANT SELECT, INSERT ON TABLE ecocounter.sites_unfiltered TO ecocounter_bot;
 
-COMMENT ON TABLE ecocounter.sites
-IS 'CAUTION: Use VIEW `ecocounter.sites` which includes only sites verified by a human.
-Sites or "locations" of separate ecocounter installations.
-Each site may have one or more flows.';
+COMMENT ON TABLE ecocounter.sites_unfiltered IS E''
+'CAUTION: Use VIEW `ecocounter.sites` which includes only sites verified by a human.'
+'Sites represent separate installations, where each site may have one or more flow.';
 
-COMMENT ON COLUMN ecocounter.sites.site_id
+COMMENT ON COLUMN ecocounter.sites_unfiltered.site_id
 IS 'unique site identifier used by ecocounter';
 
-COMMENT ON COLUMN ecocounter.sites.facility_description
+COMMENT ON COLUMN ecocounter.sites_unfiltered.facility_description
 IS 'description of bike-specific infrastructure which the sensor is installed within';
 
-COMMENT ON COLUMN ecocounter.sites.replaced_by_site_id
-IS 'Several sites had their sensors replaced and
-show up now as "new" sites though we should ideally
-treat the data as continuous with the replaced site.
-This field indicates the site_id of the new
-replacement site, if any.';
+COMMENT ON COLUMN ecocounter.sites_unfiltered.replaced_by_site_id IS E''
+'Several sites had their sensors replaced and show up now as "new" sites though we should '
+'ideally treat the data as continuous with the replaced site. This field indicates the site_id '
+'of the new replacement site, if any.';
+
+COMMENT ON COLUMN ecocounter.sites_unfiltered.centreline_id IS E''
+'The nearest street centreline_id, noting that ecocounter sensors are only configured to count '
+'bike-like objects on a portion of the roadway ie. cycletrack or multi-use-path. '
+'Join using `JOIN gis_core.centreline_latest USING (centreline_id)`.';

--- a/volumes/ecocounter/updates/ecocounter_centreline_updates.sql
+++ b/volumes/ecocounter/updates/ecocounter_centreline_updates.sql
@@ -1,0 +1,45 @@
+--use a temp table to visualize ecocounter - centreline intersection matches. 
+
+CREATE TEMP TABLE ecocounter_centrelines AS (
+    WITH centrelines AS (
+            SELECT
+                centreline_id,
+                linear_name_full,
+                ST_SetSRID(geom, 4326) AS geom,
+                feature_code_desc
+            FROM gis_core.centreline_latest
+            WHERE feature_code_desc NOT IN (
+                'Expressway',
+                'Expressway Ramp'
+            ) -- definitely no ecocounters here!
+        )
+    
+    SELECT DISTINCT ON (det.site_id)
+        rank() OVER (ORDER BY det.site_id) AS _rank, --uid needed for plotting in qgis
+        det.site_id,
+        cl.centreline_id,
+        cl.linear_name_full,
+        cl.geom AS centreline_geom,
+        cl.feature_code_desc,
+        det.site_description AS detector_loc,
+        det.geom AS sensor_geom
+    FROM ecocounter.sites AS det
+    LEFT JOIN centrelines AS cl
+        ON st_intersects(cl.geom, st_buffer(det.geom, 0.01))
+    WHERE det.centreline_id IS NULL
+    ORDER BY
+        det.site_id,
+        --select the closest match
+        st_distance(det.geom, cl.geom)
+);
+
+--can visualize with two layers in qgis to see both centreline and sensor geom at once. 
+SELECT * FROM ecocounter_centrelines;
+
+--when satisfied, update sites_unfiltered:
+UPDATE ecocounter.sites_unfiltered
+SET centreline_id = cl.centreline_id
+FROM ecocounter_centrelines AS cl
+WHERE
+    sites_unfiltered.site_id = cl.site_id
+    AND sites_unfiltered.centreline_id IS NULL;

--- a/volumes/ecocounter/updates/ecocounter_centreline_updates.sql
+++ b/volumes/ecocounter/updates/ecocounter_centreline_updates.sql
@@ -2,18 +2,18 @@
 
 CREATE TEMP TABLE ecocounter_centrelines AS (
     WITH centrelines AS (
-            SELECT
-                centreline_id,
-                linear_name_full,
-                ST_SetSRID(geom, 4326) AS geom,
-                feature_code_desc
-            FROM gis_core.centreline_latest
-            WHERE feature_code_desc NOT IN (
-                'Expressway',
-                'Expressway Ramp'
-            ) -- definitely no ecocounters here!
-        )
-    
+        SELECT
+            centreline_id,
+            linear_name_full,
+            ST_SetSRID(geom, 4326) AS geom,
+            feature_code_desc
+        FROM gis_core.centreline_latest
+        WHERE feature_code_desc NOT IN (
+            'Expressway',
+            'Expressway Ramp'
+        ) -- definitely no ecocounters here!
+    )
+
     SELECT DISTINCT ON (det.site_id)
         rank() OVER (ORDER BY det.site_id) AS _rank, --uid needed for plotting in qgis
         det.site_id,

--- a/volumes/ecocounter/views/create-view-sites.sql.sql
+++ b/volumes/ecocounter/views/create-view-sites.sql.sql
@@ -19,9 +19,9 @@ GRANT SELECT ON TABLE ecocounter.sites TO bdit_humans;
 
 GRANT SELECT ON TABLE ecocounter.sites TO ecocounter_bot;
 
-COMMENT ON VIEW ecocounter.sites
-IS 'Sites or "locations" of separate ecocounter
-installations. Each site may have one or more flows.';
+COMMENT ON VIEW ecocounter.sites IS E''
+'CAUTION: Use VIEW `ecocounter.sites` which includes only sites verified by a human.'
+'Sites represent separate installations, where each site may have one or more flow.';
 
 COMMENT ON COLUMN ecocounter.sites.site_id
 IS 'unique site identifier used by ecocounter';
@@ -29,9 +29,12 @@ IS 'unique site identifier used by ecocounter';
 COMMENT ON COLUMN ecocounter.sites.facility_description
 IS 'description of bike-specific infrastructure which the sensor is installed within';
 
-COMMENT ON COLUMN ecocounter.sites.replaced_by_site_id
-IS 'Several sites had their sensors replaced and
-show up now as "new" sites though we should ideally
-treat the data as continuous with the replaced site.
-This field indicates the site_id of the new
-replacement site, if any.';
+COMMENT ON COLUMN ecocounter.sites.replaced_by_site_id IS E''
+'Several sites had their sensors replaced and show up now as "new" sites though we should '
+'ideally treat the data as continuous with the replaced site. This field indicates the site_id '
+'of the new replacement site, if any.';
+
+COMMENT ON COLUMN ecocounter.sites.centreline_id IS E''
+'The nearest street centreline_id, noting that ecocounter sensors are only configured to count '
+'bike-like objects on a portion of the roadway ie. cycletrack or multi-use-path. '
+'Join using `JOIN gis_core.centreline_latest USING (centreline_id)`.';

--- a/volumes/ecocounter/views/create-view-sites.sql.sql
+++ b/volumes/ecocounter/views/create-view-sites.sql.sql
@@ -5,7 +5,8 @@ CREATE VIEW ecocounter.sites AS (
         geom,
         facility_description,
         notes,
-        replaced_by_site_id
+        replaced_by_site_id,
+        centreline_id
     FROM ecocounter.sites_unfiltered
     WHERE validated
 );


### PR DESCRIPTION
## What this pull request accomplishes:

- adds `centreline_id` to `ecocounter.sites` and `ecocounter.sites_unfiltered`. 
- a sql script used to identify new matches

## Issue(s) this solves:

- #966 

## What, in particular, needs to reviewed:
- Decision to add centreline_id to sites and not to flows. I figured for flows it would be duplicated between the flows at a given site which would make it very difficult to visualize. 
- Should I also add cl_geom to `ecocounter.sites` view?

## What needs to be done by a sysadmin after this PR is merged
Nothing.
