### PR TITLE
#1158 allow null geometries in gcc puller

### DIFF
--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -264,7 +264,10 @@ def get_geometry(geometry_type, geom):
         'esriGeometryPolygon': polygon
     }
     func = switcher.get(geometry_type)
-    geometry = (func(geom)) 
+    try:
+        geometry = (func(geom))
+    except IndexError:
+        geometry = None
     return geometry
 
 def to_time(input):


### PR DESCRIPTION
## What this pull request accomplishes:

- allow null geometries in gcc puller

## Issue(s) this solves:

- #1158 

## What, in particular, needs to reviewed:

- I couldn't figure out an arcserver WHERE clause to filter out null geometries, but adding a try..except worked. 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
