### PR TITLE
Add from/to "intersection" node IDs to SVC directions view

### DIFF
--- a/volumes/short_term_counting_program/sql/create-view-svc_centreline_directions.sql
+++ b/volumes/short_term_counting_program/sql/create-view-svc_centreline_directions.sql
@@ -28,13 +28,21 @@ WITH to_cardinal (bearing, direction) AS (
 
 SELECT
     cl.centreline_id,
+    CASE
+        WHEN sq.angular_distance > radians(90) THEN to_intersection_id -- reversed
+        ELSE cl.from_intersection_id
+    END AS from_node,
+    CASE
+        WHEN sq.angular_distance > radians(90) THEN from_intersection_id -- reversed
+        ELSE cl.to_intersection_id
+    END AS to_node,
     sq.direction,
     CASE
-        WHEN sq.angular_distance > radians(90) THEN ST_Reverse(cl.geom)
+        WHEN sq.angular_distance > radians(90) THEN ST_Reverse(cl.geom) -- reversed
         ELSE cl.geom
     END AS centreline_geom_directed,
     CASE
-        WHEN degrees(sq.angular_distance) > 90 THEN (180 - degrees(sq.angular_distance))::real
+        WHEN sq.angular_distance > radians(90) THEN (180 - degrees(sq.angular_distance))::real -- reversed
         ELSE degrees(sq.angular_distance)::real
     END AS absolute_angular_distance
 FROM gis_core.centreline_latest AS cl

--- a/volumes/short_term_counting_program/sql/create-view-svc_centreline_directions.sql
+++ b/volumes/short_term_counting_program/sql/create-view-svc_centreline_directions.sql
@@ -29,21 +29,21 @@ WITH to_cardinal (bearing, direction) AS (
 SELECT
     cl.centreline_id,
     CASE
-        WHEN sq.angular_distance > radians(90) THEN cl.to_intersection_id -- reversed
+        WHEN r.reversed THEN cl.to_intersection_id
         ELSE cl.from_intersection_id
     END AS from_node,
     CASE
-        WHEN sq.angular_distance > radians(90) THEN cl.from_intersection_id -- reversed
+        WHEN r.reversed THEN cl.from_intersection_id
         ELSE cl.to_intersection_id
     END AS to_node,
-    sq.direction,
+    ad.direction,
     CASE
-        WHEN sq.angular_distance > radians(90) THEN ST_Reverse(cl.geom) -- reversed
+        WHEN r.reversed THEN ST_Reverse(cl.geom)
         ELSE cl.geom
     END AS centreline_geom_directed,
     CASE
-        WHEN sq.angular_distance > radians(90) THEN (180 - degrees(sq.angular_distance))::real -- reversed
-        ELSE degrees(sq.angular_distance)::real
+        WHEN r.reversed THEN (180 - degrees(ad.angular_distance))::real
+        ELSE degrees(ad.angular_distance)::real
     END AS absolute_angular_distance
 FROM gis_core.centreline_latest AS cl
 CROSS JOIN LATERAL (
@@ -61,11 +61,16 @@ CROSS JOIN LATERAL (
             )
         ) AS angular_distance
     FROM to_cardinal
-) AS sq -- sq for sub-query
+) AS ad, -- ad for angular distance
+LATERAL (
+    -- edge geometry should be reversed where such a reversal
+    -- would reduce the angular distance
+    SELECT ad.angular_distance > radians(90) AS reversed
+) AS r
 -- exclude results where the cardinal direction is orthogonal, +/- 10 degrees
 WHERE
-    sq.angular_distance < radians(80)
-    OR sq.angular_distance > radians(100);
+    ad.angular_distance < radians(80)
+    OR ad.angular_distance > radians(100);
 
 CREATE UNIQUE INDEX ON traffic.svc_centreline_directions (centreline_id, direction);
 

--- a/volumes/short_term_counting_program/sql/create-view-svc_centreline_directions.sql
+++ b/volumes/short_term_counting_program/sql/create-view-svc_centreline_directions.sql
@@ -29,11 +29,11 @@ WITH to_cardinal (bearing, direction) AS (
 SELECT
     cl.centreline_id,
     CASE
-        WHEN sq.angular_distance > radians(90) THEN to_intersection_id -- reversed
+        WHEN sq.angular_distance > radians(90) THEN cl.to_intersection_id -- reversed
         ELSE cl.from_intersection_id
     END AS from_node,
     CASE
-        WHEN sq.angular_distance > radians(90) THEN from_intersection_id -- reversed
+        WHEN sq.angular_distance > radians(90) THEN cl.from_intersection_id -- reversed
         ELSE cl.to_intersection_id
     END AS to_node,
     sq.direction,


### PR DESCRIPTION
## What this pull request accomplishes:

- Adds from/to centreline node IDs to the directed SVC view to make it easier to join back to a fuller representation of the centreline network. 

## Issue(s) this solves:

- Would have had to join on a geom field, which seems sketchy

## What, in particular, needs to reviewed:

- the code

## What needs to be done by a sysadmin after this PR is merged

- recreate the matview (can drop AADT dependents)
