### PR TITLE
#992 fix vds detector_loc formula

### DIFF
--- a/volumes/vds/sql/views/create-view-detector_inventory.sql
+++ b/volumes/vds/sql/views/create-view-detector_inventory.sql
@@ -8,7 +8,7 @@ CREATE OR REPLACE VIEW vds.detector_inventory AS (
         c.detector_id,
         pairs.first_active,
         pairs.last_active,
-        (upper(e.main_road_name::text) || ' and '::text) || upper(e.cross_road_name::text)
+        upper(e.main_road_name::text) || COALESCE(' and '::text || upper(e.cross_road_name::text), ''::text)
         AS detector_loc,
         e.geom AS sensor_geom,
         cl_vds.centreline_id,

--- a/volumes/vds/sql/views/create-view-detector_inventory.sql
+++ b/volumes/vds/sql/views/create-view-detector_inventory.sql
@@ -1,15 +1,15 @@
 --DROP VIEW vds.detector_inventory;
 CREATE OR REPLACE VIEW vds.detector_inventory AS (
     SELECT DISTINCT ON (pairs.vdsconfig_uid, pairs.entity_location_uid, pairs.division_id)
-        row_number() OVER (), --uid to make this view mappable in QGIS
+        row_number() OVER () AS row_number, --uid to make this view mappable in QGIS
         pairs.vdsconfig_uid,
         pairs.entity_location_uid,
         pairs.division_id,
         c.detector_id,
         pairs.first_active,
         pairs.last_active,
-        upper(e.main_road_name::text) || COALESCE(' and '::text || upper(e.cross_road_name::text), ''::text)
-        AS detector_loc,
+        upper(e.main_road_name::text)
+        || COALESCE(' and '::text || upper(e.cross_road_name::text), ''::text) AS detector_loc,
         e.geom AS sensor_geom,
         cl_vds.centreline_id,
         cl.geom AS centreline_geom,


### PR DESCRIPTION
## What this pull request accomplishes:
- one line fix to detector_loc formula
- tested using:
```sql
SELECT upper(e.main_road_name::text) || COALESCE(' and '::text || upper(e.cross_road_name::text), ''::text)
FROM vds.entity_locations AS e
WHERE division_id = 2 AND e.cross_road_name IS NULL
```

## Issue(s) this solves:

- Closes #992

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
