### PR TITLE
#1321 limit dependabot to security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,5 @@ updates:
     reviewers:
       - "radumas"
     target-branch: "master"
+    #only security updates and exclude version updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Set open-pull-requests-limit to 0 to only allow security updates.

Source:
> If you only require security updates and want to exclude version updates, you can set open-pull-requests-limit to 0 in order to prevent version updates for a given package-ecosystem.

https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-security-updates
