### PR TITLE
973 ecocounter investigate discrepency between bigdata and online dashboard tools

### DIFF
--- a/dags/ecocounter_pull.py
+++ b/dags/ecocounter_pull.py
@@ -167,7 +167,8 @@ def pull_ecocounter_dag():
                     for count in counts:
                         row=(flow_id, count['date'], count['counts'])
                         volume.append(row)
-                    LOGGER.debug(f'{len(volume)} rows fetched for flow {flow_id} of site {site_id}.')
+                    if len(volume) == 0:
+                        LOGGER.info(f'{len(volume)} rows fetched for flow {flow_id} of site {site_id}.')
                     insertFlowCounts(conn, volume)
                 LOGGER.info(f'Data inserted for site {site_id}.')
           

--- a/dags/ecocounter_pull.py
+++ b/dags/ecocounter_pull.py
@@ -62,7 +62,7 @@ default_args = {
 @dag(
     dag_id=DAG_NAME,
     default_args=default_args,
-    schedule='0 3 * * *',
+    schedule='0 10 * * *',
     template_searchpath=os.path.join(repo_path,'dags/sql'),
     catchup=True,
     max_active_runs=1,

--- a/dags/ecocounter_pull.py
+++ b/dags/ecocounter_pull.py
@@ -152,7 +152,6 @@ def pull_ecocounter_dag():
         start_date = dateutil.parser.parse(str(ds))
         end_date = dateutil.parser.parse(str(ds_add(ds, 1)))
         LOGGER.info(f'Pulling data from {start_date} to {end_date}.')
-
         with eco_postgres.get_conn() as conn:
             for site_id in getKnownSites(conn):
                 LOGGER.debug(f'Starting on site {site_id}.')
@@ -168,8 +167,8 @@ def pull_ecocounter_dag():
                     for count in counts:
                         row=(flow_id, count['date'], count['counts'])
                         volume.append(row)
+                    LOGGER.debug(f'{len(volume)} rows fetched for flow {flow_id} of site {site_id}.')
                     insertFlowCounts(conn, volume)
-                    LOGGER.debug(f'Data inserted for flow {flow_id} of site {site_id}.')
                 LOGGER.info(f'Data inserted for site {site_id}.')
           
     t_done = ExternalTaskMarker(
@@ -206,7 +205,7 @@ def pull_ecocounter_dag():
             retries=0,
             params=data_check_params | {
                     "id_col": "flow_id",
-                    "threshold": 0.7
+                    "threshold": 0.85
                 },
         )
         check_distinct_flow_ids.doc_md = '''


### PR DESCRIPTION
## What this pull request accomplishes:
- captures 401 and other bad api status_codes (encountered during testing, but doesn't appear to be the issue)
- changes schedule to 10am to capture data from some late arriving sensors (this was the issue)
- add logging for when 0 volumes are pulled for a site

See runs from Master (Log 1) / 973 (Log 2) here: https://trans-bdit.intra.prod-toronto.ca/airflow/dags/ecocounter_pull/grid?dag_run_id=scheduled__2024-06-12T07%3A00%3A00%2B00%3A00&task_id=data_checks.check_volume&tab=logs
- 14K rows pulled at 3AM ❌ 
- 21K rows pulled at 9:40AM ✔️ 

## Issue(s) this solves:

- #973 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged
