### PR TITLE
Include bus movements in `traffic.tmc_to_atr` view

### DIFF
--- a/volumes/short_term_counting_program/sql/create-view-tmc_to_atr.sql
+++ b/volumes/short_term_counting_program/sql/create-view-tmc_to_atr.sql
@@ -82,12 +82,12 @@ WITH json_bundled AS (
                     'WB', e_bus_t + e_bus_r + e_bus_l
                 ),
                 'S', json_build_object(
-                    'NB', s_bus_t + s_bus_r + s_bus_l,
-                    'SB', n_bus_t + e_bus_l + w_bus_r
+                    'SB', n_bus_t + e_bus_l + w_bus_r,
+                    'NB', s_bus_t + s_bus_r + s_bus_l
                 ),
                 'W', json_build_object(
-                    'EB', w_bus_t + w_bus_r + w_bus_l,
-                    'WB', e_bus_t + s_bus_l + n_bus_r
+                    'WB', e_bus_t + s_bus_l + n_bus_r,
+                    'EB', w_bus_t + w_bus_r + w_bus_l
                 )
             )
         ) AS counts


### PR DESCRIPTION
## What this pull request accomplishes:

- includes buses in `traffic.tmc_to_atr`

## Issue(s) this solves:

- resolves #1327 

## What, in particular, needs to reviewed:

- that selected movements and aggregations are correct transformations to ATR style

## What needs to be done by a sysadmin after this PR is merged

- REPLACE the view
