### PR TITLE
Filter for anomalous exit legs too

### DIFF
--- a/volumes/miovision/sql/views/create-view-volumes_15min_mvt_filtered.sql
+++ b/volumes/miovision/sql/views/create-view-volumes_15min_mvt_filtered.sql
@@ -9,27 +9,35 @@ CREATE OR REPLACE VIEW miovision_api.volumes_15min_mvt_filtered AS (
     FROM miovision_api.volumes_15min_mvt_unfiltered AS v15
     --anti join unacceptable_gaps
     LEFT JOIN miovision_api.unacceptable_gaps AS un USING (datetime_bin, intersection_uid)
-    --anti join anomalous_ranges
-    LEFT JOIN miovision_api.anomalous_ranges AS ar
-        ON (ar.problem_level = ANY(ARRAY['do-not-use'::text, 'questionable'::text]))
-        AND (
-            ar.intersection_uid = v15.intersection_uid
-            OR ar.intersection_uid IS NULL
-        ) AND (
-            ar.classification_uid = v15.classification_uid
-            OR ar.classification_uid IS NULL
-        ) AND (
-            ar.leg = v15.leg
-            OR ar.leg IS NULL
-        )
-        AND v15.datetime_bin >= ar.range_start
-        AND (
-            v15.datetime_bin <= ar.range_end
-            OR ar.range_end IS NULL
-        )
     WHERE
-        ar.uid IS NULL
-        AND un.datetime_bin IS NULL
+        un.datetime_bin IS NULL
+        AND NOT EXISTS (
+            SELECT 1
+            FROM miovision_api.anomalous_ranges AS ar
+            LEFT JOIN miovision_api.movement_map
+                ON ar.leg = movement_map.exit_leg
+            WHERE 
+                (ar.problem_level = ANY(ARRAY['do-not-use', 'questionable']))
+                AND (
+                    ar.intersection_uid = v15.intersection_uid
+                    OR ar.intersection_uid IS NULL
+                ) AND (
+                    ar.classification_uid = v15.classification_uid
+                    OR ar.classification_uid IS NULL
+                ) AND (
+                    ar.leg IS NULL -- applies to all legs
+                    OR v15.leg = ar.leg -- entry leg is anomalous
+                    OR ( -- exit leg is anomalous
+                        v15.leg = movement_map.leg
+                        AND v15.movement_uid = movement_map.movement_uid
+                    )
+                )
+                AND v15.datetime_bin >= ar.range_start
+                AND (
+                    v15.datetime_bin <= ar.range_end
+                    OR ar.range_end IS NULL
+                )
+        )
 );
 
 ALTER VIEW miovision_api.volumes_15min_mvt_filtered OWNER TO miovision_admins;


### PR DESCRIPTION
## What this pull request accomplishes:

- applies leg-specific anomalous_ranges to exit legs too (formerly only applied to entry leg)

## Issue(s) this solves:

- resolves #1265

## What, in particular, needs to reviewed:

- logical correctness
- that moving the conditions from a JOIN to the WHERE clause doesn't slow things down at scale (I tried it filtered down to the small example from the issue and it didn't take any longer)

## What needs to be done by a sysadmin after this PR is merged

- replace the view
