### PR TITLE
Filter some intersections from leg direction assignment

### DIFF
--- a/gis/centreline/sql/create_matview_centreline_leg_directions.sql
+++ b/gis/centreline/sql/create_matview_centreline_leg_directions.sql
@@ -32,6 +32,12 @@ nodes AS (
     -- i.e. a legit intersection with three or more legs
     SELECT node_id
     FROM node_edges
+    JOIN gis_core.centreline_intersection_point_latest AS p
+        ON node_edges.node_id = p.intersection_id
+    WHERE p.classification NOT IN (
+        'SEUML', -- "Pseudo-Intersection-Overpass/Underpass"
+        'XICSL' -- "Expressway Interchange, Single-Level"
+    )
     GROUP BY node_id
     HAVING COUNT(DISTINCT edge_id) > 2
 ),


### PR DESCRIPTION
## What this pull request accomplishes:

- in reference to https://github.com/CityofToronto/bdit_data-sources/issues/1190#issuecomment-2881526992

## Issue(s) this solves:

- Directions are assigned to intersections that are either 
    - not real (overpasses)
    - highway ramp connections with very tight/wide angles

In neither case would we do a TMC or assign some value to a leg. 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

Recreate the `gis_core.centreline_leg_directions` view.
