### PR TITLE
#1143 depends_on_past=True, remove unused imports

### DIFF
--- a/dags/miovision_pull.py
+++ b/dags/miovision_pull.py
@@ -8,8 +8,6 @@ import sys
 import os
 import pendulum
 from datetime import timedelta
-import configparser
-import dateutil.parser
 
 from airflow.decorators import dag, task, task_group
 from airflow.models.param import Param
@@ -150,7 +148,7 @@ def pull_miovision_dag():
                     intersections = get_intersection_info(conn, intersection=INTERSECTIONS)
                     aggregate_15_min_mvt(conn, time_period=time_period, intersections=intersections)
 
-        @task
+        @task(depends_on_past=True)
         def zero_volume_anomalous_ranges_task(ds = None, **context):
             mio_postgres = PostgresHook("miovision_api_bot")  
             time_period = (ds, ds_add(ds, 1))          


### PR DESCRIPTION
## What this pull request accomplishes:

- adds depends_on_past=True to anomalous_range task to prevent edge case where failed tasks are rerun in the wrong order, causing discontinuous ARs
- Tested successfully: 
![image](https://github.com/user-attachments/assets/faf48c1e-1846-4f0d-b713-2bbdee20e003)

## Issue(s) this solves:

- Closes #1143

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
