### PR TITLE
Define order of returned routed centreline links

### DIFF
--- a/gis/centreline/sql/create_function_get_centreline_btwn_intersections.sql
+++ b/gis/centreline/sql/create_function_get_centreline_btwn_intersections.sql
@@ -30,8 +30,8 @@ WITH results AS (
 SELECT
     get_centreline_btwn_intersections._node_start,
     get_centreline_btwn_intersections._node_end,
-    array_agg(routing_centreline_directional.centreline_id),
-    st_union(st_linemerge(routing_centreline_directional.geom)) AS geom 
+    array_agg(routing_centreline_directional.centreline_id ORDER BY path_seq),
+    st_union(st_linemerge(routing_centreline_directional.geom ORDER BY path_seq)) AS geom 
 FROM results
 INNER JOIN gis_core.routing_centreline_directional ON edge = id
 

--- a/gis/centreline/sql/create_function_get_centreline_btwn_intersections.sql
+++ b/gis/centreline/sql/create_function_get_centreline_btwn_intersections.sql
@@ -31,7 +31,7 @@ SELECT
     get_centreline_btwn_intersections._node_start,
     get_centreline_btwn_intersections._node_end,
     array_agg(routing_centreline_directional.centreline_id ORDER BY path_seq),
-    st_union(st_linemerge(routing_centreline_directional.geom ORDER BY path_seq)) AS geom 
+    st_union(st_linemerge(routing_centreline_directional.geom) ORDER BY path_seq) AS geom 
 FROM results
 INNER JOIN gis_core.routing_centreline_directional ON edge = id
 


### PR DESCRIPTION
## What this pull request accomplishes:

- Defines an order for the results returned by the centreline routing function. 
- Orders aggregated results by sequence in the routed path

## Issue(s) this solves:
- Closes #1126

## What, in particular, needs to reviewed:
- That this works and nothing breaks. I'm not used to working on SQL within functions.

Since the order was previously undefined, it shouldn't break anything to specify it now.

## What needs to be done by a sysadmin after this PR is merged

- replace function with the new definition
