### PR TITLE
987 ecocounter first active and last active columns

### DIFF
--- a/volumes/ecocounter/functions/function-fn_update_last_active.sql
+++ b/volumes/ecocounter/functions/function-fn_update_last_active.sql
@@ -1,8 +1,8 @@
-CREATE FUNCTION ecocounter.fn_update_last_active ()
-    RETURNS trigger
-    LANGUAGE 'plpgsql'
-    COST 100
-    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+CREATE OR REPLACE FUNCTION ecocounter.fn_update_last_active()
+RETURNS trigger
+LANGUAGE 'plpgsql'
+COST 100
+VOLATILE SECURITY DEFINER PARALLEL UNSAFE
 AS $BODY$
 
 BEGIN
@@ -33,7 +33,6 @@ BEGIN
             last_active = GREATEST(last_active, max_dt)
         FROM new_site_dates
         WHERE new_site_dates.site_id = sites_unfiltered.site_id
-        RETURNING *
     )
     
     UPDATE ecocounter.flows_unfiltered
@@ -46,7 +45,7 @@ BEGIN
 END;
 $BODY$;
 
-COMMENT ON FUNCTION ecocounter.fn_update_last_active IS E''
+COMMENT ON FUNCTION ecocounter.fn_update_last_active() IS E''
 'This function is called using a trigger after each statement on insert or update to '
 'ecocounter.counts_unfiltered. It uses newly inserted/updated rows to update the first_active and'
 'last_active columns in ecocounter.sites and ecocounter.flows.';

--- a/volumes/ecocounter/functions/function-fn_update_last_active.sql
+++ b/volumes/ecocounter/functions/function-fn_update_last_active.sql
@@ -1,0 +1,52 @@
+CREATE FUNCTION ecocounter.fn_update_last_active ()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE SECURITY DEFINER PARALLEL UNSAFE
+AS $BODY$
+
+BEGIN
+
+    WITH new_flow_dates AS (
+        SELECT
+            flow_id,
+            MIN(datetime_bin) AS min_dt,
+            MAX(datetime_bin) AS max_dt
+        FROM new_rows
+        GROUP BY flow_id
+    ),
+    
+    new_site_dates AS (
+        SELECT
+            site_id,
+            MIN(min_dt) AS min_dt,
+            MAX(max_dt) AS max_dt
+        FROM new_flow_dates
+        JOIN ecocounter.flows_unfiltered USING (flow_id)
+        GROUP BY site_id
+    ),
+    
+    updated_sites AS (    
+        UPDATE ecocounter.sites_unfiltered
+        SET
+            first_active = LEAST(first_active, min_dt),
+            last_active = GREATEST(last_active, max_dt)
+        FROM new_site_dates
+        WHERE new_site_dates.site_id = sites_unfiltered.site_id
+        RETURNING *
+    )
+    
+    UPDATE ecocounter.flows_unfiltered
+    SET
+        first_active = LEAST(first_active, min_dt),
+        last_active = GREATEST(last_active, max_dt)
+    FROM new_flow_dates
+    WHERE new_flow_dates.flow_id = flows_unfiltered.flow_id;
+    RETURN NULL;
+END;
+$BODY$;
+
+COMMENT ON FUNCTION ecocounter.fn_update_last_active IS E''
+'This function is called using a trigger after each statement on insert or update to '
+'ecocounter.counts_unfiltered. It uses newly inserted/updated rows to update the first_active and'
+'last_active columns in ecocounter.sites and ecocounter.flows.';

--- a/volumes/ecocounter/functions/function-fn_update_last_active.sql
+++ b/volumes/ecocounter/functions/function-fn_update_last_active.sql
@@ -50,3 +50,7 @@ COMMENT ON FUNCTION ecocounter.fn_update_last_active IS E''
 'This function is called using a trigger after each statement on insert or update to '
 'ecocounter.counts_unfiltered. It uses newly inserted/updated rows to update the first_active and'
 'last_active columns in ecocounter.sites and ecocounter.flows.';
+
+GRANT EXECUTE ON FUNCTION ecocounter.fn_update_last_active() TO ecocounter_bot;
+
+ALTER FUNCTION ecocounter.fn_update_last_active OWNER TO ecocounter_admins;

--- a/volumes/ecocounter/readme.md
+++ b/volumes/ecocounter/readme.md
@@ -159,6 +159,9 @@ When you want to update new rows with missing `centreline_id`s, use [this script
 | notes | text | | |
 | replaced_by_site_id  | numeric | | Several sites had their sensors replaced and show up now as "new" sites though we should ideally treat the data as continuous with the replaced site. This field indicates the site_id of the new replacement site, if any. |
 | centreline_id | integer | | The nearest street centreline_id, noting that ecocounter sensors are only configured to count bike like objects on a portion of the roadway ie. cycletrack or multi-use-path. Join using `JOIN gis_core.centreline_latest USING (centreline_id)`. |
+| first_active | timestamp without time zone | | First timestamp site_id appears in ecocounter.counts_unfiltered. Updated using trigger with each insert on ecocounter.counts_unfiltered. |
+| last_active | timestamp without time zone | | Last timestamp site_id appears in ecocounter.counts_unfiltered. Updated using trigger with each insert on ecocounter.counts_unfiltered. |
+
 
 ### `ecocounter.counts_unfiltered`
 CAUTION: Use VIEW `ecocounter.counts` instead to see data only for sites verified by a human.
@@ -188,6 +191,8 @@ Row count: 73
 | bin_size | interval | 0 days 00:15:00 | temporal bins are either 15 or 30 minutes, depending on the sensor |
 | notes | text | | |
 | replaced_by_flow_id | numeric | 353363669 | |
+| first_active | timestamp without time zone | | First timestamp flow_id appears in ecocounter.counts_unfiltered. Updated using trigger with each insert on ecocounter.counts_unfiltered. |
+| last_active | timestamp without time zone | | Last timestamp flow_id appears in ecocounter.counts_unfiltered. Updated using trigger with each insert on ecocounter.counts_unfiltered. |
 
 ## QC Tables
 These tables are used by  `ecocounter_admins` to document discontinuities and anomalous ranges in the Ecocounter data when identified.

--- a/volumes/ecocounter/tables/counts_unfiltered.sql
+++ b/volumes/ecocounter/tables/counts_unfiltered.sql
@@ -21,10 +21,22 @@ GRANT SELECT, INSERT, DELETE ON ecocounter.counts_unfiltered TO ecocounter_bot;
 
 REVOKE ALL ON TABLE ecocounter.counts_unfiltered FROM bdit_humans;
 
-COMMENT ON TABLE ecocounter.counts_unfiltered
-IS 'CAUTION: Use VIEW `ecocounter.counts` instead to see data only for sites verified by a human.
-This Table contains the actual binned counts for ecocounter flows. Please note that
-bin size varies for older data, so averaging these numbers may not be straightforward.';
+COMMENT ON TABLE ecocounter.counts_unfiltered IS E''
+'CAUTION: Use VIEW `ecocounter.counts` instead to see data only for sites verified by a human. '
+'This Table contains the actual binned counts for ecocounter flows. Please note that '
+'bin size varies for older data, so averaging these numbers may not be straightforward.';
 
 COMMENT ON COLUMN ecocounter.counts_unfiltered.datetime_bin
 IS 'indicates start time of the time bin. Note that not all time bins are the same size!';
+
+CREATE TRIGGER ecocounter_update_last_active_ins
+AFTER INSERT ON ecocounter.counts_unfiltered
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION ecocounter.fn_update_last_active();
+
+CREATE TRIGGER ecocounter_update_last_active_upd
+AFTER UPDATE ON ecocounter.counts_unfiltered
+REFERENCING NEW TABLE AS new_rows
+FOR EACH STATEMENT
+EXECUTE FUNCTION ecocounter.fn_update_last_active();

--- a/volumes/ecocounter/tables/flows_unfiltered.sql
+++ b/volumes/ecocounter/tables/flows_unfiltered.sql
@@ -9,6 +9,8 @@ CREATE TABLE ecocounter.flows_unfiltered (
     replaces_flow_id numeric,
     includes_contraflow boolean,
     validated boolean,
+    first_active timestamp without time zone,
+    last_active timestamp without time zone,
     CONSTRAINT locations_pkey PRIMARY KEY (flow_id),
     CONSTRAINT flows_replaced_by_flow_id_fkey FOREIGN KEY (replaced_by_flow_id)
     REFERENCES ecocounter.flows_unfiltered (flow_id) MATCH SIMPLE
@@ -35,31 +37,33 @@ REVOKE ALL ON TABLE ecocounter.flows_unfiltered FROM ecocounter_bot;
 GRANT ALL ON TABLE ecocounter.flows_unfiltered TO ecocounter_admins;
 GRANT SELECT, INSERT ON TABLE ecocounter.flows_unfiltered TO ecocounter_bot;
 
-COMMENT ON TABLE ecocounter.flows_unfiltered
-IS 'CAUTION: Use VIEW `ecocounter.flows` which includes only flows verified by a human.
-A flow is usually a direction of travel associated with a sensor at
-an ecocounter installation site. For earlier sensors that did not detect
-directed flows, a flow may be both directions of travel together, i.e.
-just everyone who passed over the sensor any which way.';
+COMMENT ON TABLE ecocounter.flows_unfiltered IS E''
+'CAUTION: Use VIEW `ecocounter.flows` which includes only flows verified by a human. '
+'A flow is usually a direction of travel associated with a sensor at '
+'an ecocounter installation site. For earlier sensors that did not detect '
+'directed flows, a flow may be both directions of travel together, i.e. '
+'just everyone who passed over the sensor any which way.';
 
 COMMENT ON COLUMN ecocounter.flows_unfiltered.bin_size
 IS 'temporal bins are either 15, 30, or 60 minutes, depending on the sensor';
 
-COMMENT ON COLUMN ecocounter.flows_unfiltered.flow_geom
-IS 'A two-node line, where the first node 
-indicates the position of the sensor and
-the second indicates the normal direction
-of travel over that sensor relative to the
-first node. I.e. the line segment is an
-arrow pointing in the direction of travel.';
+COMMENT ON COLUMN ecocounter.flows_unfiltered.flow_geom IS E''
+'A two-node line, where the first node indicates the position of the sensor and '
+'the second indicates the normal direction of travel over that sensor relative to the '
+'first node. I.e. the line segment is an arrow pointing in the direction of travel.';
 
-COMMENT ON COLUMN ecocounter.flows_unfiltered.includes_contraflow
-IS 'Does the flow also count travel in the reverse of
-the indicated flow direction?
-TRUE indicates that the flow, though installed
-in one-way infrastucture like a standard bike lane,
-also counts travel going the wrong direction within
-that lane.';
+COMMENT ON COLUMN ecocounter.flows_unfiltered.includes_contraflow IS E''
+'Does the flow also count travel in the reverse of the indicated flow direction? '
+'TRUE indicates that the flow, though installed in one-way infrastucture like a standard bike '
+'lane, also counts travel going the wrong direction within that lane.';
+
+COMMENT ON COLUMN ecocounter.flows_unfiltered.first_active IS E''
+'First timestamp flow_id appears in ecocounter.counts_unfiltered. '
+'Updated using trigger with each insert on ecocounter.counts_unfiltered. ';
+
+COMMENT ON COLUMN ecocounter.flows_unfiltered.last_active IS E''
+'Last timestamp flow_id appears in ecocounter.counts_unfiltered. '
+'Updated using trigger with each insert on ecocounter.counts_unfiltered. ';
 
 CREATE INDEX IF NOT EXISTS flows_flow_id_idx
 ON ecocounter.flows_unfiltered USING btree (flow_id ASC NULLS LAST)

--- a/volumes/ecocounter/tables/sites_unfiltered.sql
+++ b/volumes/ecocounter/tables/sites_unfiltered.sql
@@ -7,6 +7,8 @@ CREATE TABLE ecocounter.sites_unfiltered (
     replaced_by_site_id numeric,
     validated boolean,
     centreline_id integer,
+    first_active timestamp without time zone,
+    last_active timestamp without time zone,
     CONSTRAINT sites_pkey PRIMARY KEY (site_id),
     CONSTRAINT sites_replaced_by_fkey FOREIGN KEY (replaced_by_site_id)
     REFERENCES ecocounter.sites_unfiltered (site_id) MATCH SIMPLE
@@ -43,3 +45,11 @@ COMMENT ON COLUMN ecocounter.sites_unfiltered.centreline_id IS E''
 'The nearest street centreline_id, noting that ecocounter sensors are only configured to count '
 'bike-like objects on a portion of the roadway ie. cycletrack or multi-use-path. '
 'Join using `JOIN gis_core.centreline_latest USING (centreline_id)`.';
+
+COMMENT ON COLUMN ecocounter.sites_unfiltered.first_active IS E''
+'First timestamp site_id appears in ecocounter.counts_unfiltered. '
+'Updated using trigger with each insert on ecocounter.counts_unfiltered. ';
+
+COMMENT ON COLUMN ecocounter.sites_unfiltered.last_active IS E''
+'Last timestamp site_id appears in ecocounter.counts_unfiltered. '
+'Updated using trigger with each insert on ecocounter.counts_unfiltered. ';

--- a/volumes/ecocounter/views/create-view-flows.sql
+++ b/volumes/ecocounter/views/create-view-flows.sql
@@ -1,4 +1,4 @@
-CREATE VIEW ecocounter.flows AS (
+CREATE OR REPLACE VIEW ecocounter.flows AS (
     SELECT
         flow_id,
         site_id,
@@ -8,11 +8,12 @@ CREATE VIEW ecocounter.flows AS (
         notes,
         replaced_by_flow_id,
         replaces_flow_id,
-        includes_contraflow
+        includes_contraflow,
+        first_active,
+        last_active
     FROM ecocounter.flows_unfiltered
     WHERE validated
-)
-TABLESPACE pg_default;
+);
 
 ALTER VIEW ecocounter.flows OWNER TO ecocounter_admins;
 GRANT ALL ON TABLE ecocounter.flows TO ecocounter_admins;
@@ -22,29 +23,30 @@ GRANT SELECT ON TABLE ecocounter.flows TO bdit_humans;
 
 GRANT SELECT ON TABLE ecocounter.flows TO ecocounter_bot;
 
-COMMENT ON VIEW ecocounter.flows
-IS 'A flow is usually a direction of travel associated with a sensor at
-an ecocounter installation site. For earlier sensors that did not detect
-directed flows, a flow may be both directions of travel together, i.e.
-just everyone who passed over the sensor any which way.
-
-This table should only contain flows with at least some valid-ish data. ';
+COMMENT ON VIEW ecocounter.flows IS E''
+'A flow is usually a direction of travel associated with a sensor at '
+'an ecocounter installation site. For earlier sensors that did not detect '
+'directed flows, a flow may be both directions of travel together, i.e. '
+'just everyone who passed over the sensor any which way. '
+'This table should only contain flows with at least some valid-ish data. ';
 
 COMMENT ON COLUMN ecocounter.flows.bin_size
 IS 'temporal bins are either 15, 30, or 60 minutes, depending on the sensor';
 
-COMMENT ON COLUMN ecocounter.flows.flow_geom
-IS 'A two-node line, where the first node 
-indicates the position of the sensor and
-the second indicates the normal direction
-of travel over that sensor relative to the
-first node. I.e. the line segment is an
-arrow pointing in the direction of travel.';
+COMMENT ON COLUMN ecocounter.flows.flow_geom IS E''
+'A two-node line, where the first node indicates the position of the sensor and '
+'the second indicates the normal direction of travel over that sensor relative to the '
+'first node. I.e. the line segment is an arrow pointing in the direction of travel.';
 
-COMMENT ON COLUMN ecocounter.flows.includes_contraflow
-IS 'Does the flow also count travel in the reverse of
-the indicated flow direction?
-TRUE indicates that the flow, though installed
-in one-way infrastucture like a standard bike lane,
-also counts travel going the wrong direction within
-that lane.';
+COMMENT ON COLUMN ecocounter.flows.includes_contraflow IS E''
+'Does the flow also count travel in the reverse of the indicated flow direction? '
+'TRUE indicates that the flow, though installed in one-way infrastucture like a standard bike '
+'lane, also counts travel going the wrong direction within that lane.';
+
+COMMENT ON COLUMN ecocounter.flows_unfiltered.first_active IS E''
+'First timestamp flow_id appears in ecocounter.counts_unfiltered. '
+'Updated using trigger with each insert on ecocounter.counts_unfiltered. ';
+
+COMMENT ON COLUMN ecocounter.flows_unfiltered.last_active IS E''
+'Last timestamp flow_id appears in ecocounter.counts_unfiltered. '
+'Updated using trigger with each insert on ecocounter.counts_unfiltered. ';

--- a/volumes/ecocounter/views/create-view-sites.sql
+++ b/volumes/ecocounter/views/create-view-sites.sql
@@ -1,4 +1,4 @@
-CREATE VIEW ecocounter.sites AS (
+CREATE OR REPLACE VIEW ecocounter.sites AS (
     SELECT
         site_id,
         site_description,
@@ -6,7 +6,9 @@ CREATE VIEW ecocounter.sites AS (
         facility_description,
         notes,
         replaced_by_site_id,
-        centreline_id
+        centreline_id,
+        first_active,
+        last_active
     FROM ecocounter.sites_unfiltered
     WHERE validated
 );
@@ -38,3 +40,11 @@ COMMENT ON COLUMN ecocounter.sites.centreline_id IS E''
 'The nearest street centreline_id, noting that ecocounter sensors are only configured to count '
 'bike-like objects on a portion of the roadway ie. cycletrack or multi-use-path. '
 'Join using `JOIN gis_core.centreline_latest USING (centreline_id)`.';
+
+COMMENT ON COLUMN ecocounter.sites.first_active IS E''
+'First timestamp site_id appears in ecocounter.counts_unfiltered. '
+'Updated using trigger with each insert on ecocounter.counts_unfiltered. ';
+
+COMMENT ON COLUMN ecocounter.sites.last_active IS E''
+'Last timestamp site_id appears in ecocounter.counts_unfiltered. '
+'Updated using trigger with each insert on ecocounter.counts_unfiltered. ';


### PR DESCRIPTION
## What this pull request accomplishes:

- adds first_active and last_active columns to ecocounter sites, flows, sites_unfiltered, flows_unfiltered
- adds tigger on ecocounter.counts_unfiltered and a new function to update first_active and last_active columns on each update/insert. 

## Issue(s) this solves:

- Closes #987 

## What, in particular, needs to reviewed:
- First use of `TRIGGER... REFERENCING NEW TABLE` ! 
- volumes/ecocounter/functions/function-fn_update_last_active.sql

## What needs to be done by a sysadmin after this PR is merged
Nothing
