### PR TITLE
#1039 remove limited lookback window in intersection outages check

### DIFF
--- a/volumes/miovision/sql/data_checks/select-ongoing_intersection_outages.sql
+++ b/volumes/miovision/sql/data_checks/select-ongoing_intersection_outages.sql
@@ -1,18 +1,16 @@
 WITH ongoing_outages AS (
     SELECT
         i.intersection_name || ' (id: ' || i.id || ') - data last received: '
-        || MAX(v.datetime_bin::date) || ' (' || '{{ macros.ds_add(ds, 6) }}'::date --noqa: TMP, LT05
-        - MAX(v.datetime_bin::date) || ' days)' AS descrip
-    FROM miovision_api.volumes AS v
+        || MAX(v.dt) || ' (' || '{{ macros.ds_add(ds, 6) }}'::date --noqa: TMP, LT05
+        - MAX(v.dt) || ' days)' AS descrip
+    FROM miovision_api.volumes_daily_unfiltered AS v
     JOIN miovision_api.intersections AS i USING (intersection_uid)
-    WHERE
-        v.datetime_bin >= '{{ macros.ds_add(ds, 6) }}'::date - interval '{{ params.lookback }}' --noqa: TMP, LT05
-        AND v.datetime_bin < '{{ macros.ds_add(ds, 6) }}'::date + interval '1 day' --noqa: TMP, LT05
+    WHERE i.date_decommissioned IS NULL
     GROUP BY
         i.intersection_uid,
         i.intersection_name
     HAVING
-        MAX(v.datetime_bin::date)
+        MAX(v.dt)
         < '{{ macros.ds_add(ds, 6) }}'::date - interval '{{ params.min_duration }}' --noqa: TMP
 )
 


### PR DESCRIPTION
## What this pull request accomplishes:

- remove limited lookback window in miovision intersection outages check. Use `volumes_daily_unfiltered` instead to maintain speed. 

## Issue(s) this solves:

- Closes #1039

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

- Pull into data_scripts