### PR TITLE
1123 bug: gcc puller return json keyerror fields

### DIFF
--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -313,6 +313,8 @@ def get_data(mapserver, layer_id, max_number = None, record_max = None):
     # Exception if the data we want to get is centreline
     if mapserver == 'cot_geospatial' and layer_id == 2:
         where = "\"FEATURE_CODE_DESC\" IN ('Collector','Collector Ramp','Expressway','Expressway Ramp','Local','Major Arterial','Major Arterial Ramp','Minor Arterial','Minor Arterial Ramp','Pending', 'Other')"
+    elif mapserver == 'cot_geospatial27' and layer_id == 41:
+        where = "OBJECTID>0"
     else:
         where = "1=1"
         

--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -345,8 +345,16 @@ def get_data(mapserver, layer_id, max_number = None, record_max = None):
         except requests.exceptions.RequestException as err:
             LOGGER.error("Error: %s", err)
         else:
+            if r.status_code != 200:
+                LOGGER.error("Query was not successful. Response: %s", r)
             return_json = r.json()
             break
+    
+    keys = ['fields', 'features', 'geometryType']
+    for k in keys:
+        if not(k in return_json.keys()):
+            LOGGER.error("return_json: %s", return_json)
+            raise KeyError(f"Return json missing field: {k}")
     
     return return_json
 

--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -310,7 +310,7 @@ def get_data(mapserver, layer_id, max_number = None, record_max = None):
     """
     return_json = None
     base_url = f"https://insideto-gis.toronto.ca/arcgis/rest/services/{mapserver}/MapServer/{layer_id}/query"
-    # If the data we want to get is centreline
+    # Exception if the data we want to get is centreline
     if mapserver == 'cot_geospatial' and layer_id == 2:
         where = "\"FEATURE_CODE_DESC\" IN ('Collector','Collector Ramp','Expressway','Expressway Ramp','Local','Major Arterial','Major Arterial Ramp','Minor Arterial','Minor Arterial Ramp','Pending', 'Other')"
     else:
@@ -350,6 +350,7 @@ def get_data(mapserver, layer_id, max_number = None, record_max = None):
             return_json = r.json()
             break
     
+    #check neccessary fields are contained in the return json.
     keys = ['fields', 'features', 'geometryType']
     for k in keys:
         if not(k in return_json.keys()):

--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -309,54 +309,41 @@ def get_data(mapserver, layer_id, max_number = None, record_max = None):
         Resulted json response from calling the GCCView rest api
     """
     return_json = None
-    base_url = "https://insideto-gis.toronto.ca/arcgis/rest/services/{}/MapServer/{}/query".format(mapserver, layer_id)
-    
+    base_url = f"https://insideto-gis.toronto.ca/arcgis/rest/services/{mapserver}/MapServer/{layer_id}/query"
     # If the data we want to get is centreline
     if mapserver == 'cot_geospatial' and layer_id == 2:
-        query = {"where": "\"FEATURE_CODE_DESC\" IN ('Collector','Collector Ramp','Expressway','Expressway Ramp','Local','Major Arterial','Major Arterial Ramp','Minor Arterial','Minor Arterial Ramp','Pending', 'Other')",
-             "outFields": "*",
-             "outSR": '4326',
-             "returnGeometry": "true",
-             "returnTrueCurves": "false",
-             "returnIdsOnly": "false",
-             "returnCountOnly": "false",
-             "returnZ": "false",
-             "returnM": "false",
-             "orderByFields": "OBJECTID", 
-             "returnDistinctValues": "false",
-             "returnExtentsOnly": "false",
-             "resultOffset": "{}".format(max_number),
-             "resultRecordCount": "{}".format(record_max),
-             "f":"json"}
+        where = "\"FEATURE_CODE_DESC\" IN ('Collector','Collector Ramp','Expressway','Expressway Ramp','Local','Major Arterial','Major Arterial Ramp','Minor Arterial','Minor Arterial Ramp','Pending', 'Other')"
     else:
-        query = {"where":"1=1",
-             "outFields": "*",
-             "outSR": '4326',
-             "returnGeometry": "true",
-             "returnTrueCurves": "false",
-             "returnIdsOnly": "false",
-             "returnCountOnly": "false",
-             "returnZ": "false",
-             "returnM": "false",
-             "orderByFields": "OBJECTID", 
-             "returnDistinctValues": "false",
-             "returnExtentsOnly": "false",
-             "resultOffset": "{}".format(max_number),
-             "resultRecordCount": "{}".format(record_max),
-             "f":"json"}
+        where = "1=1"
+        
+    query = {"where": where,
+            "outFields": "*",
+            "outSR": '4326',
+            "returnGeometry": "true",
+            "returnTrueCurves": "false",
+            "returnIdsOnly": "false",
+            "returnCountOnly": "false",
+            "returnZ": "false",
+            "returnM": "false",
+            "orderByFields": "OBJECTID", 
+            "returnDistinctValues": "false",
+            "returnExtentsOnly": "false",
+            "resultOffset": f"{max_number}",
+            "resultRecordCount": f"{record_max}",
+            "f":"json"}
     
-    for retry in range(3):
+    for _ in range(3):
         try:
             r = requests.get(base_url, params = query, verify = False, timeout = 300)
             r.raise_for_status()
         except requests.exceptions.HTTPError as err_h:
-            LOGGER.error("Invalid HTTP response: ", err_h)
+            LOGGER.error("Invalid HTTP response: %s", err_h)
         except requests.exceptions.ConnectionError as err_c:
-            LOGGER.error("Network problem: ", err_c)
+            LOGGER.error("Network problem: %s", err_c)
         except requests.exceptions.Timeout as err_t:
-            LOGGER.error("Timeout: ", err_t)
+            LOGGER.error("Timeout: %s", err_t)
         except requests.exceptions.RequestException as err:
-            LOGGER.error("Error: ", err)
+            LOGGER.error("Error: %s", err)
         else:
             return_json = r.json()
             break


### PR DESCRIPTION
## What this pull request accomplishes:

- additional error catching for non-200 status code or incorrect return_json fields
- reduce duplication of `query` (only where clause differs)

updated: 
- fixed bug which resulted in 1 too few iterations (max_number incorrectly incremented before 2nd pull)
  - reduced some nesting in `get_layer`, `find_limit` functions.
  - reran all the affected layers (centreline, centreline_intersection_point, intersection, traffic_bylaw_line/point) from most recent Airflow run and deleted the 20250101 partition where applicable. 

- Added `OBJECTID>0` special case for address point layer which fixed duplicate-key error. 

## Issue(s) this solves:

- Closes #1123, #1124

## What, in particular, needs to reviewed:

- Nothing: reran those two failed Sirius layers and they worked (I think the error was transitory, but this will help catch it next time). 

## What needs to be done by a sysadmin after this PR is merged
- pull data_scripts on Morbius
