### PR TITLE
645 replication processes check if data

### DIFF
--- a/dags/common_tasks.py
+++ b/dags/common_tasks.py
@@ -40,31 +40,6 @@ def get_variable(var_name:str) -> list:
     return Variable.get(var_name, deserialize_json=True)
 
 @task()
-def check_not_empty(conn_id:str, table:str, **context) -> None:
-    con = PostgresHook(conn_id).get_conn()
-    sch, tbl = table.split(".")
-    check_query = sql.SQL("SELECT True FROM {}.{} LIMIT 1;").format(sql.Identifier(sch), sql.Identifier(tbl))
-    try:
-        with con.cursor() as cur:
-            # check for non-empty table
-            cur.execute(check_query)
-            check = cur.fetchone()[0]
-            if check != True:
-                context["task_instance"].xcom_push(
-                    key="extra_msg",
-                    value=f"`{table}` is empty. Copying not completed."
-                )
-                raise AirflowFailException(e)
-    #catch psycopg2 errors:
-    except Error as e:
-        # push an extra failure message to be sent to Slack in case of failing
-        context["task_instance"].xcom_push(
-            key="extra_msg",
-            value=f"Failed to check `{table}` non-empty: `{str(e).strip()}`."
-        )
-        raise AirflowFailException(e)
-
-@task()
 def copy_table(conn_id:str, table:Tuple[str, str], **context) -> None:
     """Copies ``table[0]`` table into ``table[1]`` after truncating it.
 

--- a/dags/replicators.py
+++ b/dags/replicators.py
@@ -3,10 +3,11 @@
 # noqa: D415
 import os
 import sys
+from functools import partial
 from datetime import timedelta
 import pendulum
 # pylint: disable=import-error
-from airflow.decorators import dag, task
+from airflow.decorators import dag, task, task_group
 from airflow.models import Variable
 from airflow.exceptions import AirflowFailException
 
@@ -14,7 +15,7 @@ from airflow.exceptions import AirflowFailException
 repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 sys.path.insert(0, repo_path)
 # pylint: disable=wrong-import-position
-from dags.dag_functions import task_fail_slack_alert, send_slack_msg
+from dags.dag_functions import task_fail_slack_alert, send_slack_msg, check_not_empty
 # pylint: enable=import-error
 
 def create_replicator_dag(dag_id, short_name, tables_var, conn, doc_md, default_args): 
@@ -31,27 +32,25 @@ def create_replicator_dag(dag_id, short_name, tables_var, conn, doc_md, default_
     def replicator_DAG():
         f"""The main function of the {short_name} DAG."""
         from dags.common_tasks import (
-            wait_for_external_trigger, get_variable, copy_table, check_not_empty
+            wait_for_external_trigger, get_variable, copy_table
         )
 
         # Returns a list of source and destination tables stored in the given
         # Airflow variable.
         tables = get_variable.override(task_id="get_list_of_tables")(tables_var)
         
-        @task()
-        def get_source_tables(tables):
-            return [tbl[0] for tbl in tables]
-        
-        @task()
-        def get_dest_tables(tables):
-            return [tbl[1] for tbl in tables]
-        
-        # Copies tables
-        copy_tables = copy_table.override(task_id="copy_tables", on_failure_callback = None).partial(conn_id=conn).expand(table=tables)
+        @task_group
+        def copy_tables_with_checks(conn_id, tables):          
+            @task(on_failure_callback = None)
+            def check_tbl_not_empty(conn_id, tables, tbl_index, **context):
+                table = tables[tbl_index]
+                check_not_empty(context, conn_id, table)
 
-        # Check if empty
-        check_source_table = check_not_empty.override(task_id="check_source_table", on_failure_callback=None).partial(conn_id=conn).expand(table=get_source_tables(tables))
-        check_dest_table = check_not_empty.override(task_id="check_dest_table", on_failure_callback=None).partial(conn_id=conn).expand(table=get_dest_tables(tables))
+            [
+                check_tbl_not_empty.override(task_id="check_source_not_empty")(conn_id, tables, 0) >>
+                copy_table.override(task_id="copy_tables", on_failure_callback = None)(conn_id, tables) >>
+                check_tbl_not_empty.override(task_id="check_dest_not_empty")(conn_id, tables, 1)
+            ]
 
         @task(
             retries=0,
@@ -63,7 +62,12 @@ def create_replicator_dag(dag_id, short_name, tables_var, conn, doc_md, default_
             failures = []
             #iterate through mapped tasks to find any failure messages
             for m_i in range(0, len(tables)):
-                failure_msg = ti.xcom_pull(key="extra_msg", task_ids="copy_tables", map_indexes=m_i)
+                extra_msg = partial(ti.xcom_pull, key="extra_msg", map_indexes=m_i)
+                failure_0 = extra_msg(task_ids="copy_tables_with_checks.check_source_not_empty")
+                failure_1 = extra_msg(task_ids="copy_tables_with_checks.copy_tables")
+                failure_2 = extra_msg(task_ids="copy_tables_with_checks.check_dest_not_empty")
+                #pick the first non empty failure message from each mapped index.
+                failure_msg = failure_0 or failure_1 or failure_2
                 if failure_msg is not None:
                     failures.append(failure_msg)
             if failures == []:
@@ -77,7 +81,11 @@ def create_replicator_dag(dag_id, short_name, tables_var, conn, doc_md, default_
                 raise AirflowFailException('One or more tables failed to copy.')
             
         # Waits for an external trigger
-        wait_for_external_trigger() >> tables >> check_source_table >> copy_tables >> check_dest_table >> status_message(tables=tables)
+        [
+            wait_for_external_trigger() >>
+            copy_tables_with_checks.partial(conn_id=conn).expand(tables=tables) >>
+            status_message(tables=tables)
+        ]
 
     generated_dag = replicator_DAG()
 


### PR DESCRIPTION
## What this pull request accomplishes:

- Check for non-zero row count in source table before and destination table after truncate/insert.
- The dynamic task mapping is now done over task_group instead of task so that `check_source -> copy_table -> check_dest` happens in sequence for each map index (copy shouldn't proceed if source check failed)
- I tested successfully with a dummy table variable and then tested successfully with the actual table variables. I caught one empty table in move_staging which I notified MOVE about: `move_staging.collision_factors_cyccond` (failure msg [here](https://bditto.slack.com/archives/C04BWRWVB3L/p1719331402031249))

![image](https://github.com/CityofToronto/bdit_data-sources/assets/80077912/8789050e-b3fa-49fc-bdd0-b83c90ef9fac)


## Issue(s) this solves:

- Closes #645

## What, in particular, needs to reviewed:
- 

## What needs to be done by a sysadmin after this PR is merged

Update in data_scripts
