### PR TITLE
Change intersection_uid to id in ongoing_outages select

### DIFF
--- a/volumes/miovision/sql/data_checks/select-ongoing_intersection_outages.sql
+++ b/volumes/miovision/sql/data_checks/select-ongoing_intersection_outages.sql
@@ -1,6 +1,6 @@
 WITH ongoing_outages AS (
     SELECT
-        i.intersection_name || ' (uid: ' || i.intersection_uid || ') - data last received: '
+        i.intersection_name || ' (id: ' || i.id || ') - data last received: '
         || MAX(v.datetime_bin::date) || ' (' || '{{ macros.ds_add(ds, 6) }}'::date --noqa: TMP, LT05
         - MAX(v.datetime_bin::date) || ' days)' AS descrip
     FROM miovision_api.volumes AS v


### PR DESCRIPTION


## What this pull request accomplishes:

- Chris prefers this id for entering into his tracker.

## Issue(s) this solves:

- #

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
