### PR TITLE
GCC - pull layers monthly, repartition

### DIFF
--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -74,7 +74,7 @@ def create_gcc_puller_dag(dag_id, default_args, name, conn_id, aggs_to_trigger):
                 examples=['gis', 'gis_core'],
             )
         },
-        schedule='0 7 1 */3 *' #'@quarterly'
+        schedule='0 7 1 * *' #first day of each month
     )
     def gcc_layers_dag():
         

--- a/gis/gccview/sql/partition_migration/repartition_by_yy_mm_centreline.sql
+++ b/gis/gccview/sql/partition_migration/repartition_by_yy_mm_centreline.sql
@@ -1,0 +1,128 @@
+--deps save and drop doesn't support "-"; temporarily rename
+--ALTER MATERIALIZED VIEW zghayen."mto-friction_data_joined_centreline" RENAME TO mto_friction_data_joined_centreline; 
+--ALTER MATERIALIZED VIEW zghayen."mto-friction_data_joined_collisions" RENAME TO mto_friction_data_joined_collisions;
+
+--store the names of `gis_core.centreline` partitions
+DROP TABLE IF EXISTS gis_core.centreline_partitions;
+CREATE TABLE gis_core.centreline_partitions AS
+SELECT child.relname, substring(child.relname, 0, 16) AS yr, substring(child.relname, 12, 8)::date AS version_date
+FROM pg_inherits
+JOIN pg_class AS parent ON pg_inherits.inhparent = parent.oid
+JOIN pg_class AS child ON pg_inherits.inhrelid = child.oid
+JOIN pg_namespace AS nmsp_parent ON nmsp_parent.oid = parent.relnamespace
+WHERE
+    nmsp_parent.nspname = 'gis_core'
+    AND parent.relname = 'centreline';
+
+--save dependencies
+SELECT public.deps_save_and_drop_dependencies_dryrun(
+	p_view_schema:= 'gis_core'::character varying COLLATE "C",
+	p_view_name:= 'centreline'::character varying COLLATE "C", 
+	dryrun := False::boolean, 
+	max_depth := 20::integer
+);
+
+ALTER TABLE gis_core.centreline RENAME TO centreline_old;
+
+--create new partitioned table
+CREATE TABLE IF NOT EXISTS gis_core.centreline
+(
+    version_date date,
+    centreline_id integer,
+    linear_name_id integer,
+    linear_name_full text COLLATE pg_catalog."default",
+    linear_name_full_legal text COLLATE pg_catalog."default",
+    address_l text COLLATE pg_catalog."default",
+    address_r text COLLATE pg_catalog."default",
+    parity_l text COLLATE pg_catalog."default",
+    parity_r text COLLATE pg_catalog."default",
+    lo_num_l integer,
+    hi_num_l integer,
+    lo_num_r integer,
+    hi_num_r integer,
+    begin_addr_point_id_l integer,
+    end_addr_point_id_l integer,
+    begin_addr_point_id_r integer,
+    end_addr_point_id_r integer,
+    begin_addr_l integer,
+    end_addr_l integer,
+    begin_addr_r integer,
+    end_addr_r integer,
+    linear_name text COLLATE pg_catalog."default",
+    linear_name_type text COLLATE pg_catalog."default",
+    linear_name_dir text COLLATE pg_catalog."default",
+    linear_name_desc text COLLATE pg_catalog."default",
+    linear_name_label text COLLATE pg_catalog."default",
+    from_intersection_id integer,
+    to_intersection_id integer,
+    oneway_dir_code integer,
+    oneway_dir_code_desc text COLLATE pg_catalog."default",
+    feature_code integer,
+    feature_code_desc text COLLATE pg_catalog."default",
+    jurisdiction text COLLATE pg_catalog."default",
+    centreline_status text COLLATE pg_catalog."default",
+    shape_length numeric,
+    objectid integer,
+    shape_len numeric,
+    mi_prinx integer,
+    low_num_odd integer,
+    high_num_odd integer,
+    low_num_even integer,
+    high_num_even integer,
+    geom geometry
+) PARTITION BY RANGE (version_date);
+--partition by range instead of list this time
+
+ALTER TABLE IF EXISTS gis_core.centreline OWNER TO gis_admins;
+REVOKE ALL ON TABLE gis_core.centreline FROM bdit_humans;
+REVOKE ALL ON TABLE gis_core.centreline FROM events_bot;
+GRANT SELECT ON TABLE gis_core.centreline TO bdit_humans;
+GRANT SELECT ON TABLE gis_core.centreline TO events_bot;
+GRANT ALL ON TABLE gis_core.centreline TO gis_admins;
+
+--create new partitions, which are also subpartitioned
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT DISTINCT yr, version_date::date as vd 
+        FROM gis_core.centreline_partitions
+    LOOP 
+        EXECUTE format('CREATE TABLE IF NOT EXISTS gis_core.%I PARTITION OF gis_core.centreline
+                        FOR VALUES FROM (%L) TO (%L)
+                        PARTITION BY LIST (version_date);', 
+                partition_rec.yr,
+                date_trunc('year', partition_rec.vd),
+                date_trunc('year', partition_rec.vd) + interval '1 year');
+    END LOOP;
+END$$;
+
+--detach each partition and attach to new table
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT relname, yr, version_date::date as vd 
+        FROM gis_core.centreline_partitions
+    LOOP 
+        EXECUTE format('ALTER TABLE gis_core.centreline_old DETACH PARTITION gis_core.%I', 
+            partition_rec.relname);
+        EXECUTE format('ALTER TABLE gis_core.%I ATTACH PARTITION gis_core.%I FOR VALUES IN (%L)',
+            partition_rec.yr, partition_rec.relname, partition_rec.vd);
+    END LOOP;
+END$$;
+
+
+--now restore dependencies:
+SELECT public.deps_restore_dependencies(
+	p_view_schema:= 'gis_core'::character varying COLLATE "C",
+	p_view_name:= 'centreline'::character varying COLLATE "C"
+);
+
+ALTER MATERIALIZED VIEW zghayen.mto_friction_data_joined_centreline RENAME TO "mto-friction_data_joined_centreline"; 
+ALTER MATERIALIZED VIEW zghayen.mto_friction_data_joined_collisions RENAME TO "mto-friction_data_joined_collisions";
+
+--do this manually after checking no rows
+--DROP TABLE gis_core.centreline_old;

--- a/gis/gccview/sql/partition_migration/repartition_by_yy_mm_centreline_intersection_point.sql
+++ b/gis/gccview/sql/partition_migration/repartition_by_yy_mm_centreline_intersection_point.sql
@@ -1,0 +1,111 @@
+--store the names of `gis_core.centreline_intersection_point` partitions
+DROP TABLE IF EXISTS gis_core.centreline_intersection_point_partitions;
+CREATE TABLE gis_core.centreline_intersection_point_partitions AS
+SELECT child.relname, substring(child.relname, 0, 35) AS yr, substring(child.relname, 31, 8)::date AS version_date
+FROM pg_inherits
+JOIN pg_class AS parent ON pg_inherits.inhparent = parent.oid
+JOIN pg_class AS child ON pg_inherits.inhrelid = child.oid
+JOIN pg_namespace AS nmsp_parent ON nmsp_parent.oid = parent.relnamespace
+WHERE
+    nmsp_parent.nspname = 'gis_core'
+    AND parent.relname = 'centreline_intersection_point';
+
+--save dependencies
+SELECT public.deps_save_and_drop_dependencies_dryrun(
+	p_view_schema:= 'gis_core'::character varying COLLATE "C",
+	p_view_name:= 'centreline_intersection_point'::character varying COLLATE "C", 
+	dryrun := False::boolean, 
+	max_depth := 20::integer
+);
+
+ALTER TABLE gis_core.centreline_intersection_point RENAME TO centreline_intersection_point_old;
+
+--create new partitioned table
+CREATE TABLE IF NOT EXISTS gis_core.centreline_intersection_point
+(
+    version_date date,
+    intersection_id integer,
+    date_effective timestamp without time zone,
+    date_expiry timestamp without time zone,
+    intersection_desc text COLLATE pg_catalog."default",
+    ward_number text COLLATE pg_catalog."default",
+    ward text COLLATE pg_catalog."default",
+    municipality text COLLATE pg_catalog."default",
+    classification text COLLATE pg_catalog."default",
+    classification_desc text COLLATE pg_catalog."default",
+    number_of_elevations integer,
+    x numeric,
+    y numeric,
+    longitude numeric,
+    latitude numeric,
+    trans_id_create integer,
+    trans_id_expire integer,
+    objectid integer NOT NULL,
+    geom geometry
+) PARTITION BY RANGE (version_date);
+--partition by range this time!
+
+ALTER TABLE IF EXISTS gis_core.centreline_intersection_point
+    OWNER to gis_admins;
+
+REVOKE ALL ON TABLE gis_core.centreline_intersection_point FROM bdit_humans;
+
+GRANT SELECT ON TABLE gis_core.centreline_intersection_point TO bdit_humans;
+
+GRANT ALL ON TABLE gis_core.centreline_intersection_point TO gis_admins;
+
+COMMENT ON TABLE gis_core.centreline_intersection_point
+    IS 'Intersection Layer pulled from (https://insideto-gis.toronto.ca/arcgis/rest/services/cot_geospatial/FeatureServer/19)
+Contains additional boundary information such as ward, and municpality, as well as trails and ferry routes';
+
+
+ALTER TABLE IF EXISTS gis_core.centreline_intersection_point OWNER TO gis_admins;
+REVOKE ALL ON TABLE gis_core.centreline_intersection_point FROM bdit_humans;
+REVOKE ALL ON TABLE gis_core.centreline_intersection_point FROM events_bot;
+GRANT SELECT ON TABLE gis_core.centreline_intersection_point TO bdit_humans;
+GRANT SELECT ON TABLE gis_core.centreline_intersection_point TO events_bot;
+GRANT ALL ON TABLE gis_core.centreline_intersection_point TO gis_admins;
+
+--create new partitions, which are also subpartitioned
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT DISTINCT yr, version_date::date as vd 
+        FROM gis_core.centreline_intersection_point_partitions
+    LOOP 
+        EXECUTE format('CREATE TABLE IF NOT EXISTS gis_core.%I PARTITION OF gis_core.centreline_intersection_point
+                        FOR VALUES FROM (%L) TO (%L)
+                        PARTITION BY LIST (version_date);', 
+                partition_rec.yr,
+                date_trunc('year', partition_rec.vd),
+                date_trunc('year', partition_rec.vd) + interval '1 year');
+    END LOOP;
+END$$;
+
+--detach each partition and attach to new table
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT relname, yr, version_date::date as vd 
+        FROM gis_core.centreline_intersection_point_partitions
+    LOOP 
+        EXECUTE format('ALTER TABLE gis_core.centreline_intersection_point_old DETACH PARTITION gis_core.%I', 
+            partition_rec.relname);
+        EXECUTE format('ALTER TABLE gis_core.%I ATTACH PARTITION gis_core.%I FOR VALUES IN (%L)',
+            partition_rec.yr, partition_rec.relname, partition_rec.vd);
+    END LOOP;
+END$$;
+
+
+--now restore dependencies:
+SELECT public.deps_restore_dependencies(
+	p_view_schema:= 'gis_core'::character varying COLLATE "C",
+	p_view_name:= 'centreline_intersection_point'::character varying COLLATE "C"
+)
+
+--do this manually after checking no rows
+--DROP TABLE gis_core.centreline_intersection_point_old;

--- a/gis/gccview/sql/partition_migration/repartition_by_yy_mm_centreline_intersection_point_morbius.sql
+++ b/gis/gccview/sql/partition_migration/repartition_by_yy_mm_centreline_intersection_point_morbius.sql
@@ -1,0 +1,109 @@
+--store the names of `gis.centreline_intersection_point` partitions
+DROP TABLE IF EXISTS gis.centreline_intersection_point_partitions;
+CREATE TABLE gis.centreline_intersection_point_partitions AS
+SELECT child.relname, substring(child.relname, 0, 35) AS yr, substring(child.relname, 31, 8)::date AS version_date
+FROM pg_inherits
+JOIN pg_class AS parent ON pg_inherits.inhparent = parent.oid
+JOIN pg_class AS child ON pg_inherits.inhrelid = child.oid
+JOIN pg_namespace AS nmsp_parent ON nmsp_parent.oid = parent.relnamespace
+WHERE
+    nmsp_parent.nspname = 'gis'
+    AND parent.relname = 'centreline_intersection_point';
+
+--save dependencies
+SELECT public.deps_save_and_drop_dependencies_dryrun(
+	p_view_schema:= 'gis'::character varying COLLATE "C",
+	p_view_name:= 'centreline_intersection_point'::character varying COLLATE "C", 
+	dryrun := False::boolean, 
+	max_depth := 20::integer
+);
+
+ALTER TABLE gis.centreline_intersection_point RENAME TO centreline_intersection_point_old;
+
+--create new partitioned table
+CREATE TABLE IF NOT EXISTS gis.centreline_intersection_point
+(
+    version_date date,
+    intersection_id integer,
+    date_effective timestamp without time zone,
+    date_expiry timestamp without time zone,
+    intersection_desc text COLLATE pg_catalog."default",
+    ward_number text COLLATE pg_catalog."default",
+    ward text COLLATE pg_catalog."default",
+    municipality text COLLATE pg_catalog."default",
+    classification text COLLATE pg_catalog."default",
+    classification_desc text COLLATE pg_catalog."default",
+    number_of_elevations integer,
+    x numeric,
+    y numeric,
+    longitude numeric,
+    latitude numeric,
+    trans_id_create integer,
+    trans_id_expire integer,
+    objectid integer NOT NULL,
+    geom geometry
+) PARTITION BY RANGE (version_date);
+--partition by range this time!
+
+ALTER TABLE IF EXISTS gis.centreline_intersection_point
+    OWNER to gis_admins;
+
+REVOKE ALL ON TABLE gis.centreline_intersection_point FROM ptc_humans, collision_humans;
+
+GRANT SELECT ON TABLE gis.centreline_intersection_point TO ptc_humans, collision_humans;
+
+GRANT ALL ON TABLE gis.centreline_intersection_point TO gis_admins;
+
+COMMENT ON TABLE gis.centreline_intersection_point
+    IS 'Intersection Layer pulled from (https://insideto-gis.toronto.ca/arcgis/rest/services/cot_geospatial/FeatureServer/19)
+Contains additional boundary information such as ward, and municpality, as well as trails and ferry routes';
+
+
+ALTER TABLE IF EXISTS gis.centreline_intersection_point OWNER TO gis_admins;
+REVOKE ALL ON TABLE gis.centreline_intersection_point FROM ptc_humans, collision_humans;
+GRANT SELECT ON TABLE gis.centreline_intersection_point TO ptc_humans, collision_humans;
+GRANT ALL ON TABLE gis.centreline_intersection_point TO gis_admins;
+
+--create new partitions, which are also subpartitioned
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT DISTINCT yr, version_date::date as vd 
+        FROM gis.centreline_intersection_point_partitions
+    LOOP 
+        EXECUTE format('CREATE TABLE IF NOT EXISTS gis.%I PARTITION OF gis.centreline_intersection_point
+                        FOR VALUES FROM (%L) TO (%L)
+                        PARTITION BY LIST (version_date);', 
+                partition_rec.yr,
+                date_trunc('year', partition_rec.vd),
+                date_trunc('year', partition_rec.vd) + interval '1 year');
+    END LOOP;
+END$$;
+
+--detach each partition and attach to new table
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT relname, yr, version_date::date as vd 
+        FROM gis.centreline_intersection_point_partitions
+    LOOP 
+        EXECUTE format('ALTER TABLE gis.centreline_intersection_point_old DETACH PARTITION gis.%I', 
+            partition_rec.relname);
+        EXECUTE format('ALTER TABLE gis.%I ATTACH PARTITION gis.%I FOR VALUES IN (%L)',
+            partition_rec.yr, partition_rec.relname, partition_rec.vd);
+    END LOOP;
+END$$;
+
+
+--now restore dependencies:
+SELECT public.deps_restore_dependencies(
+	p_view_schema:= 'gis'::character varying COLLATE "C",
+	p_view_name:= 'centreline_intersection_point'::character varying COLLATE "C"
+)
+
+--do this manually after checking no rows
+--DROP TABLE gis.centreline_intersection_point_old;

--- a/gis/gccview/sql/partition_migration/repartition_by_yy_mm_centreline_morbius.sql
+++ b/gis/gccview/sql/partition_migration/repartition_by_yy_mm_centreline_morbius.sql
@@ -1,0 +1,119 @@
+--store the names of `gis.centreline` partitions
+DROP TABLE IF EXISTS gis.centreline_partitions;
+CREATE TABLE gis.centreline_partitions AS
+SELECT child.relname, substring(child.relname, 0, 16) AS yr, substring(child.relname, 12, 8)::date AS version_date
+FROM pg_inherits
+JOIN pg_class AS parent ON pg_inherits.inhparent = parent.oid
+JOIN pg_class AS child ON pg_inherits.inhrelid = child.oid
+JOIN pg_namespace AS nmsp_parent ON nmsp_parent.oid = parent.relnamespace
+WHERE
+    nmsp_parent.nspname = 'gis'
+    AND parent.relname = 'centreline';
+
+--save dependencies
+SELECT public.deps_save_and_drop_dependencies_dryrun(
+	p_view_schema:= 'gis'::character varying COLLATE "C",
+	p_view_name:= 'centreline'::character varying COLLATE "C", 
+	dryrun := False::boolean, 
+	max_depth := 20::integer
+);
+
+ALTER TABLE gis.centreline RENAME TO centreline_old;
+
+--create new partitioned table
+CREATE TABLE IF NOT EXISTS gis.centreline
+(
+    version_date date,
+    centreline_id integer,
+    linear_name_id integer,
+    linear_name_full text COLLATE pg_catalog."default",
+    linear_name_full_legal text COLLATE pg_catalog."default",
+    address_l text COLLATE pg_catalog."default",
+    address_r text COLLATE pg_catalog."default",
+    parity_l text COLLATE pg_catalog."default",
+    parity_r text COLLATE pg_catalog."default",
+    lo_num_l integer,
+    hi_num_l integer,
+    lo_num_r integer,
+    hi_num_r integer,
+    begin_addr_point_id_l integer,
+    end_addr_point_id_l integer,
+    begin_addr_point_id_r integer,
+    end_addr_point_id_r integer,
+    begin_addr_l integer,
+    end_addr_l integer,
+    begin_addr_r integer,
+    end_addr_r integer,
+    linear_name text COLLATE pg_catalog."default",
+    linear_name_type text COLLATE pg_catalog."default",
+    linear_name_dir text COLLATE pg_catalog."default",
+    linear_name_desc text COLLATE pg_catalog."default",
+    linear_name_label text COLLATE pg_catalog."default",
+    from_intersection_id integer,
+    to_intersection_id integer,
+    oneway_dir_code integer,
+    oneway_dir_code_desc text COLLATE pg_catalog."default",
+    feature_code integer,
+    feature_code_desc text COLLATE pg_catalog."default",
+    jurisdiction text COLLATE pg_catalog."default",
+    centreline_status text COLLATE pg_catalog."default",
+    shape_length numeric,
+    objectid integer,
+    shape_len numeric,
+    mi_prinx integer,
+    low_num_odd integer,
+    high_num_odd integer,
+    low_num_even integer,
+    high_num_even integer,
+    geom geometry
+) PARTITION BY RANGE (version_date);
+--partition by range instead of list this time
+
+ALTER TABLE IF EXISTS gis.centreline OWNER TO gis_admins;
+REVOKE ALL ON TABLE gis.centreline FROM ptc_humans, collision_humans;
+GRANT SELECT ON TABLE gis.centreline TO ptc_humans, collision_humans;
+GRANT ALL ON TABLE gis.centreline TO gis_admins;
+
+--create new partitions, which are also subpartitioned
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT DISTINCT yr, version_date::date as vd 
+        FROM gis.centreline_partitions
+    LOOP 
+        EXECUTE format('CREATE TABLE IF NOT EXISTS gis.%I PARTITION OF gis.centreline
+                        FOR VALUES FROM (%L) TO (%L)
+                        PARTITION BY LIST (version_date);', 
+                partition_rec.yr,
+                date_trunc('year', partition_rec.vd),
+                date_trunc('year', partition_rec.vd) + interval '1 year');
+    END LOOP;
+END$$;
+
+--detach each partition and attach to new table
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT relname, yr, version_date::date as vd 
+        FROM gis.centreline_partitions
+    LOOP 
+        EXECUTE format('ALTER TABLE gis.centreline_old DETACH PARTITION gis.%I', 
+            partition_rec.relname);
+        EXECUTE format('ALTER TABLE gis.%I ATTACH PARTITION gis.%I FOR VALUES IN (%L)',
+            partition_rec.yr, partition_rec.relname, partition_rec.vd);
+    END LOOP;
+END$$;
+
+
+--now restore dependencies:
+SELECT public.deps_restore_dependencies(
+	p_view_schema:= 'gis'::character varying COLLATE "C",
+	p_view_name:= 'centreline'::character varying COLLATE "C"
+);
+
+--do this manually after checking no rows
+--DROP TABLE gis.centreline_old;

--- a/gis/gccview/sql/partition_migration/repartition_by_yy_mm_intersection.sql
+++ b/gis/gccview/sql/partition_migration/repartition_by_yy_mm_intersection.sql
@@ -1,0 +1,121 @@
+--store the names of `gis_core.intersection` partitions
+DROP TABLE IF EXISTS gis_core.intersection_partitions;
+CREATE TABLE gis_core.intersection_partitions AS
+SELECT child.relname, substring(child.relname, 0, 18) AS yr, substring(child.relname, 14, 8)::date AS version_date
+FROM pg_inherits
+JOIN pg_class AS parent ON pg_inherits.inhparent = parent.oid
+JOIN pg_class AS child ON pg_inherits.inhrelid = child.oid
+JOIN pg_namespace AS nmsp_parent ON nmsp_parent.oid = parent.relnamespace
+WHERE
+    nmsp_parent.nspname = 'gis_core'
+    AND parent.relname = 'intersection';
+
+--save dependencies
+SELECT public.deps_save_and_drop_dependencies_dryrun(
+	p_view_schema:= 'gis_core'::character varying COLLATE "C",
+	p_view_name:= 'intersection'::character varying COLLATE "C", 
+	dryrun := False::boolean, 
+	max_depth := 20::integer
+);
+
+ALTER TABLE gis_core.intersection RENAME TO intersection_old;
+
+--create new partitioned table
+CREATE TABLE IF NOT EXISTS gis_core.intersection
+(
+    version_date date,
+    intersection_id integer,
+    date_effective timestamp without time zone,
+    date_expiry timestamp without time zone,
+    trans_id_create integer,
+    trans_id_expire integer,
+    x numeric,
+    y numeric,
+    longitude numeric,
+    latitude numeric,
+    centreline_id_from integer,
+    linear_name_full_from text COLLATE pg_catalog."default",
+    linear_name_id_from numeric,
+    turn_direction text COLLATE pg_catalog."default",
+    centreline_id_to integer,
+    linear_name_full_to text COLLATE pg_catalog."default",
+    linear_name_id_to numeric,
+    connected text COLLATE pg_catalog."default",
+    objectid integer,
+    elevation_id integer,
+    elevation_level integer,
+    classification text COLLATE pg_catalog."default",
+    classification_desc text COLLATE pg_catalog."default",
+    number_of_elevations integer,
+    elevation_feature_code integer,
+    elevation_feature_code_desc text COLLATE pg_catalog."default",
+    elevation numeric,
+    elevation_unit text COLLATE pg_catalog."default",
+    height_restriction numeric,
+    height_restriction_unit text COLLATE pg_catalog."default",
+    feature_class_from text COLLATE pg_catalog."default",
+    feature_class_to text COLLATE pg_catalog."default",
+    geom geometry
+) PARTITION BY RANGE (version_date);
+--partition by range instead of list this time
+
+ALTER TABLE IF EXISTS gis_core.intersection OWNER to gis_admins;
+REVOKE ALL ON TABLE gis_core.intersection FROM bdit_humans;
+GRANT SELECT ON TABLE gis_core.intersection TO bdit_humans;
+GRANT ALL ON TABLE gis_core.intersection TO gis_admins;
+
+COMMENT ON TABLE gis_core.intersection
+    IS 'Intersection Layer pulled from (https://insideto-gis.toronto.ca/arcgis/rest/services/cot_geospatial12/FeatureServer/42).
+Ccontains additional elevation information such as elevation level, elevation unit, height restriction, etc, does not include cul-de-sacs, overpass/underpass.';
+
+
+ALTER TABLE IF EXISTS gis_core.intersection OWNER TO gis_admins;
+REVOKE ALL ON TABLE gis_core.intersection FROM bdit_humans;
+REVOKE ALL ON TABLE gis_core.intersection FROM events_bot;
+GRANT SELECT ON TABLE gis_core.intersection TO bdit_humans;
+GRANT SELECT ON TABLE gis_core.intersection TO events_bot;
+GRANT ALL ON TABLE gis_core.intersection TO gis_admins;
+
+--create new partitions, which are also subpartitioned
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT DISTINCT yr, version_date::date as vd 
+        FROM gis_core.intersection_partitions
+    LOOP 
+        EXECUTE format('CREATE TABLE IF NOT EXISTS gis_core.%I PARTITION OF gis_core.intersection
+                        FOR VALUES FROM (%L) TO (%L)
+                        PARTITION BY LIST (version_date);', 
+                partition_rec.yr,
+                date_trunc('year', partition_rec.vd),
+                date_trunc('year', partition_rec.vd) + interval '1 year');
+    END LOOP;
+END$$;
+
+--detach each partition and attach to new table
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT relname, yr, version_date::date as vd 
+        FROM gis_core.intersection_partitions
+    LOOP 
+        EXECUTE format('ALTER TABLE gis_core.intersection_old DETACH PARTITION gis_core.%I;', 
+            partition_rec.relname);
+        EXECUTE format('ALTER TABLE gis_core.%I ATTACH PARTITION gis_core.%I FOR VALUES IN (%L);',
+            partition_rec.yr, partition_rec.relname, partition_rec.vd);
+    END LOOP;
+END$$;
+
+
+--now restore dependencies:
+SELECT public.deps_restore_dependencies(
+	p_view_schema:= 'gis_core'::character varying COLLATE "C",
+	p_view_name:= 'intersection'::character varying COLLATE "C"
+)
+
+--do this manually after checking no rows
+--DROP TABLE gis_core.intersection_old;

--- a/gis/gccview/sql/partition_migration/repartition_by_yy_mm_intersection_morbius.sql
+++ b/gis/gccview/sql/partition_migration/repartition_by_yy_mm_intersection_morbius.sql
@@ -1,0 +1,135 @@
+--store the names of `gis.intersection` partitions
+DROP TABLE IF EXISTS gis.intersection_partitions;
+CREATE TABLE gis.intersection_partitions AS
+SELECT child.relname, substring(child.relname, 0, 18) AS yr, substring(child.relname, 14, 8)::date AS version_date
+FROM pg_inherits
+JOIN pg_class AS parent ON pg_inherits.inhparent = parent.oid
+JOIN pg_class AS child ON pg_inherits.inhrelid = child.oid
+JOIN pg_namespace AS nmsp_parent ON nmsp_parent.oid = parent.relnamespace
+WHERE
+    nmsp_parent.nspname = 'gis'
+    AND parent.relname = 'intersection';
+
+--save dependencies
+SELECT public.deps_save_and_drop_dependencies_dryrun(
+	p_view_schema:= 'gis'::character varying COLLATE "C",
+	p_view_name:= 'intersection'::character varying COLLATE "C", 
+	dryrun := False::boolean, 
+	max_depth := 20::integer
+);
+
+ALTER TABLE gis.intersection RENAME TO intersection_old;
+
+--create new partitioned table
+CREATE TABLE IF NOT EXISTS gis.intersection
+(
+    version_date date,
+    intersection_id integer,
+    date_effective timestamp without time zone,
+    date_expiry timestamp without time zone,
+    trans_id_create integer,
+    trans_id_expire integer,
+    x numeric,
+    y numeric,
+    longitude numeric,
+    latitude numeric,
+    centreline_id_from integer,
+    linear_name_full_from text COLLATE pg_catalog."default",
+    linear_name_id_from numeric,
+    turn_direction text COLLATE pg_catalog."default",
+    centreline_id_to integer,
+    linear_name_full_to text COLLATE pg_catalog."default",
+    linear_name_id_to numeric,
+    connected text COLLATE pg_catalog."default",
+    objectid integer,
+    elevation_id integer,
+    elevation_level integer,
+    classification text COLLATE pg_catalog."default",
+    classification_desc text COLLATE pg_catalog."default",
+    number_of_elevations integer,
+    elevation_feature_code integer,
+    elevation_feature_code_desc text COLLATE pg_catalog."default",
+    elevation numeric,
+    elevation_unit text COLLATE pg_catalog."default",
+    height_restriction numeric,
+    height_restriction_unit text COLLATE pg_catalog."default",
+    feature_class_from text COLLATE pg_catalog."default",
+    feature_class_to text COLLATE pg_catalog."default",
+    geom geometry
+) PARTITION BY RANGE (version_date);
+
+ALTER TABLE IF EXISTS gis.intersection
+    OWNER to gis_admins;
+
+REVOKE ALL ON TABLE gis.intersection FROM collision_humans;
+REVOKE ALL ON TABLE gis.intersection FROM ptc_airflow_bot;
+REVOKE ALL ON TABLE gis.intersection FROM ptc_humans;
+
+GRANT SELECT ON TABLE gis.intersection TO collision_humans;
+
+GRANT ALL ON TABLE gis.intersection TO gis_admins;
+
+GRANT ALL ON TABLE gis.intersection TO natalie;
+
+GRANT SELECT ON TABLE gis.intersection TO ptc_airflow_bot;
+
+GRANT SELECT ON TABLE gis.intersection TO ptc_humans;
+-- Index: intersection_version_date_idx1
+
+-- DROP INDEX IF EXISTS gis.intersection_version_date_idx1;
+
+CREATE INDEX IF NOT EXISTS intersection_version_date_idx1
+    ON gis.intersection USING brin
+    (version_date)
+;
+-- Index: intersection_version_date_idx2
+
+-- DROP INDEX IF EXISTS gis.intersection_version_date_idx2;
+
+CREATE INDEX IF NOT EXISTS intersection_version_date_idx2
+    ON gis.intersection USING btree
+    (version_date ASC NULLS LAST);
+
+--create new partitions, which are also subpartitioned
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT DISTINCT yr, version_date::date as vd 
+        FROM gis.intersection_partitions
+    LOOP 
+        EXECUTE format('CREATE TABLE IF NOT EXISTS gis.%I PARTITION OF gis.intersection
+                        FOR VALUES FROM (%L) TO (%L)
+                        PARTITION BY LIST (version_date);', 
+                partition_rec.yr,
+                date_trunc('year', partition_rec.vd),
+                date_trunc('year', partition_rec.vd) + interval '1 year');
+    END LOOP;
+END$$;
+
+--detach each partition and attach to new table
+DO $$
+DECLARE
+    partition_rec RECORD;
+BEGIN
+    FOR partition_rec IN
+        SELECT relname, yr, version_date::date as vd 
+        FROM gis.intersection_partitions
+    LOOP 
+        EXECUTE format('ALTER TABLE gis.intersection_old DETACH PARTITION gis.%I;', 
+            partition_rec.relname);
+        EXECUTE format('ALTER TABLE gis.%I ATTACH PARTITION gis.%I FOR VALUES IN (%L);',
+            partition_rec.yr, partition_rec.relname, partition_rec.vd);
+    END LOOP;
+END$$;
+
+
+--now restore dependencies:
+SELECT public.deps_restore_dependencies(
+	p_view_schema:= 'gis'::character varying COLLATE "C",
+	p_view_name:= 'intersection'::character varying COLLATE "C"
+)
+
+--do this manually after checking no rows
+--DROP TABLE gis.intersection_old;


### PR DESCRIPTION
## What this pull request accomplishes:

- change schedule from quarterly to monthly
- adjust puller script to partition first by year (range) then by version_date (list)
  - Adjusted to use pendulum instead of datetime which I find a bit more clear

## Issue(s) this solves:

- #1231 

## What, in particular, needs to reviewed:

- Just: `gis/gccview/gcc_puller_functions.py`
- the 6 sqls under `partition_migration` folder have already been implemented (tested on personal schema first), so do not need to be reviewed. Committing since they are helpful references for future re-partition exercises.  

## What needs to be done by a sysadmin after this PR is merged

- [x] Re-partition on Bancroft 
- [ ] pull latest gcc puller DAG there
- [ ] Delete gcc_dags airflow variable
