### PR TITLE
1079 remove portable traffic signals from vzdashboard, add fields to `gis.traffic_signal`

### DIFF
--- a/dags/assets_pull.py
+++ b/dags/assets_pull.py
@@ -355,16 +355,15 @@ def pull_traffic_signal():
     # each "info" is all the properties of one APS, including its coords
     
     for obj in return_json:
-            
+        #do not add temporary portable traffic signals to vz_safety_programs_staging.signals_cart
+        if obj['px'] >= '3300' and obj['px'] < '3400':
+            continue
         # temporary list of properties of one TS to be appended into the rows list
         one_ts = []
-
         one_ts.append('Traffic Signals') # append the asset_name as listed in EC2
-
         # append the values in the same order as in the table
         for attr in att_names:
             one_ts.append(obj[attr])
-
         rows.append(tuple(one_ts))
     
     # delete existing Traffic Signals and insert into the local table

--- a/dags/assets_pull.py
+++ b/dags/assets_pull.py
@@ -326,7 +326,14 @@ def get_point_geometry(long, lat):
     lat: value of 'lat' in traffic_signals/v3 json
     '''
     return 'SRID=4326;Point('+(str(long))+' '+ (str(lat))+')'  
-        
+
+def identify_temp_signals(px):
+    if px >= '3300' and px < '3400':
+        return 'Temporary (portable)'
+    if px >= '3100' and px < '3200':
+        return 'Temporary'
+    return None
+
 def pull_traffic_signal():
     '''
     This function would pull all records from https://secure.toronto.ca/opendata/cart/traffic_signals/v3?format=json
@@ -374,14 +381,12 @@ def pull_traffic_signal():
     Upsert into gis.traffic_signal, an audited table
     '''
     
-    complete_rows = []
-    
     # column names in the PG table
     column_names = ['px', 'main_street', 'midblock_route', 'side1_street', 'side2_street', 'private_access', 'additional_info', 'x', 'y', 'latitude', 'longitude',
                     'activationdate', 'signalsystem', 'non_system', 'control_mode', 'pedwalkspeed', 'aps_operation', 'numberofapproaches', 'geo_id', 'node_id',
                     'audiblepedsignal', 'transit_preempt', 'fire_preempt', 'rail_preempt', 'bicycle_signal', 'ups', 'led_blankout_sign',
                     'lpi_north_implementation_date', 'lpi_south_implementation_date', 'lpi_east_implementation_date', 'lpi_west_implementation_date', 'lpi_comment',
-                    'aps_activation_date', 'leading_pedestrian_intervals', 'geom']
+                    'aps_activation_date', 'leading_pedestrian_intervals', 'geom', 'removed_date', 'temp_signal']
     
     # attribute names in JSON dict
     attribute_names = ['px', 'main', 'mid_block', 'side1', 'side2', 'private_access', 'additional_info', 'x', 'y', 'lat', 'long',
@@ -390,13 +395,17 @@ def pull_traffic_signal():
                       'lpiNorthImplementationDate', 'lpiSouthImplementationDate', 'lpiEastImplementationDate', 'lpiWestImplementationDate', 'lpiComment',
                       'aps_activation_date', 'leading_pedestrian_intervals']
     
+    complete_rows = []
     for obj in return_json:
         one_complete_ts = []
         for attr in attribute_names:
             one_complete_ts.append(obj[attr])
         # Create point geometry based on x and y
         one_complete_ts.append(get_point_geometry(obj['long'], obj['lat']))
-        
+        #removed_date
+        one_complete_ts.append(None)
+        #identify temporary and temporary (portable) signals
+        one_complete_ts.append(identify_temp_signals(obj['px']))
         complete_rows.append(one_complete_ts)
     
     # Upsert query to update gis.traffic_signal
@@ -409,9 +418,17 @@ def pull_traffic_signal():
         columns = sql.SQL(',').join([sql.Identifier(col) for col in column_names])
     )
 
+    #label traffic signals removed from open data.
+    update_deleted = sql.SQL("""UPDATE gis.traffic_signal
+                             SET removed_date = CURRENT_DATE
+                             WHERE removed_date IS NULL AND NOT(px IN ({}));""")
+    current_pxs = [obj['px'] for obj in return_json]
+    update_deleted = update_deleted.format(sql.SQL(',').join(map(sql.Literal, current_pxs)))
+    
     with conn:
         with conn.cursor() as cur:
             execute_values(cur, upsert_query_gis, complete_rows)
+            cur.execute(update_deleted)
     
 # ------------------------------------------------------------------------------
 # Set up the dag and task

--- a/dags/assets_pull.py
+++ b/dags/assets_pull.py
@@ -355,8 +355,8 @@ def pull_traffic_signal():
     # each "info" is all the properties of one APS, including its coords
     
     for obj in return_json:
-        #do not add temporary portable traffic signals to vz_safety_programs_staging.signals_cart
-        if obj['px'] >= '3300' and obj['px'] < '3400':
+        #do not add Temporary (portable) traffic signals to vz_safety_programs_staging.signals_cart
+        if identify_temp_signals(obj['px']) == 'Temporary (portable)':
             continue
         # temporary list of properties of one TS to be appended into the rows list
         one_ts = []

--- a/gis/assets/README.md
+++ b/gis/assets/README.md
@@ -40,7 +40,7 @@ Records from this URL are inserted into `gis.traffic_signal` and `vz_safety_prog
 `gis.traffic_signal`
 - rows are upserted so that the changes can be audited.
 - `removed_date` field notes when the row was removed from the Open Dataset. Note the field was first populated on 2024-10-09 so signals removed before that date will be rounded up to that date.
-- `temp_signal` field notes temporary (px = '31XX') and temporary (portable) (px = '33XX') traffic signals.
+- `temp_signal` field notes temporary (px = '31XX', to be replaced by a permanent signal) and temporary (portable, typically for a work zone, and will be removed) (px = '33XX') traffic signals.
 
 `signals_cart`
 - existing records of traffic signals will first be deleted and then new ones inserted

--- a/gis/assets/README.md
+++ b/gis/assets/README.md
@@ -35,7 +35,16 @@ https://secure.toronto.ca/opendata/cart/traffic_signals/v3?format=json
 This is one of the [datasets managed by the Traffic Control group](https://github.com/CityofToronto/bdit_vz_programs#datasets-and-their-owners). 
  Traffic Signals data from Open and update the relevant tables in the bigdata RDS. 
 
-Every record from this URL will end up in `gis.traffic_signal` and `vz_safety_programs_staging.signals_cart`. For `signals_cart`, existing records of traffic signals will first be deleted and then new ones inserted. For `traffic_signal`, the script will perform upsert instead so that the changes could be audited.
+Records from this URL are inserted into `gis.traffic_signal` and `vz_safety_programs_staging.signals_cart` as follows: 
+
+`gis.traffic_signal`
+- rows are upserted so that the changes can be audited.
+- `removed_date` field notes when the row was removed from the Open Dataset. Note the field was first populated on 2024-10-09 so signals removed before that date will be rounded up to that date.
+- `temp_signal` field notes temporary (px = '31XX') and temporary (portable) (px = '33XX') traffic signals.
+
+`signals_cart`
+- existing records of traffic signals will first be deleted and then new ones inserted
+- Temporary (portable) (px = '33XX') signals are exlcuded based on request from VZ Team. 
 
 ### APS and LPI
 

--- a/gis/assets/sql/traffic_signals.sql
+++ b/gis/assets/sql/traffic_signals.sql
@@ -1,36 +1,87 @@
-﻿DROP TABLE IF EXISTS gis.traffic_signals;
-CREATE TABLE gis.traffic_signals (
-PX int primary key ,
-Main text ,
-Mid_Block text ,
-Side_1 text ,
-Side_2 text ,
-Private_Access text ,
-Additional_info text ,
-Geo_id bigint not null,
-Node_id bigint not null,
-X numeric,
-Y numeric ,
-Latitude text ,
-Longitude text ,
-Activation_date DATE,
-Signal_System text ,
-Non_system text ,
-Mode_of_Control text ,
-Pedestrian_Walk_speed text ,
-APS_Signal smallint,
-APS_Operation text ,
-APS_Activation_date DATe,
-Transit_Preempt BOOLEAN,
-Fire_preempt BOOLEAN,
-Rail_preempt BOOLEAN,
-Signalized_Approaches smallint ,
-UPS BOOLEAN,
-LED_Blankout BOOLEAN,
-lpi BOOLEAN ,
-Bicycle_Signal BOOLEAN
-);
-GRANT SELECT ON gis.traffic_signals TO bdit_humans;
+﻿-- Table: gis.traffic_signal
+-- DROP TABLE IF EXISTS gis.traffic_signal;
 
-ALTER TABLE gis.traffic_signals ADD COLUMN geom geometry(Point, 4326);
-UPDATE gis.traffic_signals SET geom = ST_SetSRID(ST_MakePoint(latitude::numeric, longitude::numeric), 4326);
+CREATE TABLE IF NOT EXISTS gis.traffic_signal
+(
+    px text COLLATE pg_catalog."default" NOT NULL,
+    main_street text COLLATE pg_catalog."default",
+    midblock_route text COLLATE pg_catalog."default",
+    side1_street text COLLATE pg_catalog."default",
+    side2_street text COLLATE pg_catalog."default",
+    private_access text COLLATE pg_catalog."default",
+    additional_info text COLLATE pg_catalog."default",
+    x numeric,
+    y numeric,
+    latitude numeric,
+    longitude numeric,
+    activationdate timestamp without time zone,
+    signalsystem text COLLATE pg_catalog."default",
+    non_system text COLLATE pg_catalog."default",
+    control_mode text COLLATE pg_catalog."default",
+    pedwalkspeed text COLLATE pg_catalog."default",
+    aps_operation text COLLATE pg_catalog."default",
+    numberofapproaches text COLLATE pg_catalog."default",
+    objectid integer,
+    geo_id integer,
+    node_id integer,
+    audiblepedsignal numeric,
+    transit_preempt numeric,
+    fire_preempt numeric,
+    rail_preempt numeric,
+    mi_prinx integer,
+    geom geometry,
+    bicycle_signal numeric,
+    ups numeric,
+    led_blankout_sign numeric,
+    lpi_north_implementation_date timestamp without time zone,
+    lpi_south_implementation_date timestamp without time zone,
+    lpi_east_implementation_date timestamp without time zone,
+    lpi_west_implementation_date timestamp without time zone,
+    lpi_comment text COLLATE pg_catalog."default",
+    aps_activation_date timestamp without time zone,
+    leading_pedestrian_intervals integer,
+    CONSTRAINT _traffic_signal_pkey PRIMARY KEY (px)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS gis.traffic_signal OWNER TO gis_admins;
+
+REVOKE ALL ON TABLE gis.traffic_signal FROM bdit_humans;
+
+GRANT SELECT ON TABLE gis.traffic_signal TO bdit_humans;
+
+GRANT ALL ON TABLE gis.traffic_signal TO gis_admins;
+
+GRANT ALL ON TABLE gis.traffic_signal TO vz_api_bot;
+
+COMMENT ON TABLE gis.traffic_signal
+IS 'Updated daily by the assets_pull dag https://github.com/CityofToronto/bdit_data-sources/tree/master/gis/assets';
+-- Index: traffic_signal_gix
+
+-- DROP INDEX IF EXISTS gis.traffic_signal_gix;
+
+CREATE INDEX IF NOT EXISTS traffic_signal_gix
+ON gis.traffic_signal USING gist
+(geom)
+TABLESPACE pg_default;
+
+-- Trigger: audit_trigger_row
+
+-- DROP TRIGGER IF EXISTS audit_trigger_row ON gis.traffic_signal;
+
+CREATE OR REPLACE TRIGGER audit_trigger_row
+AFTER INSERT OR DELETE OR UPDATE
+ON gis.traffic_signal
+FOR EACH ROW
+EXECUTE FUNCTION gis.if_modified_func('true');
+
+-- Trigger: audit_trigger_stm
+
+-- DROP TRIGGER IF EXISTS audit_trigger_stm ON gis.traffic_signal;
+
+CREATE OR REPLACE TRIGGER audit_trigger_stm
+AFTER TRUNCATE
+ON gis.traffic_signal
+FOR EACH STATEMENT
+EXECUTE FUNCTION gis.if_modified_func('true');

--- a/gis/assets/sql/traffic_signals.sql
+++ b/gis/assets/sql/traffic_signals.sql
@@ -40,6 +40,8 @@ CREATE TABLE IF NOT EXISTS gis.traffic_signal
     lpi_comment text COLLATE pg_catalog."default",
     aps_activation_date timestamp without time zone,
     leading_pedestrian_intervals integer,
+    removed_date date,
+    temporary_signal text,
     CONSTRAINT _traffic_signal_pkey PRIMARY KEY (px)
 )
 
@@ -56,32 +58,32 @@ GRANT ALL ON TABLE gis.traffic_signal TO gis_admins;
 GRANT ALL ON TABLE gis.traffic_signal TO vz_api_bot;
 
 COMMENT ON TABLE gis.traffic_signal
-IS 'Updated daily by the assets_pull dag https://github.com/CityofToronto/bdit_data-sources/tree/master/gis/assets';
+    IS 'Updated daily by the assets_pull dag https://github.com/CityofToronto/bdit_data-sources/tree/master/gis/assets';
 -- Index: traffic_signal_gix
 
 -- DROP INDEX IF EXISTS gis.traffic_signal_gix;
 
 CREATE INDEX IF NOT EXISTS traffic_signal_gix
-ON gis.traffic_signal USING gist
-(geom)
-TABLESPACE pg_default;
+    ON gis.traffic_signal USING gist
+    (geom)
+    TABLESPACE pg_default;
 
 -- Trigger: audit_trigger_row
 
 -- DROP TRIGGER IF EXISTS audit_trigger_row ON gis.traffic_signal;
 
 CREATE OR REPLACE TRIGGER audit_trigger_row
-AFTER INSERT OR DELETE OR UPDATE
-ON gis.traffic_signal
-FOR EACH ROW
-EXECUTE FUNCTION gis.if_modified_func('true');
+    AFTER INSERT OR DELETE OR UPDATE 
+    ON gis.traffic_signal
+    FOR EACH ROW
+    EXECUTE FUNCTION gis.if_modified_func('true');
 
 -- Trigger: audit_trigger_stm
 
 -- DROP TRIGGER IF EXISTS audit_trigger_stm ON gis.traffic_signal;
 
 CREATE OR REPLACE TRIGGER audit_trigger_stm
-AFTER TRUNCATE
-ON gis.traffic_signal
-FOR EACH STATEMENT
-EXECUTE FUNCTION gis.if_modified_func('true');
+    AFTER TRUNCATE
+    ON gis.traffic_signal
+    FOR EACH STATEMENT
+    EXECUTE FUNCTION gis.if_modified_func('true');


### PR DESCRIPTION
## What this pull request accomplishes:

- do not add temp (portable) traffic signals to `vz_safety_programs_staging.signals_cart`
- add removed_date and temp_signal fields to `gis.traffic_signal`
  - **Note:** modifications tested under `gis.traffic_signal_copy`

## Issue(s) this solves:

- Closes #1079

## What, in particular, needs to reviewed:
- It was mentioned we should only store this information only in one place; I elected to store it in a function in assets.py. 

## What needs to be done by a sysadmin after this PR is merged

- update DAG link
- `DROP TABLE gis.traffic_signal_copy`
- Add columns:
```sql
ALTER TABLE gis.traffic_signal ADD COLUMN removed_date date;
ALTER TABLE gis.traffic_signal ADD COLUMN temp_signal text;
```
