### PR TITLE
#1308 - dependabot package-ecosystem, add cooldown, reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
## What this pull request accomplishes:

- Adds a 7 day dependency cooldown
- Fixes incorrect package ecosystem
- Fixes outdated reviewer

## Issue(s) this solves:

- Closes #1308 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
