### PR TITLE
1065 miovision stop aggregating bikes in crosswalk

### DIFF
--- a/nohup.out
+++ b/nohup.out
@@ -1,1 +1,0 @@
-psql: error: update_wys_fkey.sql: No such file or directory

--- a/nohup.out
+++ b/nohup.out
@@ -1,0 +1,1 @@
+psql: error: update_wys_fkey.sql: No such file or directory

--- a/volumes/miovision/sql/function/function-aggregate_volumes_daily.sql
+++ b/volumes/miovision/sql/function/function-aggregate_volumes_daily.sql
@@ -84,6 +84,13 @@ BEGIN
             v.datetime_bin >= start_date
             AND v.datetime_bin < end_date
             AND v.intersection_uid = ANY(target_intersections)
+            --exclude bike exits 
+            AND NOT (
+                classification_uid = 10
+                AND movement_uid = 8
+            )
+            --exclude bikes in crosswalk
+            AND NOT (classification_uid = 7)
         GROUP BY
             v.intersection_uid,
             v.classification_uid,

--- a/volumes/miovision/sql/readme.md
+++ b/volumes/miovision/sql/readme.md
@@ -112,10 +112,10 @@ Note that bicycles are available at both a turning movement level and at an appr
 | 4                  | SingleUnitTruck  | false         | "Vehicles"    | A truck that has a non-detachable cab and trailer system |
 | 5                  | ArticulatedTruck | false         | "Vehicles"    | A truck that has a detachable cab and trailer system |
 | 6                  | Pedestrian       | true          | "Pedestrians" | A walker. May or may not include zombies... |
-| 7                  | Bicycle          | true          | "Cyclists"    | Bicycle in crosswalk. Same movement_uids as 6, Pedestrian. Unclear if it is necessarily being walked or ridden. do not use aggregate volumes will be removed from tables |
+| 7                  | Bicycle          | true          | "Cyclists"    | Bicycle in crosswalk. Same movement_uids as 6, Pedestrian. Unclear if it is necessarily being walked or ridden. This movement is exlcuded from aggregate tables. |
 | 8                  | WorkVan          |               |               | A van used for commercial purposes Workvan classification was folded in to "Light" vehicles in the API. |
 | 9                  | MotorizedVehicle | false         | "Vehicles"    | Miscellaneous vehicles. Prior to 2019-08-22 this included streetcars. |
-| 10                 | Bicycle          | false         | "Cyclists"    | Tracks bicycle entrances and exits. There are currently  no exits in the aggregated tables. This classification is only  available from 2021-07-11 on. Bicycle data is not great - stay tuned. |
+| 10                 | Bicycle          | false         | "Cyclists"    | The preferred bike classification. Tracks bicycle entrances and exits passing through manually drawn zones on the SmartSense overlay. Exits are exlcuded from aggregate tables. This classification is only  available from 2021-07-11 on. Bicycle data is not great - stay tuned. |
 
 ### `movements`
 

--- a/volumes/miovision/sql/table/create-table-intersection_movements.sql
+++ b/volumes/miovision/sql/table/create-table-intersection_movements.sql
@@ -26,3 +26,11 @@ CREATE OR REPLACE TRIGGER intersection_movements_denylist_exclusion
 BEFORE INSERT ON miovision_api.intersection_movements
 FOR EACH ROW
 EXECUTE FUNCTION miovision_api.intersection_movements_exclude();
+
+ALTER TABLE IF EXISTS miovision_api.intersection_movements
+ADD CONSTRAINT intersecton_movements_exclude_bike_exits
+CHECK (NOT (classification_uid = 10 AND movement_uid = 8));
+
+ALTER TABLE IF EXISTS miovision_api.intersection_movements
+ADD CONSTRAINT intersecton_movements_exclude_xwalk_bikes
+CHECK (NOT (classification_uid = 7));

--- a/volumes/miovision/sql/views/create-view-monitor_intersection_movements.sql
+++ b/volumes/miovision/sql/views/create-view-monitor_intersection_movements.sql
@@ -32,6 +32,7 @@ CREATE OR REPLACE VIEW miovision_api.monitor_intersection_movements AS (
         v.volume_15min_mvt_uid IS NULL --not aggregated
         AND v.datetime_bin >= CURRENT_DATE - 100
         AND NOT (v.classification_uid = 10 AND movement_uid = 8) --bike exit
+        AND NOT (v.classification_uid = 7) --bikes in crosswalk
         AND im_dl.intersection_uid IS NULL
     GROUP BY
         v.intersection_uid,


### PR DESCRIPTION
## What this pull request accomplishes:

- Make sure bikes in crosswalk and bike exits do not end up in aggregate tables (via intersection_movements)
- Delete existing bikes in crosswalk and bike exits. 

## Issue(s) this solves:

- #1065 

## What, in particular, needs to reviewed:

- @radumas  **Do we still want to do this, or change tack to follow MOVE which is now including bikes in crosswalk**

## What needs to be done by a sysadmin after this PR is merged

- [x] Run:
```sql
DELETE FROM miovision_api.volumes_15min_mvt WHERE classification_uid = 7;
DELETE FROM miovision_api.volumes_15min WHERE classification_uid = 7;
DELETE FROM miovision_api.intersection_movements WHERE classification_uid = 7;

--this is the only aggregate table that includes bike exits
DELETE FROM miovision_api.volumes_daily_unfiltered WHERE
classification_uid = 7 --these we're deleting for good
OR classification_uid = 10; --these we'll need to reaggregate
```
- [x] IMPORTANT: run a modified miovision_api.aggregate_volumes_daily to reaggregate classification_uid = 10 for all intersections to exclude bike exits.
- [x] Is there a documentation change needed?

