### PR TITLE
1138 add note about address point negative objectids

### DIFF
--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -660,7 +660,6 @@ def manual_get_layer(mapserver, layer_id, schema_name, is_audited, include_addit
         primary_key = primary_key,
         con=connection_obj,
         is_partitioned = is_partitioned
-        include_additional_layers = include_additional_layers
     )
 
 if __name__ == '__main__':

--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -662,6 +662,7 @@ def manual_get_layer(mapserver, layer_id, schema_name, is_audited, include_addit
         primary_key = primary_key,
         con=connection_obj,
         is_partitioned = is_partitioned
+        include_additional_layers = include_additional_layers
     )
 
 if __name__ == '__main__':

--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -313,16 +313,14 @@ def get_data(mapserver, layer_id, include_additional_feature, max_number = None,
     """
     return_json = None
     base_url = f"https://insideto-gis.toronto.ca/arcgis/rest/services/{mapserver}/MapServer/{layer_id}/query"
+    # Exclude negative objectids from ALL layers based on recommendation from GCC (#1138)
+    where = "OBJECTID>0"
     # Exception if the data we want to get is centreline
     if mapserver == 'cot_geospatial' and layer_id == 2:
-        where = "\"FEATURE_CODE_DESC\" IN ('Collector','Collector Ramp','Expressway','Expressway Ramp','Local','Major Arterial','Major Arterial Ramp','Minor Arterial','Minor Arterial Ramp','Pending', 'Other')"
+        feature_list = ['Collector','Collector Ramp','Expressway','Expressway Ramp','Local','Major Arterial','Major Arterial Ramp','Minor Arterial','Minor Arterial Ramp','Pending', 'Other']
         if include_additional_feature: # Then add the additional 5 roadclasses
-            where += " OR \"FEATURE_CODE_DESC\" IN ('Trail', 'Busway', 'Laneway', 'Other Ramp', 'Access Road')"
-    elif mapserver == 'cot_geospatial27' and layer_id == 41:
-        # Exclude negative objectids from address point layer based on recommendation from GCC (internal use only)
-        where = "OBJECTID>0"
-    else:
-        where = "1=1"
+            feature_list += ['Trail', 'Busway', 'Laneway', 'Other Ramp', 'Access Road']
+        where += " AND FEATURE_CODE_DESC IN ('{}')".format("','".join(feature_list))
         
     query = {"where": where,
             "outFields": "*",

--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -319,6 +319,7 @@ def get_data(mapserver, layer_id, include_additional_feature, max_number = None,
         if include_additional_feature: # Then add the additional 5 roadclasses
             where += " OR \"FEATURE_CODE_DESC\" IN ('Trail', 'Busway', 'Laneway', 'Other Ramp', 'Access Road')"
     elif mapserver == 'cot_geospatial27' and layer_id == 41:
+        # Exclude negative objectids from address point layer based on recommendation from GCC (internal use only)
         where = "OBJECTID>0"
     else:
         where = "1=1"


### PR DESCRIPTION
## What this pull request accomplishes:

- Exclude objectid<=0 from all queries, by recommendation of GCC.
- Note: Of the layers we pull, currently only address_point seems to have negative objectids

## Issue(s) this solves:

- Closes #1138 

## What, in particular, needs to reviewed:

- Tested successfully by pulling centreline ✅ 
- Is it the right approach to exclude negative objectid from all layers? I think so.
  - Someone from GCC said to
  - None of the layers we currently pull have negatives in our database, so effectively no change

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
