### PR TITLE
#1082 upgrade airflow to 2.10.2

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,6 @@
 
 #
-# This constraints file was automatically generated on 2024-08-12T09:36:59.478072
+# This constraints file was automatically generated on 2024-09-16T16:21:46.279414
 # via "eager-upgrade" mechanism of PIP. For the "v2-10-test" branch of Airflow.
 # This variant of constraints install just the 'bare' 'apache-airflow' package build from the HEAD of
 # the branch, without installing any of the providers.
@@ -8,7 +8,7 @@
 # Those constraints represent the "newest" dependencies airflow could use, if providers did not limit
 # Airflow in any way.
 #
-Authlib==1.3.1
+Authlib==1.3.2
 ConfigUpdater==3.2
 Deprecated==1.2.14
 Flask-AppBuilder==4.5.0
@@ -30,13 +30,13 @@ PyYAML==6.0.2
 Pygments==2.18.0
 SQLAlchemy-JSONField==1.0.2
 SQLAlchemy-Utils==0.41.2
-SQLAlchemy==1.4.53
+SQLAlchemy==1.4.54
 WTForms==3.1.2
 Werkzeug==2.2.3
-aiobotocore==2.13.2
-aiohappyeyeballs==2.3.5
-aiohttp==3.10.3
-aioitertools==0.11.0
+aiobotocore==2.15.0
+aiohappyeyeballs==2.4.0
+aiohttp==3.10.5
+aioitertools==0.12.0
 aiosignal==1.3.1
 alembic==1.13.2
 amqp==5.2.0
@@ -52,10 +52,10 @@ babel==2.16.0
 backoff==2.2.1
 bcrypt==4.2.0
 blinker==1.8.2
-botocore==1.34.131
+botocore==1.35.16
 cachelib==0.9.0
-certifi==2024.7.4
-cffi==1.17.0
+certifi==2024.8.30
+cffi==1.17.1
 cgroupspy==0.2.3
 charset-normalizer==3.3.2
 click==8.1.7
@@ -64,9 +64,9 @@ cloudpickle==3.0.0
 colorama==0.4.6
 colorlog==6.8.2
 connexion==2.14.2
-cron-descriptor==1.4.3
+cron-descriptor==1.4.5
 croniter==3.0.3
-cryptography==43.0.0
+cryptography==43.0.1
 decorator==5.1.1
 dill==0.3.8
 distlib==0.3.8
@@ -74,27 +74,27 @@ dnspython==2.6.1
 docopt==0.6.2
 docutils==0.21.2
 email_validator==2.2.0
-eventlet==0.36.1
+eventlet==0.37.0
 exceptiongroup==1.2.2
-fastavro==1.9.5
-filelock==3.15.4
+fastavro==1.9.7
+filelock==3.16.0
 frozenlist==1.4.1
-fsspec==2024.6.1
+fsspec==2024.9.0
 gevent==24.2.1
 google-re2==1.1.20240702
-googleapis-common-protos==1.63.2
+googleapis-common-protos==1.65.0
 graphviz==0.20.3
-greenlet==3.0.3
-grpcio==1.65.4
+greenlet==3.1.0
+grpcio==1.66.1
 gssapi==1.8.3
 gunicorn==23.0.0
 h11==0.14.0
 hdfs==2.7.3
 httpcore==1.0.5
-httpx==0.27.0
-idna==3.7
-importlib_metadata==8.2.0
-importlib_resources==6.4.0
+httpx==0.27.2
+idna==3.10
+importlib_metadata==8.5.0
+importlib_resources==6.4.5
 inflection==0.5.1
 isodate==0.6.1
 itsdangerous==2.2.0
@@ -111,12 +111,12 @@ lxml==5.3.0
 markdown-it-py==3.0.0
 marshmallow-oneofschema==3.1.1
 marshmallow-sqlalchemy==0.28.2
-marshmallow==3.21.3
-mdit-py-plugins==0.4.1
+marshmallow==3.22.0
+mdit-py-plugins==0.4.2
 mdurl==0.1.2
 methodtools==0.4.7
-more-itertools==10.4.0
-multidict==6.0.5
+more-itertools==10.5.0
+multidict==6.1.0
 numpy==1.26.4
 opentelemetry-api==1.16.0
 opentelemetry-exporter-otlp-proto-grpc==1.16.0
@@ -131,7 +131,7 @@ packaging==24.1
 pandas==2.1.4
 pathspec==0.12.1
 pendulum==3.0.0
-platformdirs==4.2.2
+platformdirs==4.3.3
 pluggy==1.5.0
 plyvel==1.5.1
 prison==0.2.1
@@ -139,11 +139,11 @@ prometheus_client==0.20.0
 protobuf==4.25.4
 psutil==6.0.0
 pure-sasl==0.6.2
-pyasn1==0.6.0
-pyasn1_modules==0.4.0
+pyasn1==0.6.1
+pyasn1_modules==0.4.1
 pycparser==2.22
-pydantic==2.8.2
-pydantic_core==2.20.1
+pydantic==2.9.1
+pydantic_core==2.23.3
 pykerberos==1.2.4
 pyspnego==0.11.1
 python-daemon==3.0.1
@@ -152,17 +152,17 @@ python-ldap==3.4.4
 python-nvd3==0.16.0
 python-slugify==8.0.4
 python3-saml==1.16.0
-pytz==2024.1
+pytz==2024.2
 referencing==0.35.1
 requests-kerberos==0.15.0
 requests-toolbelt==1.0.0
 requests==2.32.3
 rfc3339-validator==0.1.4
 rich-argparse==1.5.2
-rich==13.7.1
+rich==13.8.1
 rpds-py==0.20.0
-s3fs==2024.6.1
-sentry-sdk==2.12.0
+s3fs==2024.9.0
+sentry-sdk==2.14.0
 setproctitle==1.3.3
 six==1.16.0
 sniffio==1.3.1
@@ -179,15 +179,15 @@ typing_extensions==4.12.2
 tzdata==2024.1
 uc-micro-py==1.0.3
 unicodecsv==0.14.1
-universal_pathlib==0.2.2
-urllib3==2.2.2
-uv==0.2.34
+universal_pathlib==0.2.5
+urllib3==2.2.3
+uv==0.4.1
 vine==5.1.0
-virtualenv==20.26.3
+virtualenv==20.26.4
 wirerope==0.4.7
 wrapt==1.16.0
 xmlsec==1.3.14
-yarl==1.9.4
-zipp==3.20.0
+yarl==1.11.1
+zipp==3.20.2
 zope.event==5.0
-zope.interface==7.0.1
+zope.interface==7.0.3

--- a/requirements.in
+++ b/requirements.in
@@ -1,26 +1,29 @@
-# Airflow constraints pulled from https://raw.githubusercontent.com/apache/airflow/constraints-2.10.0/constraints-no-providers-3.10.txt
+# Airflow constraints pulled from https://raw.githubusercontent.com/apache/airflow/constraints-2.10.2/constraints-no-providers-3.10.txt
 -c constraints.txt
 
 # Airflow
-apache-airflow==2.10.0
+apache-airflow==2.10.2
 
 # Airflow service providers
 apache-airflow-providers-celery
 apache-airflow-providers-google
 apache-airflow-providers-postgres
 apache-airflow-providers-slack
+apache-airflow-providers-ftp
+apache-airflow-providers-http
 
 # Airflow dag list
 graphviz
 
 # Python dependency management
-pip-tools==7.3.0
+pip-tools==7.4.1
 
 # pipelines
 bs4==0.0.1
 env-canada==0.6.1
 geopandas==1.0.1
 holidays==0.31
+requests-oauthlib
 
 # development
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@
 #
 aiofiles==23.2.1
     # via gcloud-aio-storage
-aiohappyeyeballs==2.3.5
+aiohappyeyeballs==2.4.0
     # via
     #   -c constraints.txt
     #   aiohttp
-aiohttp==3.10.3
+aiohttp==3.10.5
     # via
     #   -c constraints.txt
     #   apache-airflow-providers-http
@@ -38,7 +38,7 @@ anyio==4.4.0
     # via
     #   -c constraints.txt
     #   httpx
-apache-airflow==2.10.0
+apache-airflow==2.10.2
     # via
     #   -r requirements.in
     #   apache-airflow-providers-celery
@@ -54,32 +54,37 @@ apache-airflow==2.10.0
     #   apache-airflow-providers-slack
     #   apache-airflow-providers-smtp
     #   apache-airflow-providers-sqlite
-apache-airflow-providers-celery==3.8.1
+apache-airflow-providers-celery==3.8.3
     # via -r requirements.in
-apache-airflow-providers-common-compat==1.2.0
+apache-airflow-providers-common-compat==1.2.1
     # via
     #   apache-airflow
+    #   apache-airflow-providers-fab
     #   apache-airflow-providers-google
-apache-airflow-providers-common-io==1.4.0
+apache-airflow-providers-common-io==1.4.2
     # via apache-airflow
-apache-airflow-providers-common-sql==1.16.0
+apache-airflow-providers-common-sql==1.18.0
     # via
     #   apache-airflow
     #   apache-airflow-providers-google
     #   apache-airflow-providers-postgres
     #   apache-airflow-providers-slack
     #   apache-airflow-providers-sqlite
-apache-airflow-providers-fab==1.3.0
+apache-airflow-providers-fab==1.4.1
     # via apache-airflow
-apache-airflow-providers-ftp==3.11.0
-    # via apache-airflow
-apache-airflow-providers-google==10.22.0
+apache-airflow-providers-ftp==3.11.1
+    # via
+    #   -r requirements.in
+    #   apache-airflow
+apache-airflow-providers-google==10.24.0
     # via -r requirements.in
-apache-airflow-providers-http==4.13.0
-    # via apache-airflow
+apache-airflow-providers-http==4.13.1
+    # via
+    #   -r requirements.in
+    #   apache-airflow
 apache-airflow-providers-imap==3.7.0
     # via apache-airflow
-apache-airflow-providers-postgres==5.12.0
+apache-airflow-providers-postgres==5.13.1
     # via -r requirements.in
 apache-airflow-providers-slack==8.9.0
     # via -r requirements.in
@@ -90,7 +95,6 @@ apache-airflow-providers-sqlite==3.9.0
 apispec[yaml]==6.6.1
     # via
     #   -c constraints.txt
-    #   apispec
     #   flask-appbuilder
 argcomplete==3.5.0
     # via
@@ -132,7 +136,7 @@ backoff==2.2.1
     #   opentelemetry-exporter-otlp-proto-http
 beautifulsoup4==4.12.3
     # via bs4
-billiard==4.2.0
+billiard==4.2.1
     # via celery
 blinker==1.8.2
     # via
@@ -140,7 +144,7 @@ blinker==1.8.2
     #   apache-airflow
 bs4==0.0.1
     # via -r requirements.in
-build==1.2.1
+build==1.2.2.post1
     # via pip-tools
 cachelib==0.9.0
     # via
@@ -149,14 +153,13 @@ cachelib==0.9.0
     #   flask-session
 cachetools==5.5.0
     # via google-auth
-cattrs==24.1.0
+cattrs==24.1.2
     # via looker-sdk
 celery[redis]==5.4.0
     # via
     #   apache-airflow-providers-celery
-    #   celery
     #   flower
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   -c constraints.txt
     #   httpcore
@@ -164,7 +167,7 @@ certifi==2024.7.4
     #   pyogrio
     #   pyproj
     #   requests
-cffi==1.17.0
+cffi==1.17.1
     # via
     #   -c constraints.txt
     #   cryptography
@@ -213,8 +216,7 @@ connexion[flask]==2.14.2
     # via
     #   -c constraints.txt
     #   apache-airflow
-    #   connexion
-cron-descriptor==1.4.3
+cron-descriptor==1.4.5
     # via
     #   -c constraints.txt
     #   apache-airflow
@@ -222,7 +224,7 @@ croniter==3.0.3
     # via
     #   -c constraints.txt
     #   apache-airflow
-cryptography==43.0.0
+cryptography==43.0.1
     # via
     #   -c constraints.txt
     #   apache-airflow
@@ -230,7 +232,7 @@ cryptography==43.0.0
     #   pyopenssl
 db-dtypes==1.3.0
     # via pandas-gbq
-debugpy==1.8.5
+debugpy==1.8.7
     # via ipykernel
 decorator==5.1.1
     # via
@@ -336,7 +338,7 @@ frozenlist==1.4.1
     #   -c constraints.txt
     #   aiohttp
     #   aiosignal
-fsspec==2024.6.1
+fsspec==2024.9.0
     # via
     #   -c constraints.txt
     #   apache-airflow
@@ -351,7 +353,7 @@ gcloud-aio-bigquery==7.1.0
     # via apache-airflow-providers-google
 gcloud-aio-storage==9.3.0
     # via apache-airflow-providers-google
-gcsfs==2024.6.1
+gcsfs==2024.9.0.post1
     # via apache-airflow-providers-google
 geographiclib==2.0
     # via geopy
@@ -363,7 +365,7 @@ google-ads==25.0.0
     # via apache-airflow-providers-google
 google-analytics-admin==0.23.0
     # via apache-airflow-providers-google
-google-api-core[grpc]==2.19.2
+google-api-core[grpc]==2.21.0
     # via
     #   apache-airflow-providers-google
     #   google-ads
@@ -411,9 +413,9 @@ google-api-core[grpc]==2.19.2
     #   google-cloud-workflows
     #   pandas-gbq
     #   sqlalchemy-bigquery
-google-api-python-client==2.144.0
+google-api-python-client==2.149.0
     # via apache-airflow-providers-google
-google-auth==2.34.0
+google-auth==2.35.0
     # via
     #   apache-airflow-providers-google
     #   gcsfs
@@ -474,7 +476,7 @@ google-auth-oauthlib==1.2.1
     #   google-ads
     #   pandas-gbq
     #   pydata-google-auth
-google-cloud-aiplatform==1.65.0
+google-cloud-aiplatform==1.70.0
     # via apache-airflow-providers-google
 google-cloud-appengine-logging==1.4.5
     # via google-cloud-logging
@@ -482,23 +484,23 @@ google-cloud-audit-log==0.3.0
     # via google-cloud-logging
 google-cloud-automl==2.13.5
     # via apache-airflow-providers-google
-google-cloud-batch==0.17.27
+google-cloud-batch==0.17.29
     # via apache-airflow-providers-google
-google-cloud-bigquery==3.20.1
+google-cloud-bigquery==3.26.0
     # via
     #   apache-airflow-providers-google
     #   google-cloud-aiplatform
     #   pandas-gbq
     #   sqlalchemy-bigquery
-google-cloud-bigquery-datatransfer==3.15.7
+google-cloud-bigquery-datatransfer==3.16.0
     # via apache-airflow-providers-google
 google-cloud-bigtable==2.26.0
     # via apache-airflow-providers-google
-google-cloud-build==3.24.2
+google-cloud-build==3.25.0
     # via apache-airflow-providers-google
 google-cloud-compute==1.19.2
     # via apache-airflow-providers-google
-google-cloud-container==2.51.0
+google-cloud-container==2.52.0
     # via apache-airflow-providers-google
 google-cloud-core==2.4.1
     # via
@@ -516,13 +518,13 @@ google-cloud-dataform==0.5.11
     # via apache-airflow-providers-google
 google-cloud-dataplex==2.2.2
     # via apache-airflow-providers-google
-google-cloud-dataproc==5.11.0
+google-cloud-dataproc==5.13.0
     # via apache-airflow-providers-google
 google-cloud-dataproc-metastore==1.15.5
     # via apache-airflow-providers-google
-google-cloud-dlp==3.22.0
+google-cloud-dlp==3.23.0
     # via apache-airflow-providers-google
-google-cloud-kms==2.24.2
+google-cloud-kms==3.0.0
     # via apache-airflow-providers-google
 google-cloud-language==2.14.0
     # via apache-airflow-providers-google
@@ -532,21 +534,21 @@ google-cloud-memcache==1.9.5
     # via apache-airflow-providers-google
 google-cloud-monitoring==2.22.2
     # via apache-airflow-providers-google
-google-cloud-orchestration-airflow==1.13.1
+google-cloud-orchestration-airflow==1.14.0
     # via apache-airflow-providers-google
 google-cloud-os-login==2.14.6
     # via apache-airflow-providers-google
-google-cloud-pubsub==2.23.0
+google-cloud-pubsub==2.25.0
     # via apache-airflow-providers-google
 google-cloud-redis==2.15.5
     # via apache-airflow-providers-google
 google-cloud-resource-manager==1.12.5
     # via google-cloud-aiplatform
-google-cloud-run==0.10.8
+google-cloud-run==0.10.9
     # via apache-airflow-providers-google
 google-cloud-secret-manager==2.20.2
     # via apache-airflow-providers-google
-google-cloud-spanner==3.49.0
+google-cloud-spanner==3.49.1
     # via
     #   apache-airflow-providers-google
     #   sqlalchemy-spanner
@@ -561,7 +563,7 @@ google-cloud-storage-transfer==1.12.0
     # via apache-airflow-providers-google
 google-cloud-tasks==2.16.5
     # via apache-airflow-providers-google
-google-cloud-texttospeech==2.17.2
+google-cloud-texttospeech==2.18.0
     # via apache-airflow-providers-google
 google-cloud-translate==3.16.0
     # via apache-airflow-providers-google
@@ -585,7 +587,7 @@ google-resumable-media==2.7.2
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
-googleapis-common-protos[grpc]==1.63.2
+googleapis-common-protos[grpc]==1.65.0
     # via
     #   -c constraints.txt
     #   google-ads
@@ -599,7 +601,7 @@ graphviz==0.20.3
     # via
     #   -c constraints.txt
     #   -r requirements.in
-greenlet==3.0.3
+greenlet==3.1.0
     # via
     #   -c constraints.txt
     #   sqlalchemy
@@ -621,7 +623,9 @@ grpc-google-iam-v1==0.13.1
     #   google-cloud-spanner
     #   google-cloud-tasks
     #   google-cloud-translate
-grpcio==1.65.4
+grpc-interceptor==0.15.4
+    # via google-cloud-spanner
+grpcio==1.66.1
     # via
     #   -c constraints.txt
     #   google-ads
@@ -629,6 +633,7 @@ grpcio==1.65.4
     #   google-cloud-pubsub
     #   googleapis-common-protos
     #   grpc-google-iam-v1
+    #   grpc-interceptor
     #   grpcio-gcp
     #   grpcio-status
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -657,14 +662,14 @@ httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-httpx==0.27.0
+httpx==0.27.2
     # via
     #   -c constraints.txt
     #   apache-airflow
     #   apache-airflow-providers-google
-humanize==4.10.0
+humanize==4.11.0
     # via flower
-idna==3.7
+idna==3.10
     # via
     #   -c constraints.txt
     #   anyio
@@ -672,13 +677,15 @@ idna==3.7
     #   httpx
     #   requests
     #   yarl
-imageio==2.35.1
+imageio==2.36.0
     # via env-canada
-importlib-metadata==8.2.0
+immutabledict==4.2.0
+    # via apache-airflow-providers-google
+importlib-metadata==8.5.0
     # via
     #   -c constraints.txt
     #   apache-airflow
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via
     #   -c constraints.txt
     #   limits
@@ -690,7 +697,7 @@ iniconfig==2.0.0
     # via pytest
 ipykernel==6.29.5
     # via -r requirements.in
-ipython==8.27.0
+ipython==8.28.0
     # via
     #   -r requirements.in
     #   ipykernel
@@ -728,13 +735,13 @@ jsonschema-specifications==2023.12.1
     # via
     #   -c constraints.txt
     #   jsonschema
-jupyter-client==8.6.2
+jupyter-client==8.6.3
     # via ipykernel
 jupyter-core==5.7.2
     # via
     #   ipykernel
     #   jupyter-client
-kombu==5.4.0
+kombu==5.4.2
     # via celery
 lazy-object-proxy==1.10.0
     # via
@@ -754,7 +761,7 @@ lockfile==0.12.2
     #   -c constraints.txt
     #   apache-airflow
     #   python-daemon
-looker-sdk==24.14.0
+looker-sdk==24.18.0
     # via apache-airflow-providers-google
 lxml==5.3.0
     # via
@@ -778,7 +785,7 @@ markupsafe==2.1.5
     #   mako
     #   werkzeug
     #   wtforms
-marshmallow==3.21.3
+marshmallow==3.22.0
     # via
     #   -c constraints.txt
     #   flask-appbuilder
@@ -798,7 +805,7 @@ matplotlib-inline==0.1.7
     #   ipython
 mccabe==0.7.0
     # via pylint
-mdit-py-plugins==0.4.1
+mdit-py-plugins==0.4.2
     # via
     #   -c constraints.txt
     #   apache-airflow
@@ -810,11 +817,11 @@ methodtools==0.4.7
     # via
     #   -c constraints.txt
     #   apache-airflow
-more-itertools==10.4.0
+more-itertools==10.5.0
     # via
     #   -c constraints.txt
     #   apache-airflow-providers-common-sql
-multidict==6.0.5
+multidict==6.1.0
     # via
     #   -c constraints.txt
     #   aiohttp
@@ -840,6 +847,7 @@ opentelemetry-api==1.16.0
     #   -c constraints.txt
     #   apache-airflow
     #   google-cloud-logging
+    #   google-cloud-pubsub
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
@@ -863,6 +871,7 @@ opentelemetry-proto==1.16.0
 opentelemetry-sdk==1.16.0
     # via
     #   -c constraints.txt
+    #   google-cloud-pubsub
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-semantic-conventions==0.37b0
@@ -901,7 +910,7 @@ pandas==2.1.4
     #   env-canada
     #   geopandas
     #   pandas-gbq
-pandas-gbq==0.23.1
+pandas-gbq==0.24.0
     # via apache-airflow-providers-google
 parso==0.8.4
     # via jedi
@@ -915,13 +924,13 @@ pendulum==3.0.0
     #   apache-airflow
 pexpect==4.9.0
     # via ipython
-pillow==10.4.0
+pillow==11.0.0
     # via
     #   env-canada
     #   imageio
-pip-tools==7.3.0
+pip-tools==7.4.1
     # via -r requirements.in
-platformdirs==4.2.2
+platformdirs==4.3.3
     # via
     #   -c constraints.txt
     #   jupyter-core
@@ -939,7 +948,7 @@ prometheus-client==0.20.0
     # via
     #   -c constraints.txt
     #   flower
-prompt-toolkit==3.0.47
+prompt-toolkit==3.0.48
     # via
     #   click-repl
     #   ipython
@@ -1050,7 +1059,7 @@ pyarrow==17.0.0
     # via
     #   db-dtypes
     #   pandas-gbq
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   -c constraints.txt
     #   pyasn1-modules
@@ -1064,11 +1073,11 @@ pycparser==2.22
     # via
     #   -c constraints.txt
     #   cffi
-pydantic==2.8.2
+pydantic==2.9.1
     # via
     #   -c constraints.txt
     #   google-cloud-aiplatform
-pydantic-core==2.20.1
+pydantic-core==2.23.3
     # via
     #   -c constraints.txt
     #   pydantic
@@ -1091,17 +1100,19 @@ pyjwt==2.9.0
     #   gcloud-aio-auth
 pylint==2.17.5
     # via -r requirements.in
-pyogrio==0.9.0
+pyogrio==0.10.0
     # via geopandas
 pyopenssl==24.2.1
     # via apache-airflow-providers-google
-pyparsing==3.1.4
+pyparsing==3.2.0
     # via httplib2
-pyproj==3.6.1
+pyproj==3.7.0
     # via geopandas
-pyproject-hooks==1.1.0
-    # via build
-pytest==8.3.2
+pyproject-hooks==1.2.0
+    # via
+    #   build
+    #   pip-tools
+pytest==8.3.3
     # via
     #   -r requirements.in
     #   pytest-mock
@@ -1135,7 +1146,7 @@ python-slugify==8.0.4
     #   apache-airflow
     #   apache-airflow-providers-google
     #   python-nvd3
-pytz==2024.1
+pytz==2024.2
     # via
     #   -c constraints.txt
     #   croniter
@@ -1153,7 +1164,7 @@ pyzmq==26.2.0
     # via
     #   ipykernel
     #   jupyter-client
-redis==5.0.8
+redis==5.1.1
     # via celery
 referencing==0.35.1
     # via
@@ -1175,7 +1186,9 @@ requests==2.32.3
     #   requests-oauthlib
     #   requests-toolbelt
 requests-oauthlib==2.0.0
-    # via google-auth-oauthlib
+    # via
+    #   -r requirements.in
+    #   google-auth-oauthlib
 requests-toolbelt==1.0.0
     # via
     #   -c constraints.txt
@@ -1185,7 +1198,7 @@ rfc3339-validator==0.1.4
     # via
     #   -c constraints.txt
     #   apache-airflow
-rich==13.7.1
+rich==13.8.1
     # via
     #   -c constraints.txt
     #   apache-airflow
@@ -1220,7 +1233,7 @@ six==1.16.0
     #   python-dateutil
     #   rfc3339-validator
     #   wirerope
-slack-sdk==3.31.0
+slack-sdk==3.33.1
     # via apache-airflow-providers-slack
 sniffio==1.3.1
     # via
@@ -1231,7 +1244,7 @@ snowballstemmer==2.2.0
     # via pydocstyle
 soupsieve==2.6
     # via beautifulsoup4
-sqlalchemy==1.4.53
+sqlalchemy==1.4.54
     # via
     #   -c constraints.txt
     #   alembic
@@ -1243,7 +1256,7 @@ sqlalchemy==1.4.53
     #   sqlalchemy-jsonfield
     #   sqlalchemy-spanner
     #   sqlalchemy-utils
-sqlalchemy-bigquery==1.11.0
+sqlalchemy-bigquery==1.12.0
     # via apache-airflow-providers-google
 sqlalchemy-jsonfield==1.0.2
     # via
@@ -1283,7 +1296,7 @@ time-machine==2.15.0
     # via
     #   -c constraints.txt
     #   pendulum
-tomli==2.0.1
+tomli==2.0.2
     # via
     #   build
     #   pip-tools
@@ -1316,6 +1329,7 @@ typing-extensions==4.12.2
     #   ipython
     #   limits
     #   looker-sdk
+    #   multidict
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core
@@ -1323,6 +1337,7 @@ tzdata==2024.1
     # via
     #   -c constraints.txt
     #   celery
+    #   kombu
     #   pandas
     #   pendulum
 uc-micro-py==1.0.3
@@ -1333,13 +1348,13 @@ unicodecsv==0.14.1
     # via
     #   -c constraints.txt
     #   apache-airflow
-universal-pathlib==0.2.2
+universal-pathlib==0.2.5
     # via
     #   -c constraints.txt
     #   apache-airflow
 uritemplate==4.1.1
     # via google-api-python-client
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   -c constraints.txt
     #   requests
@@ -1378,11 +1393,11 @@ wtforms==3.1.2
     #   -c constraints.txt
     #   flask-appbuilder
     #   flask-wtf
-yarl==1.9.4
+yarl==1.11.1
     # via
     #   -c constraints.txt
     #   aiohttp
-zipp==3.20.0
+zipp==3.20.2
     # via
     #   -c constraints.txt
     #   importlib-metadata


### PR DESCRIPTION
## What this pull request accomplishes:

- update airflow to 2.10.2
- add http, ftp providers to requirements.in (they were being installed via airflow_setup.sh)
  - `pip install "apache-airflow[celery,postgres,google,slack,ftp,http]==${AIRFLOW_VERSION}"`

## Issue(s) this solves:

- #1082 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
