### PR TITLE
#1286 fix Miovision Anomalous Range Alert partial outage count

### DIFF
--- a/volumes/miovision/sql/data_checks/select-ongoing_intersection_outages.sql
+++ b/volumes/miovision/sql/data_checks/select-ongoing_intersection_outages.sql
@@ -1,5 +1,7 @@
 WITH all_outages AS (
-    SELECT COUNT(*) AS cnt
+    SELECT
+        COUNT(*) AS cnt,
+        COUNT(*) FILTER (WHERE classification_uid IS NOT NULL) AS partial_outage
     FROM miovision_api.open_issues
     WHERE COALESCE(classification_uid, 0) != 2
 ),
@@ -21,7 +23,7 @@ SELECT
         WHEN
             COUNT(total_outages.*) = 1 THEN ' full outages.' ELSE ' full outages '
         || 'and '
-        || (SELECT cnt FROM all_outages
+        || (SELECT partial_outage FROM all_outages
         )
         || ' partial outages. See `miovision_api.open_issues`.'
     END AS summ, --gap_threshold


### PR DESCRIPTION
## What this pull request accomplishes:

- Fixes the "partial outage" count in the miovision anomalous_range slack notification
- 

## Issue(s) this solves:

- Closes #1286 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
