### PR TITLE
#952 replicate using destination columns instead of source columns

### DIFF
--- a/dags/common_tasks.py
+++ b/dags/common_tasks.py
@@ -100,15 +100,15 @@ def copy_table(conn_id:str, table:Tuple[str, str], **context) -> None:
             # truncate the destination table
             cur.execute(truncate_query)
             # get the column names of the source table
-            cur.execute(source_columns_query, [src_schema, src_table])
-            src_columns = [r[0] for r in cur.fetchall()]
+            cur.execute(source_columns_query, [dst_schema, dst_table])
+            dst_columns = [r[0] for r in cur.fetchall()]
             # copy all the data
             insert_query = sql.SQL(
                 "INSERT INTO {}.{} ({}) SELECT {} FROM {}.{}"
                 ).format(
                     sql.Identifier(dst_schema), sql.Identifier(dst_table),
-                    sql.SQL(', ').join(map(sql.Identifier, src_columns)),
-                    sql.SQL(', ').join(map(sql.Identifier, src_columns)),
+                    sql.SQL(', ').join(map(sql.Identifier, dst_columns)),
+                    sql.SQL(', ').join(map(sql.Identifier, dst_columns)),
                     sql.Identifier(src_schema), sql.Identifier(src_table)
                 )
             cur.execute(insert_query)


### PR DESCRIPTION
## What this pull request accomplishes:
- There was a bug in `day_no` column of MOVE's `countinfo` and `countinfomics` and Maddy and Raph agreed it was best to remove that column from bigdata.
- In order to do this I had to alter the dependencies on those columns (use `date_part('isodow'...)` instead), drop the columns, and then change the replicator to pull column names from the destination table instead of the source table. 
- Now we are free to drop deprecated columns like this from the destination tables without breaking the replicator.

## Issue(s) this solves:

- Closes #952

## What, in particular, needs to reviewed:
- 

## What needs to be done by a sysadmin after this PR is merged
- update dag link back to data_scripts
