### PR TITLE
#1043 add map_index_template, fix name->item bug from #1035

### DIFF
--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -34,11 +34,11 @@ def create_gcc_puller_dag(dag_id, default_args, name, conn_id):
             tables = Variable.get('gcc_layers', deserialize_json=True)
             return tables[name]
                     
-        @task() #add after 2.9.3 upgrade: map_index_template="{{ table_name }}"
+        @task(map_index_template="{{ table_name }}")
         def pull_layer(layer, conn_id):
-            #name mapped task (implement after 2.9.3 upgrade)
-            #context = get_current_context()
-            #context["table_name"] = layer[0]
+            #name mapped task
+            context = get_current_context()
+            context["table_name"] = layer[0]
             #get db connection
             conn = PostgresHook(conn_id).get_conn()
             
@@ -92,7 +92,7 @@ for item in filtered_dags:
         create_gcc_puller_dag(
             dag_id=dag_name,
             default_args=DEFAULT_ARGS,
-            name=dag_name,
+            name=item,
             conn_id=DAGS[item]['conn'],
         )
     )

--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -198,7 +198,7 @@ def create_partitioned_table(output_table, return_json, schema_name, con):
                                                                                                                                             schema_parent_table = sql.Identifier(schema_name, output_table))
             cur.execute(create_sql, (today_string, ))
 
-            index_sql = sql.SQL("CREATE INDEX {idx_name} ON {schema_child_table} USING gist (geom)").format(idx_name=sql.Identifier(index_name),
+            index_sql = sql.SQL("CREATE INDEX IF NOT EXISTS {idx_name} ON {schema_child_table} USING gist (geom)").format(idx_name=sql.Identifier(index_name),
                                                                                                                 schema_child_table=sql.Identifier(schema_name, output_table_with_date))
             cur.execute(index_sql)
             


### PR DESCRIPTION
## What this pull request accomplishes:

- Now that Morbius Airflow is upgraded past 2.9.3 we can implement named mapped tasks (`map_index_template`)
- See successful test in `gcc_pull_layers_bigdata`. ✅ (tested without unnecessary update of GIS tables by commenting out parts of `pull_layer`). 
- Also fixed small bug from #1035 (`dag_name` -> `item`).

## Issue(s) this solves:

- #1043 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

Update DAG link in Morbius.
