### PR TITLE
#977 change here to use triggerdagoperator

### DIFF
--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -105,18 +105,15 @@ def pull_here():
     #    return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $USER -d bigdata -c "\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
     # Create a task group for triggering the DAGs
     @task_group(group_id='trigger_dags_tasks')
-    def trigger_dags(**kwargs):
+    def trigger_dags():
         # Define TriggerDagRunOperator for each dag to trigger
         trigger_operators = []
-        #ds = kwargs['ds']
-        #upstream_dag = kwargs['dag'].dag_id
-        #get dags to trigger from airflow variable 
         DAGS_TO_TRIGGER = Variable.get('here_dag_triggers', deserialize_json=True)
         for dag_id in DAGS_TO_TRIGGER:
             trigger_operator = TriggerDagRunOperator(
                 task_id=f'trigger_{dag_id}',
                 trigger_dag_id=dag_id,
-                execution_date = '{{ ds }}', 
+                execution_date = '{{ ds }}',
                 reset_dag_run = True # Clear existing dag if already exists (for backfilling), old runs will not be in the logs
             )
             trigger_operators.append(trigger_operator)

--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -105,7 +105,7 @@ def pull_here():
     #    return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $USER -d bigdata -c "\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
     # Create a task group for triggering the DAGs
     @task_group(group_id='trigger_dags_tasks')
-    def trigger_dags():
+    def trigger_dags(**kwargs):
         # Define TriggerDagRunOperator for each dag to trigger
         trigger_operators = []
         DAGS_TO_TRIGGER = Variable.get('here_dag_triggers', deserialize_json=True)

--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -45,7 +45,7 @@ default_args = {'owner': ','.join(names),
                 'start_date': pendulum.datetime(2020, 1, 5, tz="America/Toronto"),
                 'email_on_failure': False,
                 'email_on_success': False,
-                'retries': 0, #Retry 3 times
+                'retries': 3, #Retry 3 times
                 'retry_delay': timedelta(minutes=60), #Retry after 60 mins
                 'retry_exponential_backoff': True, #Allow for progressive longer waits between retries
                 'on_failure_callback': task_fail_slack_alert,
@@ -70,9 +70,8 @@ def pull_here():
         return access_token
 
     @task
-    def get_request_id(access_token: str, **kwargs):
+    def get_request_id(access_token: str, ds=None):
         api_conn = BaseHook.get_connection('here_api_key')
-        ds = kwargs["ds"]
         pull_date = ds_format(ds_add(ds, -1), "%Y-%m-%d", "%Y%m%d")
         request_id = query_dates(access_token, pull_date, pull_date, api_conn.host, api_conn.login, api_conn.extra_dejson['user_email'])
         return request_id

--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -117,6 +117,7 @@ def pull_here():
             trigger_operator = TriggerDagRunOperator(
                 task_id=f'trigger_{dag_id}',
                 trigger_dag_id=dag_id,
+                execution_date = '{{ ds }}', 
                 reset_dag_run = True # Clear existing dag if already exists (for backfilling), old runs will not be in the logs
             )
             trigger_operators.append(trigger_operator)

--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -9,66 +9,118 @@ import pendulum
 from airflow import DAG
 from datetime import datetime, timedelta
 from airflow.operators.bash_operator import BashOperator
+from airflow.models.connection import Connection
+from airflow.hooks.base_hook import BaseHook
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.models import Variable 
-from airflow.utils.task_group import TaskGroup
+from airflow.models import Variable
+from airflow.decorators import dag, task, task_group
+from airflow.macros import ds_add, ds_format
 
 try:
     repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
     sys.path.insert(0, repo_path)
     from dags.dag_functions import task_fail_slack_alert
+    from here.traffic.here_api import query_dates, get_access_token, get_download_url, download_data, send_data_to_database
+    cfg_path = repo_path
 except:
     raise ImportError("Cannot import slack alert functions")
 
-dag_name = 'pull_here'
+doc_md = """
 
+### The Daily HERE pulling DAG [probe]
+
+This DAG runs daily to pull here data from traffic analytics' API to here.ta in the bigdata database using Taskflow.
+Slack notifications is raised when the airflow process fails. 
+This pulles probe data in oppose to path in the pull_here_path DAG.
+
+"""
+
+dag_name = 'pull_here'
 dag_owners = Variable.get('dag_owners', deserialize_json=True)
 names = dag_owners.get(dag_name, ['Unknown']) #find dag owners w/default = Unknown    
-
-here_postgres = PostgresHook("here_bot")
-rds_con = here_postgres.get_uri()
 
 default_args = {'owner': ','.join(names),
                 'depends_on_past':False,
                 'start_date': pendulum.datetime(2020, 1, 5, tz="America/Toronto"),
                 'email_on_failure': False,
                 'email_on_success': False,
-                'retries': 3, #Retry 3 times
+                'retries': 0, #Retry 3 times
                 'retry_delay': timedelta(minutes=60), #Retry after 60 mins
                 'retry_exponential_backoff': True, #Allow for progressive longer waits between retries
                 'on_failure_callback': task_fail_slack_alert,
-                'env':{'here_bot':rds_con,
-                       'LC_ALL':'C.UTF-8', #Necessary for Click
+                'env':{'LC_ALL':'C.UTF-8', #Necessary for Click
                        'LANG':'C.UTF-8'}
                 }
 
-dag = DAG(dag_id = dag_name, default_args = default_args, schedule = ' 30 16 * * * ')
-#Every day at 1630
+@dag(dag_id = dag_name,
+     default_args=default_args,
+     schedule_interval='30 16 * * * ' ,
+     catchup=False,
+     doc_md = doc_md,
+     tags=["HERE"]
+     )
 
-# Execution date seems to be the day before this was run, so yesterday_ds_nodash
-# should be equivalent to two days ago. https://stackoverflow.com/a/37739468/4047679
+def pull_here():
 
-pull_data = BashOperator(
-        task_id = 'pull_here',
-        bash_command = '/data/airflow/airflow_venv/bin/python3 /data/airflow/data_scripts/here/traffic/here_api.py -d /data/airflow/data_scripts/here/traffic/config.cfg -s {{ yesterday_ds_nodash }} -e {{ yesterday_ds_nodash }} ', 
-        dag=dag,
-        )
+    @task
+    def send_request():
+        api_conn = BaseHook.get_connection('here_api_key')
+        access_token = get_access_token(api_conn.password, api_conn.extra_dejson['client_secret'], api_conn.extra_dejson['token_url'])
+        return access_token
 
-#get dags to trigger from airflow variable 
-DAGS_TO_TRIGGER = Variable.get('here_dag_triggers', deserialize_json=True)
+    @task
+    def get_request_id(access_token: str, **kwargs):
+        api_conn = BaseHook.get_connection('here_api_key')
+        ds = kwargs["ds"]
+        pull_date = ds_format(ds_add(ds, -1), "%Y-%m-%d", "%Y%m%d")
+        request_id = query_dates(access_token, pull_date, pull_date, api_conn.host, api_conn.login, api_conn.extra_dejson['user_email'])
+        return request_id
+    
+    @task(retries=2) 
+    def get_download_link(request_id: str, access_token: str):
+        api_conn = BaseHook.get_connection('here_api_key')
+        download_url = get_download_url(request_id, api_conn.extra_dejson['status_base_url'], access_token, api_conn.login)
+        return download_url
+    
+    access_token = send_request()
+    request_id =  get_request_id(access_token)
+    download_url = get_download_link(request_id, access_token)
 
-# Create a task group for triggering the DAGs
-with TaskGroup(group_id='trigger_dags_tasks', dag=dag) as trigger_dags_group:
-    # Define TriggerDagRunOperator for each dag to trigger
-    trigger_operators = []
-    for dag_id in DAGS_TO_TRIGGER:
-        trigger_operator = TriggerDagRunOperator(
-            task_id=f'trigger_{dag_id}',
-            trigger_dag_id=dag_id,
-            reset_dag_run = True, # Clear existing dag if already exists (for backfilling)
-            dag=dag,
-        )
-        trigger_operators.append(trigger_operator)
+    load_data_run = BashOperator(
+        task_id = "load_data",
+        bash_command = '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $USER -d bigdata -c "\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" ''', 
+        env = {"DOWNLOAD_URL": download_url, 
+               "HOST":  BaseHook.get_connection("here_bot").host, 
+               "USER" :  BaseHook.get_connection("here_bot").login, 
+               "PGPASSWORD": BaseHook.get_connection("here_bot").password},
+        append_env=True
+    )
 
-pull_data >> trigger_operators
+    #Can implement the following when we upgrade to 2.9.1 
+    #@task.bash(env={"DOWNLOAD_URL": download_url,
+    #                "HOST":  BaseHook.get_connection("here_bot").host,
+    #                "USER" :  BaseHook.get_connection("here_bot").login,
+    #           "        PGPASSWORD": BaseHook.get_connection("here_bot").password})
+    #def load_data_run()->str:
+    #    return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $USER -d bigdata -c "\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
+    # Create a task group for triggering the DAGs
+    @task_group(group_id='trigger_dags_tasks')
+    def trigger_dags(**kwargs):
+        # Define TriggerDagRunOperator for each dag to trigger
+        trigger_operators = []
+        #ds = kwargs['ds']
+        #upstream_dag = kwargs['dag'].dag_id
+        #get dags to trigger from airflow variable 
+        DAGS_TO_TRIGGER = Variable.get('here_dag_triggers', deserialize_json=True)
+        for dag_id in DAGS_TO_TRIGGER:
+            trigger_operator = TriggerDagRunOperator(
+                task_id=f'trigger_{dag_id}',
+                trigger_dag_id=dag_id,
+                reset_dag_run = True # Clear existing dag if already exists (for backfilling), old runs will not be in the logs
+            )
+            trigger_operators.append(trigger_operator)
+
+    load_data_run >> trigger_dags()
+
+pull_here()

--- a/here/traffic/here_api.py
+++ b/here/traffic/here_api.py
@@ -220,7 +220,7 @@ def pull_here_data(ctx, startdate, enddate):
     try:
         access_token = get_access_token(apis['key_id'], apis['client_secret'], apis['token_url'])
 
-        request_id = query_dates(access_token, startdate, enddate, apis['query_url'], apis['user_id'], apis['user_email'])
+        request_id = query_dates(access_token, _get_date_yyyymmdd(startdate), _get_date_yyyymmdd(enddate), apis['query_url'], apis['user_id'], apis['user_email'])
 
         download_url = get_download_url(request_id, apis['status_base_url'], access_token, apis['user_id'])
 


### PR DESCRIPTION
## What this pull request accomplishes:

- Make pull here dag triggers dependent dag top down instead of down up using external task sensors. Dependent dags are stored in a variable for easy add/remove in the future. 

## Issue(s) this solves:

- #977 

## What, in particular, needs to reviewed:



## What needs to be done by a sysadmin after this PR is merged
Currently linked to my data home, removed all the other depedenent dag's external task sensor for testing and it worked today! FYI triggered dependent DAG runs are tagged as `manual run`. 
Will have to 
`ln -sf`

![image](https://github.com/CityofToronto/bdit_data-sources/assets/46324452/6bd25138-3cc8-42c3-885e-b06e44f548bc)
