### PR TITLE
#1147 create tmc_school_timebins, tmc_routine_timebins functions

### DIFF
--- a/volumes/short_term_counting_program/sql/function-tmc_routine_timebins.sql
+++ b/volumes/short_term_counting_program/sql/function-tmc_routine_timebins.sql
@@ -1,0 +1,31 @@
+CREATE OR REPLACE FUNCTION traffic.tmc_routine_timebins(
+    dt date
+)
+RETURNS timestamp without time zone []
+LANGUAGE 'sql'
+COST 100
+VOLATILE PARALLEL UNSAFE
+AS $BODY$
+SELECT ARRAY_AGG(dt_bins)
+FROM (VALUES
+    ('7:30'::time, '9:30'::time),
+    ('10:00', '12:00'),
+    ('13:00', '15:00'),
+    ('16:00', '18:00')
+) AS time_ranges(start_tod, end_tod),
+generate_series(
+    tmc_routine_timebins.dt + time_ranges.start_tod,
+    tmc_routine_timebins.dt + time_ranges.end_tod - '15 minutes'::interval,
+    '15 minutes'::interval
+) AS dt_bins
+$BODY$;
+
+ALTER FUNCTION traffic.tmc_routine_timebins(date)
+OWNER TO traffic_admins;
+
+GRANT EXECUTE ON FUNCTION traffic.tmc_routine_timebins(date)
+TO bdit_humans;
+
+COMMENT ON FUNCTION traffic.tmc_routine_timebins(date) IS
+'Returns the 15minute bins associated with an 8R count on the input date. '
+'Useful for comparing 14Hr counts with 8R counts.';

--- a/volumes/short_term_counting_program/sql/function-tmc_school_timebins.sql
+++ b/volumes/short_term_counting_program/sql/function-tmc_school_timebins.sql
@@ -1,0 +1,36 @@
+-- FUNCTION: gwolofs.tmc_routine_timebins(date)
+
+-- DROP FUNCTION IF EXISTS gwolofs.tmc_routine_timebins(date);
+
+CREATE OR REPLACE FUNCTION traffic.tmc_school_timebins(
+    dt date
+)
+RETURNS timestamp without time zone []
+LANGUAGE 'sql'
+COST 100
+VOLATILE PARALLEL UNSAFE
+AS $BODY$
+SELECT ARRAY_AGG(dt_bins)
+FROM (VALUES
+    ('7:30'::time, '9:30'::time),
+    ('10:00', '11:00'),
+    ('12:00', '13:30'),
+    ('14:15', '15:45'),
+    ('16:00', '18:00')
+) AS time_ranges(start_tod, end_tod),
+generate_series(
+    tmc_school_timebins.dt + time_ranges.start_tod,
+    tmc_school_timebins.dt + time_ranges.end_tod - '15 minutes'::interval,
+    '15 minutes'::interval
+) AS dt_bins
+$BODY$;
+
+ALTER FUNCTION traffic.tmc_school_timebins(date)
+OWNER TO traffic_admins;
+
+GRANT EXECUTE ON FUNCTION traffic.tmc_school_timebins(date)
+TO bdit_humans;
+
+COMMENT ON FUNCTION traffic.tmc_school_timebins(date) IS
+'Returns the 15minute bins associated with an 8S count on the input date. '
+'Useful for comparing 14Hr counts with 8S counts.';


### PR DESCRIPTION
## What this pull request accomplishes:

- 
```sql
--check both functions return 32 time bins:
SELECT array_length(traffic.tmc_school_timebins('2025-01-01'), 1) --32
SELECT array_length(traffic.tmc_routine_timebins('2025-01-01'), 1) --32
```

## Issue(s) this solves:

- #1147

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
