### PR TITLE
#1112 remove top-level connections, fix some import warnings

### DIFF
--- a/.github/workflows/test_dags.yml
+++ b/.github/workflows/test_dags.yml
@@ -20,4 +20,4 @@ jobs:
         pip install -r requirements.txt
     - name: Run basic tests on DAGs
       run: |
-        pytest -v test/integration/test_dags.py -W error
+        pytest -v test/integration/test_dags.py

--- a/.github/workflows/test_dags.yml
+++ b/.github/workflows/test_dags.yml
@@ -20,4 +20,4 @@ jobs:
         pip install -r requirements.txt
     - name: Run basic tests on DAGs
       run: |
-        pytest -v test/integration/test_dags.py
+        pytest -v test/integration/test_dags.py -W error

--- a/dags/assets_pull.py
+++ b/dags/assets_pull.py
@@ -23,7 +23,7 @@ from psycopg2 import sql
 import requests
 from psycopg2.extras import execute_values
 from airflow import DAG
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.models import Variable 
 
 from dateutil.parser import parse

--- a/dags/bluetooth_check_readers_temp.py
+++ b/dags/bluetooth_check_readers_temp.py
@@ -50,7 +50,7 @@ default_args = {
 @dag(
     dag_id=DAG_NAME,
     default_args=default_args,
-    schedule_interval='0 8 * * *',
+    schedule='0 8 * * *',
     catchup=False,
     tags=['bluetooth', 'data_checks']
 )

--- a/dags/bluetooth_check_readers_temp.py
+++ b/dags/bluetooth_check_readers_temp.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 from airflow.decorators import dag, task
 from airflow.models import Variable
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 try:
@@ -68,7 +68,7 @@ def blip_pipeline():
     ) 
 
     # Update bluetooth.routes with the latest last_reported_date
-    update_routes_table = PostgresOperator(
+    update_routes_table = SQLExecuteQueryOperator(
         sql='''SELECT * from bluetooth.insert_report_date_temp()''',
         task_id='update_routes_table',
         postgres_conn_id='bt_bot',
@@ -77,7 +77,7 @@ def blip_pipeline():
     )
 
     # Update bluetooth.reader_locations with the latest reader status
-    update_reader_status = PostgresOperator(
+    update_reader_status = SQLExecuteQueryOperator(
         sql='''SELECT * from bluetooth.reader_status_history_temp('{{ ds }}')''',
         task_id='update_reader_status',
         postgres_conn_id='bt_bot',

--- a/dags/bluetooth_check_readers_temp.py
+++ b/dags/bluetooth_check_readers_temp.py
@@ -71,7 +71,7 @@ def blip_pipeline():
     update_routes_table = SQLExecuteQueryOperator(
         sql='''SELECT * from bluetooth.insert_report_date_temp()''',
         task_id='update_routes_table',
-        postgres_conn_id='bt_bot',
+        conn_id='bt_bot',
         autocommit=True,
         retries = 0
     )
@@ -80,7 +80,7 @@ def blip_pipeline():
     update_reader_status = SQLExecuteQueryOperator(
         sql='''SELECT * from bluetooth.reader_status_history_temp('{{ ds }}')''',
         task_id='update_reader_status',
-        postgres_conn_id='bt_bot',
+        conn_id='bt_bot',
         autocommit=True,
         retries = 0
     )

--- a/dags/check_miovision.py
+++ b/dags/check_miovision.py
@@ -8,7 +8,7 @@ import os
 
 from airflow import DAG
 from datetime import datetime, timedelta
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.models import Variable 
 

--- a/dags/check_rescu.py
+++ b/dags/check_rescu.py
@@ -4,7 +4,7 @@ from functools import partial
 
 from airflow import DAG
 from datetime import timedelta
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.models import Variable 
 

--- a/dags/citywide_tti_aggregate.py
+++ b/dags/citywide_tti_aggregate.py
@@ -59,7 +59,7 @@ def citywide_tti_aggregate():
 
     aggregate_daily = SQLExecuteQueryOperator(sql="SELECT covid.generate_citywide_tti( '{{macros.ds_add(ds, -1)}}' )",
                                        task_id='aggregate_daily',
-                                       postgres_conn_id='congestion_bot',
+                                       conn_id='congestion_bot',
                                        autocommit=True,
                                        retries = 0
                                        )

--- a/dags/citywide_tti_aggregate.py
+++ b/dags/citywide_tti_aggregate.py
@@ -46,7 +46,7 @@ default_args = {'owner': ','.join(DAG_OWNERS),
 @dag(
     DAG_NAME, 
     default_args=default_args, 
-    schedule_interval=None, # gets triggered by HERE dag
+    schedule=None, # gets triggered by HERE dag
     doc_md = doc_md,
     tags=["HERE"],
     catchup=False

--- a/dags/citywide_tti_aggregate.py
+++ b/dags/citywide_tti_aggregate.py
@@ -2,7 +2,7 @@ import sys
 import os
 
 from datetime import datetime, timedelta
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.models import Variable
 from airflow.decorators import dag, task
 from airflow.macros import ds_add, ds_format
@@ -57,7 +57,7 @@ def citywide_tti_aggregate():
 
 # Task to aggregate citwyide tti
 
-    aggregate_daily = PostgresOperator(sql="SELECT covid.generate_citywide_tti( '{{macros.ds_add(ds, -1)}}' )",
+    aggregate_daily = SQLExecuteQueryOperator(sql="SELECT covid.generate_citywide_tti( '{{macros.ds_add(ds, -1)}}' )",
                                        task_id='aggregate_daily',
                                        postgres_conn_id='congestion_bot',
                                        autocommit=True,

--- a/dags/dag_functions.py
+++ b/dags/dag_functions.py
@@ -150,17 +150,15 @@ def task_fail_slack_alert(
 
 def get_readme_docmd(readme_path, dag_name):
     """Extracts a DAG doc_md from a .md file using html comments tags.
-
     Args:
         readme_path: An aboslute path to the .md file to extract from. 
         dag_name: The name of the DAG, matching the html comment in the .md
         file to extract from. The html comment should be in the format
         '<!-- dag_name_doc_md -->' before and after the relevant section. 
     """
-
     contents = open(readme_path, 'r').read()
     doc_md_key = '<!-- ' + dag_name + '_doc_md -->'
-    doc_md_regex = '(?<=' + doc_md_key + '\n)[\s\S]+(?=\n' + doc_md_key + ')'
+    doc_md_regex = '(?<=' + doc_md_key + '\\n)[\\s\\S]+(?=\\n' + doc_md_key + ')'
     try:
         doc_md = re.findall(doc_md_regex, contents)[0]
     except IndexError: #soft fail without breaking DAG.

--- a/dags/ecocounter_pull.py
+++ b/dags/ecocounter_pull.py
@@ -73,7 +73,7 @@ def pull_ecocounter_dag():
     @task_group(tooltip="Tasks to check if necessary to create new partitions and if so, exexcute.")
     def check_partitions():
 
-        create_annual_partition = PostgresOperator(
+        create_annual_partition = SQLExecuteQueryOperator(
             task_id='create_annual_partitions',
             pre_execute=check_jan_1st,
             sql="""SELECT ecocounter.create_yyyy_counts_unfiltered_partition(

--- a/dags/ecocounter_pull.py
+++ b/dags/ecocounter_pull.py
@@ -15,9 +15,9 @@ import logging
 
 from airflow.decorators import dag, task, task_group
 from airflow.models import Variable
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.macros import ds_add
 from airflow.exceptions import AirflowSkipException
 from airflow.sensors.external_task import ExternalTaskMarker
@@ -80,7 +80,7 @@ def pull_ecocounter_dag():
                     base_table := 'counts_unfiltered',
                     year_ := '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int
                 )""",
-            postgres_conn_id='ecocounter_bot',
+            conn_id='ecocounter_bot',
             autocommit=True
         )
       

--- a/dags/eoy_create_tables.py
+++ b/dags/eoy_create_tables.py
@@ -15,7 +15,7 @@ from datetime import timedelta
 
 from airflow.decorators import dag, task, task_group
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.models import Variable
 
 LOGGER = logging.getLogger(__name__)
@@ -73,24 +73,24 @@ def eoy_create_table_dag():
                     name = name.replace('Observed', 'obs')
                     cur.execute('INSERT INTO ref.holiday VALUES (%s, %s)', (dt, name))
 
-        here_create_tables = PostgresOperator(
+        here_create_tables = SQLExecuteQueryOperator(
                         task_id='here_create_tables',
                         sql="SELECT here.create_yearly_tables('{{ task_instance.xcom_pull('yr') }}')",
                         postgres_conn_id='here_bot',
                         autocommit=True)
-        here_path_create_tables = PostgresOperator(
+        here_path_create_tables = SQLExecuteQueryOperator(
                         task_id='here_path_create_tables',
                         sql="SELECT here.create_yearly_tables_path('{{ task_instance.xcom_pull('yr') }}')",
                         postgres_conn_id='here_bot',
                         autocommit=True)
         
-        bt_create_tables = PostgresOperator(
+        bt_create_tables = SQLExecuteQueryOperator(
                         task_id='bluetooth_create_tables',
                         sql="SELECT bluetooth.create_obs_tables('{{ task_instance.xcom_pull('yr') }}')",
                         postgres_conn_id='bt_bot',
                         autocommit=True)
         
-        congestion_create_table = PostgresOperator(
+        congestion_create_table = SQLExecuteQueryOperator(
                         task_id='congestion_create_table',
                         sql="SELECT congestion.create_yearly_tables('{{ task_instance.xcom_pull('yr') }}')",
                         postgres_conn_id='congestion_bot',

--- a/dags/eoy_create_tables.py
+++ b/dags/eoy_create_tables.py
@@ -76,24 +76,24 @@ def eoy_create_table_dag():
         here_create_tables = SQLExecuteQueryOperator(
                         task_id='here_create_tables',
                         sql="SELECT here.create_yearly_tables('{{ task_instance.xcom_pull('yr') }}')",
-                        postgres_conn_id='here_bot',
+                        conn_id='here_bot',
                         autocommit=True)
         here_path_create_tables = SQLExecuteQueryOperator(
                         task_id='here_path_create_tables',
                         sql="SELECT here.create_yearly_tables_path('{{ task_instance.xcom_pull('yr') }}')",
-                        postgres_conn_id='here_bot',
+                        conn_id='here_bot',
                         autocommit=True)
         
         bt_create_tables = SQLExecuteQueryOperator(
                         task_id='bluetooth_create_tables',
                         sql="SELECT bluetooth.create_obs_tables('{{ task_instance.xcom_pull('yr') }}')",
-                        postgres_conn_id='bt_bot',
+                        conn_id='bt_bot',
                         autocommit=True)
         
         congestion_create_table = SQLExecuteQueryOperator(
                         task_id='congestion_create_table',
                         sql="SELECT congestion.create_yearly_tables('{{ task_instance.xcom_pull('yr') }}')",
-                        postgres_conn_id='congestion_bot',
+                        conn_id='congestion_bot',
                         autocommit=True)
         
         bt_replace_trigger(yr=YR)

--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -6,7 +6,7 @@ from functools import partial
 import pendulum
 from airflow.decorators import dag, task
 from airflow.models import Variable
-from airflow.hooks.postgres_hook import PostgresHook
+from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.operators.python import get_current_context
 
 try:

--- a/dags/log_cleanup.py
+++ b/dags/log_cleanup.py
@@ -99,10 +99,10 @@ echo "Running Cleanup Process..."
 if [ $TYPE == file ];
 then
     FIND_STATEMENT="find ${BASE_LOG_FOLDER}/*/* -type f -mtime +${MAX_LOG_AGE_IN_DAYS}"
-    DELETE_STMT="${FIND_STATEMENT} -exec rm -f {} \;"
+    DELETE_STMT="${FIND_STATEMENT} -exec rm -f {} \\;"
 else
     FIND_STATEMENT="find ${BASE_LOG_FOLDER}/*/* -type d -empty"
-    DELETE_STMT="${FIND_STATEMENT} -prune -exec rm -rf {} \;"
+    DELETE_STMT="${FIND_STATEMENT} -prune -exec rm -rf {} \\;"
 fi
 echo "Executing Find Statement: ${FIND_STATEMENT}"
 FILES_MARKED_FOR_DELETE=`eval ${FIND_STATEMENT}`

--- a/dags/log_cleanup.py
+++ b/dags/log_cleanup.py
@@ -16,7 +16,7 @@ AIRFLOW_TASKS = os.path.join(AIRFLOW_ROOT, 'tasks')
 AIRFLOW_TASKS_LIB = os.path.join(AIRFLOW_TASKS, 'lib')
 
 from airflow.configuration import conf
-from airflow.operators.bash_operator import BashOperator
+from airflow.operators.bash import BashOperator
 from airflow.models import Variable 
 
 dag_name = 'log_cleanup'

--- a/dags/miovision_pull.py
+++ b/dags/miovision_pull.py
@@ -81,7 +81,7 @@ def pull_miovision_dag():
             sql=["SELECT miovision_api.create_yyyy_volumes_partition('volumes', '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, 'datetime_bin')",
                  "SELECT miovision_api.create_yyyy_volumes_15min_partition('volumes_15min', '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int)",
                  "SELECT miovision_api.create_yyyy_volumes_15min_partition('volumes_15min_mvt', '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int)"],
-            postgres_conn_id='miovision_api_bot',
+            conn_id='miovision_api_bot',
             autocommit=True
         )
       
@@ -89,7 +89,7 @@ def pull_miovision_dag():
             task_id='create_month_partition',
             pre_execute=check_1st_of_month,
             sql="""SELECT miovision_api.create_mm_nested_volumes_partitions('volumes'::text, '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, '{{ macros.ds_format(ds, '%Y-%m-%d', '%m') }}'::int)""",
-            postgres_conn_id='miovision_api_bot',
+            conn_id='miovision_api_bot',
             autocommit=True,
             trigger_rule='none_failed_min_one_success'
         )

--- a/dags/miovision_pull.py
+++ b/dags/miovision_pull.py
@@ -14,7 +14,7 @@ import dateutil.parser
 from airflow.decorators import dag, task, task_group
 from airflow.models.param import Param
 from airflow.models import Variable
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.macros import ds_add
@@ -75,7 +75,7 @@ def pull_miovision_dag():
     @task_group(tooltip="Tasks to check if necessary to create new partitions and if so, exexcute.")
     def check_partitions():
 
-        create_annual_partition = PostgresOperator(
+        create_annual_partition = SQLExecuteQueryOperator(
             task_id='create_annual_partitions',
             pre_execute=check_jan_1st,
             sql=["SELECT miovision_api.create_yyyy_volumes_partition('volumes', '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, 'datetime_bin')",
@@ -85,7 +85,7 @@ def pull_miovision_dag():
             autocommit=True
         )
       
-        create_month_partition = PostgresOperator(
+        create_month_partition = SQLExecuteQueryOperator(
             task_id='create_month_partition',
             pre_execute=check_1st_of_month,
             sql="""SELECT miovision_api.create_mm_nested_volumes_partitions('volumes'::text, '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, '{{ macros.ds_format(ds, '%Y-%m-%d', '%m') }}'::int)""",

--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -81,14 +81,14 @@ def pull_here():
     request_id =  get_request_id(access_token)
     download_url = get_download_link(request_id, access_token)
 
-    @task.bash(append_env=True)
-    def load_data_run(download_url)->str:
-        conn = BaseHook.get_connection("here_bot")
-        os.environ['HOST'] = conn.host
-        os.environ['LOGIN'] = conn.login
-        os.environ['PW'] = conn.password
-        os.environ['DOWNLOAD_URL'] = download_url
-        return '''curl $DOWNLOAD_URL | gunzip | PGPASSWORD=$PW psql -h $HOST -U $LOGIN -d bigdata -c "\\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
+    @task.bash(env = {
+        'HOST': '{{ conn.here_bot.host }}',
+        'LOGIN': '{{ conn.here_bot.login }}',
+        'PGPASSWORD': '{{ conn.here_bot.password }}',
+        'DOWNLOAD_URL': download_url
+    })
+    def load_data_run()->str:
+        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $LOGIN -d bigdata -c "\\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
     
     # Create a task group for triggering the DAGs
     @task_group(group_id='trigger_dags_tasks')
@@ -105,6 +105,6 @@ def pull_here():
             )
             trigger_operators.append(trigger_operator)
 
-    load_data_run(download_url) >> trigger_dags()
+    load_data_run() >> trigger_dags()
 
 pull_here()

--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -87,7 +87,7 @@ def pull_here():
         os.environ['HOST'] = conn.host
         os.environ['USER'] = conn.login
         os.environ['PGPASSWORD'] = conn.password
-        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $USER -d bigdata -c "\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
+        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $USER -d bigdata -c "\\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
     
     # Create a task group for triggering the DAGs
     @task_group(group_id='trigger_dags_tasks')

--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -86,9 +86,9 @@ def pull_here():
         conn = BaseHook.get_connection("here_bot")
         os.environ['HOST'] = conn.host
         os.environ['LOGIN'] = conn.login
-        os.environ['PGPASSWORD'] = conn.password
+        os.environ['PW'] = conn.password
         os.environ['DOWNLOAD_URL'] = download_url
-        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $LOGIN -d bigdata -c "\\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
+        return '''curl $DOWNLOAD_URL | gunzip | PGPASSWORD=$PW psql -h $HOST -U $LOGIN -d bigdata -c "\\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
     
     # Create a task group for triggering the DAGs
     @task_group(group_id='trigger_dags_tasks')

--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -85,9 +85,9 @@ def pull_here():
     def load_data_run()->str:
         conn = BaseHook.get_connection("here_bot")
         os.environ['HOST'] = conn.host
-        os.environ['USER'] = conn.login
+        os.environ['LOGIN'] = conn.login
         os.environ['PGPASSWORD'] = conn.password
-        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $USER -d bigdata -c "\\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
+        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $LOGIN -d bigdata -c "\\COPY here.ta_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
     
     # Create a task group for triggering the DAGs
     @task_group(group_id='trigger_dags_tasks')

--- a/dags/pull_here_path.py
+++ b/dags/pull_here_path.py
@@ -81,9 +81,9 @@ def pull_here_path():
         conn = BaseHook.get_connection("here_bot")
         os.environ['HOST'] = conn.host
         os.environ['LOGIN'] = conn.login
-        os.environ['PGPASSWORD'] = conn.password
+        os.environ['PW'] = conn.password
         os.environ['DOWNLOAD_URL'] = download_url
-        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $LOGIN -d bigdata -c "\\COPY here.ta_path_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
+        return '''curl $DOWNLOAD_URL | gunzip | PGPASSWORD=$PW psql -h $HOST -U $LOGIN -d bigdata -c "\\COPY here.ta_path_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
 
     load_data(download_url)
 

--- a/dags/pull_here_path.py
+++ b/dags/pull_here_path.py
@@ -80,9 +80,9 @@ def pull_here_path():
     def load_data()->str:
         conn = BaseHook.get_connection("here_bot")
         os.environ['HOST'] = conn.host
-        os.environ['USER'] = conn.login
+        os.environ['LOGIN'] = conn.login
         os.environ['PGPASSWORD'] = conn.password
-        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $USER -d bigdata -c "\\COPY here.ta_path_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
+        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $LOGIN -d bigdata -c "\\COPY here.ta_path_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
 
     load_data()
 

--- a/dags/pull_here_path.py
+++ b/dags/pull_here_path.py
@@ -82,7 +82,7 @@ def pull_here_path():
         os.environ['HOST'] = conn.host
         os.environ['USER'] = conn.login
         os.environ['PGPASSWORD'] = conn.password
-        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $USER -d bigdata -c "\COPY here.ta_path_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
+        return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $USER -d bigdata -c "\\COPY here.ta_path_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
 
     load_data()
 

--- a/dags/pull_here_path.py
+++ b/dags/pull_here_path.py
@@ -76,14 +76,15 @@ def pull_here_path():
     request_id =  get_request_id(access_token)
     download_url = get_download_link(request_id, access_token)
     
-    @task.bash(env={"DOWNLOAD_URL": download_url})
-    def load_data()->str:
+    @task.bash(append_env = True)
+    def load_data(download_url)->str:
         conn = BaseHook.get_connection("here_bot")
         os.environ['HOST'] = conn.host
         os.environ['LOGIN'] = conn.login
         os.environ['PGPASSWORD'] = conn.password
+        os.environ['DOWNLOAD_URL'] = download_url
         return '''curl $DOWNLOAD_URL | gunzip | psql -h $HOST -U $LOGIN -d bigdata -c "\\COPY here.ta_path_view FROM STDIN WITH (FORMAT csv, HEADER TRUE);" '''
 
-    load_data()
+    load_data(download_url)
 
 pull_here_path()

--- a/dags/pull_interventions_dag.py
+++ b/dags/pull_interventions_dag.py
@@ -8,7 +8,7 @@ import os
 import pendulum
 from airflow import DAG
 from datetime import timedelta
-from airflow.operators.bash_operator import BashOperator
+from airflow.operators.bash import BashOperator
 from airflow.models import Variable 
 
 repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))

--- a/dags/pull_weather.py
+++ b/dags/pull_weather.py
@@ -8,7 +8,7 @@ import sys
 import pendulum
 from airflow import DAG
 from datetime import timedelta
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.models import Variable
 from airflow.operators.latest_only_operator import LatestOnlyOperator

--- a/dags/pull_weather.py
+++ b/dags/pull_weather.py
@@ -11,7 +11,7 @@ from datetime import timedelta
 from airflow.operators.python import PythonOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.models import Variable
-from airflow.operators.latest_only_operator import LatestOnlyOperator
+from airflow.operators.latest_only import LatestOnlyOperator
 
 # DAG Information
 dag_name = 'pull_weather'

--- a/dags/readme.md
+++ b/dags/readme.md
@@ -62,7 +62,7 @@ You may notice that many older DAGs have not been renamed to this standard: it i
 - Deprecated: [**pull_interventions_dag.py**](pull_interventions_dag.py).
 
 ### [**sql**](./sql/)
-This folder contains generic sql scripts which are used by various volumes data checks via Airflow PostgresOperator + jinja templating. 
+This folder contains generic sql scripts which are used by various volumes data checks via Airflow SQLExecuteQueryOperator + jinja templating. 
 
 ### [**custom_operators.py**](custom_operators.py)  
 Contains custom Airflow Operators.  

--- a/dags/refresh_wys_monthly.py
+++ b/dags/refresh_wys_monthly.py
@@ -52,7 +52,7 @@ with DAG(dag_id = dag_name,
                             #sql in bdit_data-sources/wys/api/sql/mat-view-stationary-signs.sql
                             sql='SELECT wys.refresh_mat_view_stationary_signs()',
                             task_id='wys_view_stat_signs',
-                            postgres_conn_id='wys_bot',
+                            conn_id='wys_bot',
                             autocommit=True,
                             retries = 0)
     wys_view_mobile_api_id = SQLExecuteQueryOperator(
@@ -60,28 +60,28 @@ with DAG(dag_id = dag_name,
                             #sql in bdit_data-sources/wys/api/sql/create-view-mobile_api_id.sql
                             sql='SELECT wys.refresh_mat_view_mobile_api_id()', 
                             task_id='wys_view_mobile_api_id',
-                            postgres_conn_id='wys_bot',
+                            conn_id='wys_bot',
                             autocommit=True,
                             retries = 0)
     od_wys_view = SQLExecuteQueryOperator(
                             #sql in bdit_data-sources/wys/api/sql/open_data/mat-view-stationary-locations.sql
                             sql='SELECT wys.refresh_od_mat_view()',
                             task_id='od_wys_view',
-                            postgres_conn_id='wys_bot',
+                            conn_id='wys_bot',
                             autocommit=True,
                             retries = 0)
     wys_mobile_summary = SQLExecuteQueryOperator(
                             #sql in bdit_data-sources/wys/api/sql/function-mobile-summary.sql
                             sql="SELECT wys.mobile_summary_for_month('{{ last_month(ds) }}')",
                             task_id='wys_mobile_summary',
-                            postgres_conn_id='wys_bot',
+                            conn_id='wys_bot',
                             autocommit=True,
                             retries = 0)
     wys_stat_summary = SQLExecuteQueryOperator(
                             #sql in bdit_data-sources/wys/api/sql/function-stationary-sign-summary.sql
                             sql="SELECT wys.stationary_summary_for_month('{{ last_month(ds) }}')", 
                             task_id='wys_stat_summary',
-                            postgres_conn_id='wys_bot',
+                            conn_id='wys_bot',
                             autocommit=True,
                             retries = 0)
 

--- a/dags/refresh_wys_monthly.py
+++ b/dags/refresh_wys_monthly.py
@@ -8,7 +8,7 @@ import pendulum
 
 from airflow import DAG
 from datetime import datetime, timedelta
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.models import Variable 
 from dateutil.relativedelta import relativedelta
 
@@ -48,14 +48,14 @@ with DAG(dag_id = dag_name,
             'last_month' : last_month
           },
          schedule='0 3 2 * *') as monthly_summary:
-    wys_view_stat_signs = PostgresOperator(
+    wys_view_stat_signs = SQLExecuteQueryOperator(
                             #sql in bdit_data-sources/wys/api/sql/mat-view-stationary-signs.sql
                             sql='SELECT wys.refresh_mat_view_stationary_signs()',
                             task_id='wys_view_stat_signs',
                             postgres_conn_id='wys_bot',
                             autocommit=True,
                             retries = 0)
-    wys_view_mobile_api_id = PostgresOperator(
+    wys_view_mobile_api_id = SQLExecuteQueryOperator(
                             #sql in bdit_data-sources/wys/api/sql/function-refresh_mat_view_mobile_api_id.sql
                             #sql in bdit_data-sources/wys/api/sql/create-view-mobile_api_id.sql
                             sql='SELECT wys.refresh_mat_view_mobile_api_id()', 
@@ -63,21 +63,21 @@ with DAG(dag_id = dag_name,
                             postgres_conn_id='wys_bot',
                             autocommit=True,
                             retries = 0)
-    od_wys_view = PostgresOperator(
+    od_wys_view = SQLExecuteQueryOperator(
                             #sql in bdit_data-sources/wys/api/sql/open_data/mat-view-stationary-locations.sql
                             sql='SELECT wys.refresh_od_mat_view()',
                             task_id='od_wys_view',
                             postgres_conn_id='wys_bot',
                             autocommit=True,
                             retries = 0)
-    wys_mobile_summary = PostgresOperator(
+    wys_mobile_summary = SQLExecuteQueryOperator(
                             #sql in bdit_data-sources/wys/api/sql/function-mobile-summary.sql
                             sql="SELECT wys.mobile_summary_for_month('{{ last_month(ds) }}')",
                             task_id='wys_mobile_summary',
                             postgres_conn_id='wys_bot',
                             autocommit=True,
                             retries = 0)
-    wys_stat_summary = PostgresOperator(
+    wys_stat_summary = SQLExecuteQueryOperator(
                             #sql in bdit_data-sources/wys/api/sql/function-stationary-sign-summary.sql
                             sql="SELECT wys.stationary_summary_for_month('{{ last_month(ds) }}')", 
                             task_id='wys_stat_summary',

--- a/dags/replicator_table_check.py
+++ b/dags/replicator_table_check.py
@@ -16,7 +16,7 @@ from airflow.decorators import dag, task
 from airflow.models import Variable
 from airflow.exceptions import AirflowFailException
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.operators.latest_only_operator import LatestOnlyOperator
+from airflow.operators.latest_only import LatestOnlyOperator
 
 # import custom operators and helper functions
 repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))

--- a/dags/tti_aggregate.py
+++ b/dags/tti_aggregate.py
@@ -53,14 +53,14 @@ default_args = {'owner': ','.join(DAG_OWNERS),
 def tti_aggregate():
     aggregate_citywide_tti = SQLExecuteQueryOperator(sql="SELECT covid.generate_citywide_tti( '{{macros.ds_add(ds, -1)}}' )",
                                        task_id='aggregate_citywide_tti',
-                                       postgres_conn_id='congestion_bot',
+                                       conn_id='congestion_bot',
                                        autocommit=True,
                                        retries = 0
                                        )
     
     aggregate_downtown_tti = SQLExecuteQueryOperator(sql="SELECT covid.generate_downtown_tti( '{{macros.ds_add(ds, -1)}}' )",
                                        task_id='aggregate_downtown_tti',
-                                       postgres_conn_id='congestion_bot',
+                                       conn_id='congestion_bot',
                                        autocommit=True,
                                        retries = 0
                                        )

--- a/dags/tti_aggregate.py
+++ b/dags/tti_aggregate.py
@@ -2,7 +2,7 @@ import sys
 import os
 
 from datetime import datetime, timedelta
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.models import Variable
 from airflow.decorators import dag, task
 from airflow.macros import ds_add, ds_format
@@ -51,14 +51,14 @@ default_args = {'owner': ','.join(DAG_OWNERS),
 
 
 def tti_aggregate():
-    aggregate_citywide_tti = PostgresOperator(sql="SELECT covid.generate_citywide_tti( '{{macros.ds_add(ds, -1)}}' )",
+    aggregate_citywide_tti = SQLExecuteQueryOperator(sql="SELECT covid.generate_citywide_tti( '{{macros.ds_add(ds, -1)}}' )",
                                        task_id='aggregate_citywide_tti',
                                        postgres_conn_id='congestion_bot',
                                        autocommit=True,
                                        retries = 0
                                        )
     
-    aggregate_downtown_tti = PostgresOperator(sql="SELECT covid.generate_downtown_tti( '{{macros.ds_add(ds, -1)}}' )",
+    aggregate_downtown_tti = SQLExecuteQueryOperator(sql="SELECT covid.generate_downtown_tti( '{{macros.ds_add(ds, -1)}}' )",
                                        task_id='aggregate_downtown_tti',
                                        postgres_conn_id='congestion_bot',
                                        autocommit=True,

--- a/dags/tti_aggregate.py
+++ b/dags/tti_aggregate.py
@@ -43,7 +43,7 @@ default_args = {'owner': ','.join(DAG_OWNERS),
 @dag(
     DAG_NAME, 
     default_args=default_args, 
-    schedule_interval=None, # gets triggered by HERE dag
+    schedule=None, # gets triggered by HERE dag
     doc_md = doc_md,
     tags=["HERE"],
     catchup=False

--- a/dags/vds_pull_vdsdata.py
+++ b/dags/vds_pull_vdsdata.py
@@ -103,7 +103,7 @@ def vdsdata_dag():
                 #partition by year only: 
                 "SELECT vds.partition_vds_yyyy('counts_15min_div2'::text, '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int)",
                 "SELECT vds.partition_vds_yyyy('counts_15min_bylane_div2'::text, '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int)"],
-            postgres_conn_id='vds_bot',
+            conn_id='vds_bot',
             autocommit=True
         )
 
@@ -122,7 +122,7 @@ def vdsdata_dag():
                     dt >= '{{ds}} 00:00:00'::timestamp
                     AND dt < '{{ds}} 00:00:00'::timestamp + INTERVAL '1 DAY'""",
             task_id='delete_vdsdata',
-            postgres_conn_id='vds_bot',
+            conn_id='vds_bot',
             autocommit=True,
             retries=1,
             trigger_rule='none_failed'
@@ -148,7 +148,7 @@ def vdsdata_dag():
         summarize_v15_task = SQLExecuteQueryOperator(
             sql=["delete/delete-counts_15min.sql", "insert/insert_counts_15min.sql"],
             task_id='summarize_v15',
-            postgres_conn_id='vds_bot',
+            conn_id='vds_bot',
             autocommit=True,
             retries=1
         )
@@ -157,7 +157,7 @@ def vdsdata_dag():
         summarize_v15_bylane_task = SQLExecuteQueryOperator(
             sql=["delete/delete-counts_15min_bylane.sql", "insert/insert_counts_15min_bylane.sql"],
             task_id='summarize_v15_bylane',
-            postgres_conn_id='vds_bot',
+            conn_id='vds_bot',
             autocommit=True,
             retries=1
         )

--- a/dags/vds_pull_vdsvehicledata.py
+++ b/dags/vds_pull_vdsvehicledata.py
@@ -67,7 +67,7 @@ def vdsvehicledata_dag():
             task_id='create_partitions',
             pre_execute=check_jan_1st,
             sql="SELECT vds.partition_vds_yyyymm('raw_vdsvehicledata', '{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, 'dt')",
-            postgres_conn_id='vds_bot',
+            conn_id='vds_bot',
             autocommit=True
         )
         
@@ -85,7 +85,7 @@ def vdsvehicledata_dag():
                     dt >= '{{ds}} 00:00:00'::timestamp
                     AND dt < '{{ds}} 00:00:00'::timestamp + INTERVAL '1 DAY'""",
             task_id='delete_vdsvehicledata',
-            postgres_conn_id='vds_bot',
+            conn_id='vds_bot',
             autocommit=True,
             retries=1,
             trigger_rule='none_failed'
@@ -110,7 +110,7 @@ def vdsvehicledata_dag():
         summarize_speeds_task = SQLExecuteQueryOperator(
             sql=["delete/delete-veh_speeds_15min.sql", "insert/insert_veh_speeds_15min.sql"],
             task_id='summarize_speeds',
-            postgres_conn_id='vds_bot',
+            conn_id='vds_bot',
             autocommit=True,
             retries=1
         )
@@ -119,7 +119,7 @@ def vdsvehicledata_dag():
         summarize_lengths_task = SQLExecuteQueryOperator(
             sql=["delete/delete-veh_length_15min.sql", "insert/insert_veh_lengths_15min.sql"],
             task_id='summarize_lengths',
-            postgres_conn_id='vds_bot',
+            conn_id='vds_bot',
             autocommit=True,
             retries=1
         )

--- a/dags/weather_pull.py
+++ b/dags/weather_pull.py
@@ -13,7 +13,7 @@ from datetime import timedelta, time
 from airflow.decorators import dag, task
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.models import Variable
-from airflow.operators.latest_only_operator import LatestOnlyOperator
+from airflow.operators.latest_only import LatestOnlyOperator
 from airflow.sensors.time_sensor import TimeSensor
 
 # DAG Information

--- a/dags/wys_pull.py
+++ b/dags/wys_pull.py
@@ -10,7 +10,7 @@ import dateutil.parser
 from datetime import timedelta
 
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
 from airflow.models import Variable
 from airflow.decorators import task, dag, task_group
 from airflow.sensors.external_task import ExternalTaskMarker
@@ -67,7 +67,7 @@ def pull_wys_dag():
     @task_group
     def check_partitions():
 
-        create_annual_partition = PostgresOperator(
+        create_annual_partition = SQLExecuteQueryOperator(
             task_id='create_annual_partitions',
             pre_execute=check_jan_1st,
             sql="SELECT wys.create_yyyy_raw_data_partition('{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int)",
@@ -75,7 +75,7 @@ def pull_wys_dag():
             autocommit=True
         )
         
-        create_month_partition = PostgresOperator(
+        create_month_partition = SQLExecuteQueryOperator(
             task_id='create_month_partition',
             pre_execute=check_1st_of_month,
             trigger_rule='none_failed_min_one_success',

--- a/dags/wys_pull.py
+++ b/dags/wys_pull.py
@@ -71,7 +71,7 @@ def pull_wys_dag():
             task_id='create_annual_partitions',
             pre_execute=check_jan_1st,
             sql="SELECT wys.create_yyyy_raw_data_partition('{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int)",
-            postgres_conn_id='wys_bot',
+            conn_id='wys_bot',
             autocommit=True
         )
         
@@ -80,7 +80,7 @@ def pull_wys_dag():
             pre_execute=check_1st_of_month,
             trigger_rule='none_failed_min_one_success',
             sql="SELECT wys.create_mm_nested_raw_data_partitions('{{ macros.ds_format(ds, '%Y-%m-%d', '%Y') }}'::int, '{{ macros.ds_format(ds, '%Y-%m-%d', '%m') }}'::int)",
-            postgres_conn_id='wys_bot',
+            conn_id='wys_bot',
             autocommit=True
         )
 

--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -12,7 +12,7 @@ import traceback
 from time import sleep
 from collections import namedtuple
 
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 class BreakingError(Exception):

--- a/volumes/miovision/api/pull_alert.py
+++ b/volumes/miovision/api/pull_alert.py
@@ -11,7 +11,7 @@ import click
 from psycopg2 import sql
 from psycopg2.extras import execute_values
 
-from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.base import BaseHook
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 def logger():

--- a/weather/prediction_import.py
+++ b/weather/prediction_import.py
@@ -8,7 +8,6 @@
 
 #Environment Canada imports
 import asyncio
-from types import coroutine
 import env_canada
 
 #other packages


### PR DESCRIPTION
## What this pull request accomplishes:

- Removes top level database connections in 3 dags
- schedule_interval -> schedule deprecation warning
- fixes for many other Airflow deprecation warnings
- ~adjust pytest to include warnings~
  - I tried upgrading env_canada to latest version to remove a deprecation warning, and then it downgraded google provider to 8.3 (2022). I wasn't comfortable with this so I backtracked on failing on warnings, but the only one remaining is about an env_canada which is about 50 less than before!  

## Issue(s) this solves:

- Closes #1112, #1115

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged
- I checked out this branch in `/data/airflow/data_scripts` to test the many DAG changes, we should revert to master