### PR TITLE
Fix #1091 by properly filtering one-way streets

### DIFF
--- a/gis/centreline/readme.md
+++ b/gis/centreline/readme.md
@@ -14,7 +14,7 @@ The centreline data are used by many other groups in the City and it's often imp
 
 ## How It's Structured
 
-* The `gis_core.centreline_latest` Materialized View contains the latest set of lines with unique id `centreline_id`. These lines are undirected. All edges have _from_ and _to_ nodes, though this should not be taken to indicate that edges are directed. For a directed centreline layer, check out `gis_core.routing_centreline_directional` ([see more](#centreline-segments-edges))
+* The `gis_core.centreline_latest` Materialized View contains the latest set of lines with unique id `centreline_id`. These lines are undirected. All edges have _from_ and _to_ nodes, though this should not be taken to indicate that edges are directed. For a directed centreline layer, check out `gis_core.routing_centreline_directional` ([see more](#centreline-segments-edges)) which has the necessary schema to be used in pg_routing.
 * The `centreline_intersection_point_latest` Materialized View contains the latest set of unique intersections with unique id `intersection_id`. These are any location where two lines intersect, not strictly intersections in the transportation sense ([see more](#intersections-nodes))
 
 ## Where It's Stored
@@ -41,7 +41,7 @@ Currently we are including only the following types:
 
 #### Directionality
 
-Directionality of streets can be identified with the column `oneway_dir_code_desc`, distinguishing whether the segment is a one-way street. A two way street will be represented by a single segment. `oneway_dir_code` can be used to identify whether a segment is being drawn with the digitization or against, indicating vehicular traffic direction.
+Directionality of streets can be identified with the column `oneway_dir_code_desc`, distinguishing whether the segment is a one-way street. A two way street will be represented by a single segment (`oneway_dir_code = 0`). `oneway_dir_code` can be used to identify whether a segment is being drawn with the digitization (1) or against (-1), indicating vehicular traffic direction.
 
 #### Lineage
 

--- a/gis/centreline/sql/create_view_routing_centreline_directional.sql
+++ b/gis/centreline/sql/create_view_routing_centreline_directional.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE VIEW gis_core.routing_centreline_directional AS
 
-SELECT 
+SELECT
     centreline_id,
     concat(row_number() OVER (), dir)::bigint AS id,
     source,
     target,
-    cost,
+    "cost",
     geom
 
 FROM (
@@ -13,9 +13,9 @@ FROM (
         centreline.centreline_id,
         centreline.from_intersection_id AS source,
         centreline.to_intersection_id AS target,
-        centreline.shape_length AS cost,
+        centreline.shape_length AS "cost",
         centreline.geom,
-        0 as dir
+        0 AS dir
     FROM gis_core.centreline_latest AS centreline
     WHERE centreline.oneway_dir_code >= 0 -- bi-directional and with digitization
 
@@ -25,17 +25,20 @@ FROM (
         centreline.centreline_id,
         centreline.to_intersection_id AS source,
         centreline.from_intersection_id AS target,
-        centreline.shape_length AS cost,
+        centreline.shape_length AS "cost",
         st_reverse(centreline.geom) AS geom,
-        1 as dir
+        1 AS dir
     FROM gis_core.centreline_latest AS centreline
     WHERE centreline.oneway_dir_code <= 0 /*bi-directional or against digitization*/
-    ) AS dup;
+) AS dup;
 
 ALTER TABLE gis_core.routing_centreline_directional OWNER TO gis_admins;
 
 COMMENT ON VIEW gis_core.routing_centreline_directional
-IS 'A view that contains centreline streets for routing, with duplicated rows for two-way streets and flipped geometries when lines were drawn against digitization. A new id has been assigned to each centreline to distinguish duplicated lines.';
+IS '''A view that contains centreline streets for routing, with duplicated rows 
+for two-way streets and flipped geometries when lines were drawn against 
+digitization. A new id has been assigned to each centreline to distinguish 
+duplicated lines.''';
 
 GRANT SELECT ON TABLE gis_core.routing_centreline_directional TO bdit_humans;
 GRANT ALL ON TABLE gis_core.routing_centreline_directional TO gis_admins;

--- a/gis/centreline/sql/create_view_routing_centreline_directional.sql
+++ b/gis/centreline/sql/create_view_routing_centreline_directional.sql
@@ -5,7 +5,7 @@ SELECT
     concat(row_number() OVER (), dir)::bigint AS id,
     source,
     target,
-    "cost",
+    cost_length,
     geom
 
 FROM (
@@ -13,7 +13,7 @@ FROM (
         centreline.centreline_id,
         centreline.from_intersection_id AS source,
         centreline.to_intersection_id AS target,
-        centreline.shape_length AS "cost",
+        centreline.shape_length AS cost_length,
         centreline.geom,
         0 AS dir
     FROM gis_core.centreline_latest AS centreline
@@ -25,7 +25,7 @@ FROM (
         centreline.centreline_id,
         centreline.to_intersection_id AS source,
         centreline.from_intersection_id AS target,
-        centreline.shape_length AS "cost",
+        centreline.shape_length AS cost_length,
         st_reverse(centreline.geom) AS geom,
         1 AS dir
     FROM gis_core.centreline_latest AS centreline

--- a/gis/centreline/sql/create_view_routing_centreline_directional.sql
+++ b/gis/centreline/sql/create_view_routing_centreline_directional.sql
@@ -17,6 +17,7 @@ FROM (
         centreline.geom,
         0 as dir
     FROM gis_core.centreline_latest AS centreline
+    WHERE centreline.oneway_dir_code >= 0 -- bi-directional and with digitization
 
     UNION
 
@@ -28,12 +29,13 @@ FROM (
         st_reverse(centreline.geom) AS geom,
         1 as dir
     FROM gis_core.centreline_latest AS centreline
-    WHERE centreline.oneway_dir_code = 0) AS dup;
+    WHERE centreline.oneway_dir_code <= 0 /*bi-directional or against digitization*/
+    ) AS dup;
 
 ALTER TABLE gis_core.routing_centreline_directional OWNER TO gis_admins;
 
 COMMENT ON VIEW gis_core.routing_centreline_directional
-IS 'A view that contains centreline streets for routing, with duplicated rows for two-way streets and flipped geometries when necessary. A new id has been assigned to each centreline to distinguish duplicated lines.';
+IS 'A view that contains centreline streets for routing, with duplicated rows for two-way streets and flipped geometries when lines were drawn against digitization. A new id has been assigned to each centreline to distinguish duplicated lines.';
 
 GRANT SELECT ON TABLE gis_core.routing_centreline_directional TO bdit_humans;
 GRANT ALL ON TABLE gis_core.routing_centreline_directional TO gis_admins;


### PR DESCRIPTION
The flow of traffic is opposite the drawn direction for one way streets that are -1

## What this pull request accomplishes:

- Fix a bug routing on one-way streets

## Issue(s) this solves:

- #1091 

## What, in particular, needs to reviewed:

- Other examples worth testing? this isn't going to be perfect given the known issues with routing along the centreline

## What needs to be done by a sysadmin after this PR is merged

- [ ] Purge `gis_core.routing_centreline_directional_DO_NOT_USE`
