### PR TITLE
#1345 add airflow only upgrade notification to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,11 @@ updates:
     target-branch: "master"
     #only security updates and exclude version updates
     open-pull-requests-limit: 0
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    allow:
+      - dependency-name: "airflow"


### PR DESCRIPTION
## What this pull request accomplishes:

- add airflow only upgrade notification to dependabot with cooldown = 7 days, frequency = daily

## Issue(s) this solves:

- #1345 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

Nothing