### PR TITLE
1032 move gcc puller tables to airflow variable

### DIFF
--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -28,7 +28,7 @@ def create_gcc_puller_dag(dag_id, default_args, name, conn_id):
         schedule='0 7 1 */3 *' #'@quarterly'
     )
     def gcc_layers_dag():
-
+        
         @task()
         def get_layers(name):
             tables = Variable.get('gcc_layers', deserialize_json=True)
@@ -75,7 +75,7 @@ filtered_dags = [
     key for key, facts in DAGS.items() if dep in facts['deployments']
 ]
 
-for dag in filtered_dags:
+for item in filtered_dags:
     DAG_NAME = 'gcc_pull_layers'
     DAG_OWNERS  = Variable.get('dag_owners', deserialize_json=True).get(DAG_NAME, ["Unknown"])
 
@@ -88,12 +88,12 @@ for dag in filtered_dags:
         'on_failure_callback': partial(task_fail_slack_alert, use_proxy=True)
     }
 
-    dag_name = f"{DAG_NAME}_{dag}"
+    dag_name = f"{DAG_NAME}_{item}"
     globals()[dag_name] = (
         create_gcc_puller_dag(
             dag_id=dag_name,
             default_args=DEFAULT_ARGS,
-            name=dag,
-            conn_id=DAGS[dag]['conn'],
+            name=dag_name,
+            conn_id=DAGS[item]['conn'],
         )
     )

--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -67,15 +67,15 @@ def create_gcc_puller_dag(dag_id, default_args, name, conn_id):
     return generated_dag
 
 #get puller details from airflow variable
-PULLERS = Variable.get('gcc_pullers', deserialize_json=True)
+DAGS = Variable.get('gcc_dags', deserialize_json=True)
 
 #identify the appropriate pullers based on deployment
 dep = os.environ.get("DEPLOYMENT", "PROD")
-filtered_pullers = [
-    key for key, facts in PULLERS.items() if dep in facts['deployments']
+filtered_dags = [
+    key for key, facts in DAGS.items() if dep in facts['deployments']
 ]
 
-for puller in filtered_pullers:
+for dag in filtered_dags:
     DAG_NAME = 'gcc_pull_layers'
     DAG_OWNERS  = Variable.get('dag_owners', deserialize_json=True).get(DAG_NAME, ["Unknown"])
 
@@ -88,12 +88,12 @@ for puller in filtered_pullers:
         'on_failure_callback': partial(task_fail_slack_alert, use_proxy=True)
     }
 
-    dag_name = f"{DAG_NAME}_{puller}"
+    dag_name = f"{DAG_NAME}_{dag}"
     globals()[dag_name] = (
         create_gcc_puller_dag(
             dag_id=dag_name,
             default_args=DEFAULT_ARGS,
-            name=puller,
-            conn_id=PULLERS[puller]['conn'],
+            name=dag,
+            conn_id=DAGS[dag]['conn'],
         )
     )

--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -56,7 +56,6 @@ def create_gcc_puller_dag(dag_id, default_args, name, conn_id):
             agg_sql = layer[1].get("agg")
             if agg_sql is not None:
                 with conn.cursor() as cur:
-                    print(agg_sql)
                     cur.execute(agg_sql)
 
         layers = get_layers(name)

--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -5,25 +5,21 @@ from functools import partial
 
 import pendulum
 from psycopg2 import sql
-from airflow import DAG
-from airflow.operators.python_operator import PythonOperator
+from airflow.decorators import dag, task, task_group
 from airflow.models import Variable
 from airflow.hooks.postgres_hook import PostgresHook
+from airflow.operators.python import get_current_context
+
 try:
     repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
     sys.path.insert(0, repo_path)
     from dags.dag_functions import task_fail_slack_alert
+    from dags.common_tasks import get_variable
     from gis.gccview.gcc_puller_functions import get_layer
 except:
     raise ImportError("Cannot import DAG helper functions.")
 
-# Credentials - to be passed through PythonOperator
-# bigdata connection credentials
-bigdata_cred = PostgresHook("gcc_bot_bigdata")
-# On-prem server connection credentials
-ptc_cred = PostgresHook("gcc_bot")
-
-DAG_NAME = 'pull_gcc_layers'
+DAG_NAME = 'gcc_pull_layers'
 
 DAG_OWNERS  = Variable.get('dag_owners', deserialize_json=True).get(DAG_NAME, ["Unknown"])
 
@@ -36,96 +32,54 @@ DEFAULT_ARGS = {
     'on_failure_callback': partial(task_fail_slack_alert, use_proxy=True)
 }
 
-#-------------------------------------------------------------------------------------------------------
-bigdata_layers = {
-    "city_ward": [0, 0, 'gis_core', True], # VFH Layers
-    "centreline": [0, 2, 'gis_core', False], # VFH Layers
-    "ibms_grid": [11, 25, 'gis_core', True], # VFH Layers
-    "centreline_intersection_point": [0, 19, 'gis_core', False], # VFH Layers
-    "intersection": [12, 42, 'gis_core', False],
-    "census_tract": [26, 7, 'gis_core', True],
-    "neighbourhood_improvement_area": [26, 11, 'gis_core', True],
-    "priority_neighbourhood_for_investment": [26, 13, 'gis_core', True],
-    #"bikeway": [2, 2, 'gis', True], #replaced by cycling_infrastructure
-    "cycling_infrastructure": [2, 49, 'gis', True], 
-    "traffic_camera": [2, 3, 'gis', True],
-    "permit_parking_area": [2, 11, 'gis', True],
-    "prai_transit_shelter": [2, 35, 'gis', True],
-    "traffic_bylaw_point": [2, 38, 'gis', True],
-    "traffic_bylaw_line": [2, 39, 'gis', True],
-    "loop_detector": [2, 46, 'gis', True],
-    "electrical_vehicle_charging_station": [20, 1, 'gis', True],
-    "day_care_centre": [22, 1, 'gis', True],
-    "middle_childcare_centre": [22, 2, 'gis', True],
-    "business_improvement_area": [23, 1, 'gis', True],
-    "proposed_business_improvement_area": [23, 13, 'gis', True],
-    "film_permit_all": [23, 9, 'gis', True],
-    "film_permit_parking_all": [23, 10, 'gis', True],
-    "hotel": [23, 12, 'gis', True],
-    "convenience_store": [26, 1, 'gis', True],
-    "supermarket": [26, 4, 'gis', True],
-    "place_of_worship": [26, 5, 'gis', True],
-    "ymca": [26, 6, 'gis', True],
-    "aboriginal_organization": [26, 45, 'gis', True],
-    "attraction": [26, 46, 'gis', True],
-    "dropin": [26, 47, 'gis', True],
-    "early_years_centre": [26, 48, 'gis', True],
-    "family_resource_centre": [26, 49, 'gis', True],
-    "food_bank": [26, 50, 'gis', True],
-    "longterm_care": [26, 53, 'gis', True],
-    "parenting_family_literacy": [26, 54, 'gis', True],
-    "retirement_home": [26, 58, 'gis', True],
-    "senior_housing": [26, 59, 'gis', True],
-    "shelter": [26, 61, 'gis', True],
-    "social_housing": [26, 62, 'gis', True],
-    "private_road": [27, 13, 'gis', True],
-    "school": [28, 17, 'gis', True],
-    "library": [28, 28, 'gis', True],
-    "pavement_asset": [2, 36, 'gis', True],
-}
-
-
-ptc_layers = {
-    "city_ward": [0, 0, 'gis', True],
-    "centreline": [0, 2, 'gis', False],
-    "intersection": [12, 42, 'gis', False],
-    "centreline_intersection_point": [0, 19, 'gis', False],
-    "ibms_grid": [11, 25, 'gis', True],
-    "ibms_district": [11, 23, 'gis', True],
-}
-
 # the DAG runs at 7 am on the first day of January, April, July, and October
-with DAG(
+@dag(
     dag_id = DAG_NAME,
     catchup=False,
     default_args=DEFAULT_ARGS,
     schedule='0 7 1 */3 *' #'@quarterly'
-) as gcc_layers_dag:
-    deployment = os.environ.get("DEPLOYMENT", "PROD")
+)
+def gcc_layers_dag():
 
-    if deployment == "DEV":
-        for layer, attributes in bigdata_layers.items():
-            pull_bigdata_layer = PythonOperator(
-                task_id = 'bigdata_task_'+ str(layer),
-                python_callable = get_layer,
-                op_args = attributes + [bigdata_cred]
-            )
+    @task()
+    def get_pullers():
+        dep = os.environ.get("DEPLOYMENT", "PROD")
+        pullers = Variable.get('gcc_pullers', deserialize_json=True)
 
-    for layer, attributes in ptc_layers.items():
-        pull_ptc_layer = PythonOperator(
-            task_id = 'VFH_task_'+ str(layer),
-            python_callable = get_layer,
-            op_args = attributes + [ptc_cred]
-        )
+        #return the appropriate pullers
+        return [(puller, facts['conn']) for puller, facts in pullers.items() if dep in facts['deployments']]
 
-        if layer in ['centreline', 'intersection']:
-            sql_refresh_mat_view = sql.SQL("SELECT {function_name}()").format(
-                function_name=sql.Identifier('gis', f'refresh_mat_view_{layer}_version_date')
-            )
-            refresh_mat_view = PythonOperator(
-                python_callable=lambda:ptc_cred.get_conn().cursor().execute(sql_refresh_mat_view),
-                task_id=f'refresh_{layer}_version_date',
-                retries = 0
-            )
+    @task_group()
+    def pull_and_agg_layers(puller_details):
+        @task()
+        def get_conn_id(puller_details) -> str:
+            return puller_details[1]
 
-            pull_ptc_layer >> refresh_mat_view
+        @task()
+        def get_layers(puller: str):
+            tables = Variable.get('gcc_layers', deserialize_json=True)
+            return tables[puller]
+        
+        @task(map_index_template="{{ table_name }}")
+        def pull_layer(layer, conn_id):
+            #name mapped task
+            context = get_current_context()
+            context["table_name"] = tables[tbl_index]
+            conn = PostgresHook(conn_id).get_conn()
+            get_layer(layer, layer.items(), conn)
+        
+        #if layer in ['centreline', 'intersection']:
+        #    @task
+        #    def agg_layer():
+        #        sql_refresh_mat_view = sql.SQL("SELECT {function_name}()").format(
+        #            function_name=sql.Identifier('gis', f'refresh_mat_view_{layer}_version_date')
+        #        )
+        #        with con.cursor() as cur:
+        #            cur.execute(sql_refresh_mat_view)
+
+        pull_layer.partial(conn_id = get_conn_id(puller_details)).expand(layer = get_layers(puller_details))() #>> agg_layer()
+
+    for puller in get_pullers():
+        pull_and_agg_layers(puller_details = puller)
+
+gcc_layers_dag()

--- a/test/integration/test_dags.py
+++ b/test/integration/test_dags.py
@@ -25,10 +25,11 @@ AIRFLOW_VARIABLES = {
     'AIRFLOW_VAR_SLACK_MEMBER_ID': '{"var": "value"}',
     'AIRFLOW_VAR_SSZ_SPREADSHEET_IDS': "{"+",".join([f'"ssz{year}": "value"' for year in range(2018, datetime.now().year+1)])+"}",
     'AIRFLOW_VAR_COLLISIONS_TABLES': "["+",".join([f'["src_schema.table_{i}", "dst_schema.table_{i}"]' for i in range(0, 2)])+"]",
-	'AIRFLOW_VAR_COUNTS_TABLES': "["+",".join([f'["src_schema.table_{i}", "dst_schema.table_{i}"]' for i in range(0, 3)])+"]",
-	'AIRFLOW_VAR_HERE_DAG_TRIGGERS': "["+",".join([f'"dag_{i}"' for i in range(0, 3)])+"]",
-	'AIRFLOW_VAR_REPLICATORS': '{"dag": {"dag_name": "value", "tables": "value", "conn": "value"}}',
-	'AIRFLOW_VAR_TEST_DAG_TRIGGERS': "["+",".join([f'"dag_{i}"' for i in range(0, 3)])+"]"
+    'AIRFLOW_VAR_COUNTS_TABLES': "["+",".join([f'["src_schema.table_{i}", "dst_schema.table_{i}"]' for i in range(0, 3)])+"]",
+    'AIRFLOW_VAR_HERE_DAG_TRIGGERS': "["+",".join([f'"dag_{i}"' for i in range(0, 3)])+"]",
+    'AIRFLOW_VAR_REPLICATORS': '{"dag": {"dag_name": "value", "tables": "value", "conn": "value"}}',
+    'AIRFLOW_VAR_TEST_DAG_TRIGGERS': "["+",".join([f'"dag_{i}"' for i in range(0, 3)])+"]",
+    'AIRFLOW_VAR_GCC_DAGS': '{"dag": {"conn": "value", "deployments": ["value"]}}',
 }
 SAMPLE_CONN = Connection(
     conn_type="sample_type",


### PR DESCRIPTION
## What this pull request accomplishes:

- move GCC layers and Primary key dictionaries to Airflow variables
- Dynamic DAG generation for bigdata/ptc GCC layers using Airflow variable which stores credentials, deployment
- added mat view refreshes to Airflow variable: easier addition of new aggregations!

## Issue(s) this solves:

- Closes #1032 

## What, in particular, needs to reviewed:

- I couldn't think of an obvious way to make mat view aggregations their own Airflow tasks in a dynamic way so I just added them to the pull_layers task. Thoughts?

## What needs to be done by a sysadmin after this PR is merged
- change data_scripts link in Morbius