### PR TITLE
#1183 fix brackets regex in function-abbr_street.sql

### DIFF
--- a/gis/text_to_centreline/sql/helper_functions/function-abbr_street.sql
+++ b/gis/text_to_centreline/sql/helper_functions/function-abbr_street.sql
@@ -40,7 +40,8 @@ _abbrev_street := regexp_REPLACE(_abbrev_street, '(?<=[A-Z][a-z]+ )(Circuit)(?![
 _abbrev_street := regexp_REPLACE(_abbrev_street, '(?<=[A-Z][a-z]+ )(Park)(?![a-z])(?! [A-Z])', 'Pk', 'g');
 _abbrev_street := regexp_REPLACE(_abbrev_street, 'Gate', 'Gt', 'g');
 _abbrev_street := regexp_REPLACE(_abbrev_street, 'Pathway', 'Pthwy', 'g');
-_abbrev_street := regexp_REPLACE(_abbrev_street, '\(.*\)', '', 'g');
+--removes anything between brackets
+_abbrev_street := regexp_REPLACE(_abbrev_street, '\(([^\(]+)\)', '', 'g');
 _abbrev_street := regexp_REPLACE(_abbrev_street, 'approximately', '', 'gi');
 _abbrev_street := regexp_REPLACE(_abbrev_street, ' Grove', ' Grv', 'g');
 _abbrev_street := regexp_REPLACE(_abbrev_street, ' Grv Rd', ' Grove Rd', 'g');


### PR DESCRIPTION
## What this pull request accomplishes:

Tested: 
```sql
SELECT
val.input,
regexp_REPLACE(val.input, '\(.*\)', '', 'g') AS incorrect,
regexp_REPLACE(val.input, '\(([^\(]+)\)', '', 'g') AS correct
FROM (values('Between Scotswood Road (East Intersection) And Scotswood Road (West Intersection)')) AS val(input)
```

## Issue(s) this solves:

- #1183

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
