### PR TITLE
#1172 adjust volumes_15min_mvt_filtered for null ar.intersection_uid case

### DIFF
--- a/volumes/miovision/sql/views/create-view-volumes_15min_mvt_filtered.sql
+++ b/volumes/miovision/sql/views/create-view-volumes_15min_mvt_filtered.sql
@@ -12,8 +12,10 @@ CREATE OR REPLACE VIEW miovision_api.volumes_15min_mvt_filtered AS (
     --anti join anomalous_ranges
     LEFT JOIN miovision_api.anomalous_ranges AS ar
         ON (ar.problem_level = ANY(ARRAY['do-not-use'::text, 'questionable'::text]))
-        AND ar.intersection_uid = v15.intersection_uid
         AND (
+            ar.intersection_uid = v15.intersection_uid
+            OR ar.intersection_uid IS NULL
+        ) AND (
             ar.classification_uid = v15.classification_uid
             OR ar.classification_uid IS NULL
         ) AND (


### PR DESCRIPTION
## What this pull request accomplishes:
- Adjusts `volumes_15min_mvt_filtered` for null intersection_uid case in anomalous_ranges. Right now we only use this to caution against using data from before 2019 for certain modes. 

## Issue(s) this solves:

- Closes #1172

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
