### PR TITLE
1244 gcc puller get dest row count doesnt work for scheduled runs, missing mat view refreshes

### DIFF
--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -197,13 +197,21 @@ DAGS = {
     },
     "ptc": {
         "conn": "gcc_bot",
-        "deployments": ["DEV", "PROD"]
+        "deployments": ["DEV", "PROD"],
+        "downstream_aggs": {
+            "ibms_joined": "REFRESH MATERIALIZED VIEW gis.ibms_joined;",
+            "centreline_version_date": "REFRESH MATERIALIZED VIEW gis.centreline_version_date;",
+            "intersection_version_date": "REFRESH MATERIALIZED VIEW gis.intersection_version_date;",
+            "centreline_intersection_point_version_date": "REFRESH MATERIALIZED VIEW gis.centreline_intersection_point_version_date;"
+        }
     },
     "sirius": {
         "conn": "gcc_bot_sirius",
         "deployments": ["DEV"],
         "downstream_aggs": {
-            "centreline_latest": "REFRESH MATERIALIZED VIEW gis.centreline_latest;"
+            "centreline_latest": "REFRESH MATERIALIZED VIEW gis.centreline_latest;",
+            "centreline_version_date": "REFRESH MATERIALIZED VIEW gis.centreline_version_date;",
+            "intersection_version_date": "REFRESH MATERIALIZED VIEW gis.intersection_version_date;"
         }
     }
 }

--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -187,31 +187,31 @@ DAGS = {
         "conn": "gcc_bot_bigdata",
         "deployments": ["DEV"],
         "downstream_aggs": {
-            "centreline_latest": "REFRESH MATERIALIZED VIEW gis_core.centreline_latest;",
-            "centreline_latest_all_feature": "REFRESH MATERIALIZED VIEW gis_core.centreline_latest_all_feature;",
-            "centreline_intersection_point_latest": "REFRESH MATERIALIZED VIEW gis_core.centreline_intersection_point_latest;",
-            "intersection_latest": "REFRESH MATERIALIZED VIEW gis_core.intersection_latest;",
-            "centreline_leg_directions": "REFRESH MATERIALIZED VIEW gis_core.centreline_leg_directions;",
-            "svc_centreline_directions": "REFRESH MATERIALIZED VIEW traffic.svc_centreline_directions;"
+            "centreline_latest": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis_core.centreline_latest;",
+            "centreline_latest_all_feature": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis_core.centreline_latest_all_feature;",
+            "centreline_intersection_point_latest": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis_core.centreline_intersection_point_latest;",
+            "intersection_latest": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis_core.intersection_latest;",
+            "centreline_leg_directions": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis_core.centreline_leg_directions;",
+            "svc_centreline_directions": "REFRESH MATERIALIZED VIEW CONCURRENTLY traffic.svc_centreline_directions;"
         }
     },
     "ptc": {
         "conn": "gcc_bot",
         "deployments": ["DEV", "PROD"],
         "downstream_aggs": {
-            "ibms_joined": "REFRESH MATERIALIZED VIEW gis.ibms_joined;",
-            "centreline_version_date": "REFRESH MATERIALIZED VIEW gis.centreline_version_date;",
-            "intersection_version_date": "REFRESH MATERIALIZED VIEW gis.intersection_version_date;",
-            "centreline_intersection_point_version_date": "REFRESH MATERIALIZED VIEW gis.centreline_intersection_point_version_date;"
+            "ibms_joined": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis.ibms_joined;",
+            "centreline_version_date": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis.centreline_version_date;",
+            "intersection_version_date": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis.intersection_version_date;",
+            "centreline_intersection_point_version_date": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis.centreline_intersection_point_version_date;"
         }
     },
     "sirius": {
         "conn": "gcc_bot_sirius",
         "deployments": ["DEV"],
         "downstream_aggs": {
-            "centreline_latest": "REFRESH MATERIALIZED VIEW gis.centreline_latest;",
-            "centreline_version_date": "REFRESH MATERIALIZED VIEW gis.centreline_version_date;",
-            "intersection_version_date": "REFRESH MATERIALIZED VIEW gis.intersection_version_date;"
+            "centreline_latest": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis.centreline_latest;",
+            "centreline_version_date": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis.centreline_version_date;",
+            "intersection_version_date": "REFRESH MATERIALIZED VIEW CONCURRENTLY gis.intersection_version_date;"
         }
     }
 }

--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -117,7 +117,7 @@ def create_gcc_puller_dag(dag_id, default_args, name, conn_id, aggs_to_trigger):
                 )
 
             @task(map_index_template="{{ table_name }}")
-            def compare_row_counts(conn_id, layer, ds):
+            def compare_row_counts(conn_id, layer, data_interval_end):
                 
                 mapserver = mapserver_name(layer[1].get("mapserver"))
                 schema = layer[1].get("schema_name")
@@ -136,7 +136,7 @@ def create_gcc_puller_dag(dag_id, default_args, name, conn_id, aggs_to_trigger):
                         include_additional_feature = include_additional_feature
                     )
                 conn = PostgresHook(conn_id).get_conn()
-                dest_count = get_dest_row_count(conn, schema, table_name, is_audited, ds)
+                dest_count = get_dest_row_count(conn, schema, table_name, is_audited, data_interval_end)
                 if src_count != dest_count:
                     msg = f"`{schema}.{table_name}` - Source count: `{src_count}`, Bigdata count: `{dest_count}`"
                     context.get("task_instance").xcom_push(key="extra_msg", value=msg)

--- a/dags/gcc_layers_pull.py
+++ b/dags/gcc_layers_pull.py
@@ -117,7 +117,7 @@ def create_gcc_puller_dag(dag_id, default_args, name, conn_id, aggs_to_trigger):
                 )
 
             @task(map_index_template="{{ table_name }}")
-            def compare_row_counts(conn_id, layer, data_interval_end):
+            def compare_row_counts(conn_id, layer):
                 
                 mapserver = mapserver_name(layer[1].get("mapserver"))
                 schema = layer[1].get("schema_name")
@@ -136,7 +136,8 @@ def create_gcc_puller_dag(dag_id, default_args, name, conn_id, aggs_to_trigger):
                         include_additional_feature = include_additional_feature
                     )
                 conn = PostgresHook(conn_id).get_conn()
-                dest_count = get_dest_row_count(conn, schema, table_name, is_audited, data_interval_end)
+                today = pendulum.today().to_date_string()
+                dest_count = get_dest_row_count(conn, schema, table_name, is_audited, today)
                 if src_count != dest_count:
                     msg = f"`{schema}.{table_name}` - Source count: `{src_count}`, Bigdata count: `{dest_count}`"
                     context.get("task_instance").xcom_push(key="extra_msg", value=msg)

--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -415,7 +415,7 @@ def get_dest_row_count(conn, schema, table, is_audited, version_date):
                 table = sql.Identifier(table)
             ))
         else:
-            cur.execute(sql.SQL("SELECT COUNT(*) FROM {schema}.{table} WHERE version_date = {version_date};").format(
+            cur.execute(sql.SQL("SELECT COUNT(*) FROM {schema}.{table} WHERE version_date = {version_date}::date;").format(
                 schema = sql.Identifier(schema),
                 table = sql.Identifier(table),
                 version_date = sql.Literal(version_date)

--- a/gis/gccview/gcc_puller_functions.py
+++ b/gis/gccview/gcc_puller_functions.py
@@ -415,7 +415,7 @@ def get_dest_row_count(conn, schema, table, is_audited, version_date):
                 table = sql.Identifier(table)
             ))
         else:
-            cur.execute(sql.SQL("SELECT COUNT(*) FROM {schema}.{table} WHERE version_date = {version_date}::date;").format(
+            cur.execute(sql.SQL("SELECT COUNT(*) FROM {schema}.{table} WHERE version_date = {version_date};").format(
                 schema = sql.Identifier(schema),
                 table = sql.Identifier(table),
                 version_date = sql.Literal(version_date)


### PR DESCRIPTION
## What this pull request accomplishes:

- fix bug in gcc puller row count comparison (wrong date)
- add missing mat view refreshes on morbius/sirius/bancroft

## Issue(s) this solves:

- #1244 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
