### PR TITLE
Filter anomalous ranges from Ecocounter `counts`

### DIFF
--- a/volumes/ecocounter/readme.md
+++ b/volumes/ecocounter/readme.md
@@ -164,7 +164,11 @@ When you want to update new rows with missing `centreline_id`s, use [this script
 
 
 ### `ecocounter.counts_unfiltered`
-CAUTION: Use VIEW `ecocounter.counts` instead to see data only for sites verified by a human.
+CAUTION: Use VIEW `ecocounter.counts` instead to see only data that has been screened for
+* manually validated sites
+* manually validated flows
+* absence of manually identified anomalous ranges (in the `do-not-use` `problem_level`)
+
 This Table contains the actual binned counts for ecocounter flows. Please note that
 bin size varies for older data, so averaging these numbers may not be straightforward.
 

--- a/volumes/ecocounter/views/create-view-counts.sql
+++ b/volumes/ecocounter/views/create-view-counts.sql
@@ -7,8 +7,10 @@ FROM ecocounter.counts_unfiltered
 JOIN ecocounter.flows_unfiltered USING (flow_id)
 JOIN ecocounter.sites_unfiltered USING (site_id)
 WHERE
-    flows_unfiltered.validated --is true
+    -- must be validated at the level of both site and flow
+    flows_unfiltered.validated
     AND sites_unfiltered.validated
+    -- must not intersect with any do-not-use level anomalous ranges
     AND NOT EXISTS (
         SELECT 1
         FROM ecocounter.anomalous_ranges
@@ -16,9 +18,11 @@ WHERE
             anomalous_ranges.problem_level = 'do-not-use'
             AND (
                 (
+                    -- flow has a problem is this time range
                     counts_unfiltered.flow_id = anomalous_ranges.flow_id
                     AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
                 ) OR (
+                    -- site has a problem in this time range
                     sites_unfiltered.site_id = anomalous_ranges.site_id
                     AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
                 )
@@ -26,9 +30,12 @@ WHERE
     );
 
 COMMENT ON VIEW ecocounter.counts
-IS 'This view contains the actual binned counts for ecocounter flows. Only flows
-marked as validated by a human are included here. Please note that bin size varies
-for older data, so averaging these numbers may not be straightforward.';
+IS 'This view contains the (somewhat) validated counts for Ecocounter flows. 
+Counts are only included for sites and flows and marked as validated by a human.
+Anomalous ranges at the do-not-use problem_level are also excluded here.
+For the complete, raw count data, see ecocounter.counts_unfiltered. 
+Please note that bin size varies for older data, so averaging these numbers may 
+not be straightforward.';
 
 ALTER VIEW ecocounter.counts OWNER TO ecocounter_admins;
 

--- a/volumes/ecocounter/views/create-view-counts.sql
+++ b/volumes/ecocounter/views/create-view-counts.sql
@@ -13,8 +13,16 @@ CREATE VIEW ecocounter.counts AS (
             SELECT 1
             FROM ecocounter.anomalous_ranges
             WHERE
-                counts_unfiltered.flow_id = anomalous_ranges.flow_id
-                AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
+                anomalous_ranges.problem_level = 'do-not-use'
+                AND (
+                    (
+                        counts_unfiltered.flow_id = anomalous_ranges.flow_id
+                        AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
+                    ) OR (
+                        sites_unfiltered.site_id = anomalous_ranges.site_id
+                        AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
+                    )
+                )
         )
 );
 

--- a/volumes/ecocounter/views/create-view-counts.sql
+++ b/volumes/ecocounter/views/create-view-counts.sql
@@ -5,8 +5,10 @@ CREATE VIEW ecocounter.counts AS (
         counts_unfiltered.volume
     FROM ecocounter.counts_unfiltered
     JOIN ecocounter.flows_unfiltered USING (flow_id)
+    JOIN ecocounter.sites_unfiltered USING (site_id)
     WHERE
         flows_unfiltered.validated --is true
+        AND sites_unfiltered.validated
         AND NOT EXISTS (
             SELECT 1
             FROM ecocounter.anomalous_ranges

--- a/volumes/ecocounter/views/create-view-counts.sql
+++ b/volumes/ecocounter/views/create-view-counts.sql
@@ -16,16 +16,10 @@ WHERE
         FROM ecocounter.anomalous_ranges
         WHERE
             anomalous_ranges.problem_level = 'do-not-use'
+            AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
             AND (
-                (
-                    -- flow has a problem is this time range
-                    counts_unfiltered.flow_id = anomalous_ranges.flow_id
-                    AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
-                ) OR (
-                    -- site has a problem in this time range
-                    sites_unfiltered.site_id = anomalous_ranges.site_id
-                    AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
-                )
+                counts_unfiltered.flow_id = anomalous_ranges.flow_id
+                OR sites_unfiltered.site_id = anomalous_ranges.site_id
             )
     );
 

--- a/volumes/ecocounter/views/create-view-counts.sql
+++ b/volumes/ecocounter/views/create-view-counts.sql
@@ -1,4 +1,4 @@
-CREATE VIEW ecocounter.counts AS
+CREATE OR REPLACE VIEW ecocounter.counts AS
 SELECT
     counts_unfiltered.flow_id,
     counts_unfiltered.datetime_bin,

--- a/volumes/ecocounter/views/create-view-counts.sql
+++ b/volumes/ecocounter/views/create-view-counts.sql
@@ -5,7 +5,15 @@ CREATE VIEW ecocounter.counts AS (
         counts_unfiltered.volume
     FROM ecocounter.counts_unfiltered
     JOIN ecocounter.flows_unfiltered USING (flow_id)
-    WHERE flows_unfiltered.validated --is true
+    WHERE
+        flows_unfiltered.validated --is true
+        AND NOT EXISTS (
+            SELECT 1
+            FROM ecocounter.anomalous_ranges
+            WHERE
+                counts_unfiltered.flow_id = anomalous_ranges.flow_id
+                AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
+        )
 );
 
 COMMENT ON VIEW ecocounter.counts

--- a/volumes/ecocounter/views/create-view-counts.sql
+++ b/volumes/ecocounter/views/create-view-counts.sql
@@ -1,30 +1,29 @@
-CREATE VIEW ecocounter.counts AS (
-    SELECT
-        counts_unfiltered.flow_id,
-        counts_unfiltered.datetime_bin,
-        counts_unfiltered.volume
-    FROM ecocounter.counts_unfiltered
-    JOIN ecocounter.flows_unfiltered USING (flow_id)
-    JOIN ecocounter.sites_unfiltered USING (site_id)
-    WHERE
-        flows_unfiltered.validated --is true
-        AND sites_unfiltered.validated
-        AND NOT EXISTS (
-            SELECT 1
-            FROM ecocounter.anomalous_ranges
-            WHERE
-                anomalous_ranges.problem_level = 'do-not-use'
-                AND (
-                    (
-                        counts_unfiltered.flow_id = anomalous_ranges.flow_id
-                        AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
-                    ) OR (
-                        sites_unfiltered.site_id = anomalous_ranges.site_id
-                        AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
-                    )
+CREATE VIEW ecocounter.counts AS
+SELECT
+    counts_unfiltered.flow_id,
+    counts_unfiltered.datetime_bin,
+    counts_unfiltered.volume
+FROM ecocounter.counts_unfiltered
+JOIN ecocounter.flows_unfiltered USING (flow_id)
+JOIN ecocounter.sites_unfiltered USING (site_id)
+WHERE
+    flows_unfiltered.validated --is true
+    AND sites_unfiltered.validated
+    AND NOT EXISTS (
+        SELECT 1
+        FROM ecocounter.anomalous_ranges
+        WHERE
+            anomalous_ranges.problem_level = 'do-not-use'
+            AND (
+                (
+                    counts_unfiltered.flow_id = anomalous_ranges.flow_id
+                    AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
+                ) OR (
+                    sites_unfiltered.site_id = anomalous_ranges.site_id
+                    AND anomalous_ranges.time_range @> counts_unfiltered.datetime_bin
                 )
-        )
-);
+            )
+    );
 
 COMMENT ON VIEW ecocounter.counts
 IS 'This view contains the actual binned counts for ecocounter flows. Only flows


### PR DESCRIPTION
## What this pull request accomplishes:

- removes anomalous ranges from the `ecocounter.counts` view  

(they are still in the unfiltered tables)

## Issue(s) this solves:

- closes #995 

## What, in particular, needs to reviewed:

- make sure the query is still nice and snappy

## What needs to be done by a sysadmin after this PR is merged

- replace existing view with new definition 
