### PR TITLE
#1299 Remove unused DAGs from DAGS_TO_TRIGGER

### DIFF
--- a/dags/pull_here.py
+++ b/dags/pull_here.py
@@ -51,8 +51,6 @@ DAGS_TO_TRIGGER = [
     "tti_aggregate",
     "congestion_aggregation",
     "congestion_refresh",
-    "queens_park_aggregation",
-    "rapidto_aggregation",
     "congestion_aggregate_temp"
 ]
 


### PR DESCRIPTION
Removed 'queens_park_aggregation' and 'rapidto_aggregation' from DAGS_TO_TRIGGER.

## What this pull request accomplishes:

- Remove unused DAGs from pull_here's `DAGS_TO_TRIGGER`
- 

## Issue(s) this solves:

- Closes #1299

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

- Update data_scripts on EC2