### PR TITLE
`centreline_leg_directions` should not try to handle 5+-leg intersections

### DIFF
--- a/gis/centreline/sql/create_matview_centreline_leg_directions.sql
+++ b/gis/centreline/sql/create_matview_centreline_leg_directions.sql
@@ -33,13 +33,13 @@ node_edges AS (
 ),
 
 nodes AS (
-    -- find nodes with a degree > 2
-    -- i.e. a legit intersection with three or more legs
+    -- find nodes with a degree of either 3 or 4
+    -- i.e. a legit intersection with three or four legs
     SELECT node_id
     FROM node_edges
     GROUP BY node_id
     HAVING
-        COUNT(DISTINCT edge_id) > 2
+        COUNT(DISTINCT edge_id) IN (3, 4)
         -- no 'intersections' that are just ramps crossing eachother
         AND ARRAY_AGG(DISTINCT feature_code_desc) != ARRAY['Expressway Ramp']
 ),


### PR DESCRIPTION
## What this pull request accomplishes:

- Limits the intersections handled by `gis_core.centreline_leg_directions` to those of degree 3 or 4 

Effectively, this removes 73 intersections. 

```sql
-- adapted from the first part of the relevant query
-- this just shows intersections which we currently identify as having more than four legs
WITH node_edges AS (
    -- Identify all connections between nodes and edges
    -- remove expressways because they don't *actually* intersect other streets
    SELECT
        centreline_id AS edge_id,
        from_intersection_id AS node_id,
        feature_code_desc
    FROM gis_core.centreline_latest
    WHERE feature_code_desc != 'Expressway'

    UNION

    SELECT
        centreline_id AS edge_id,
        to_intersection_id AS node_id,
        feature_code_desc
    FROM gis_core.centreline_latest
    WHERE feature_code_desc != 'Expressway'
),

nodes AS (
    SELECT node_id
    FROM node_edges
    GROUP BY node_id
    HAVING
        COUNT(DISTINCT edge_id) > 4
        -- no 'intersections' that are just ramps crossing eachother
        AND ARRAY_AGG(DISTINCT feature_code_desc) != ARRAY['Expressway Ramp']
)

SELECT *
FROM nodes
JOIN gis_core.centreline_intersection_point_latest
ON node_id = intersection_id
```

## Issue(s) this solves:

- https://github.com/CityofToronto/bdit_data-sources/issues/1190#issuecomment-3935880476

There are only (up to) four cardinal directions to be assigned. If we have a 5+ leg intersection, this view should not even try because the results will almost certainly be misleading.

## What, in particular, needs to reviewed:

- that this does indeed only have the effect of removing this handful of intersections

## What needs to be done by a sysadmin after this PR is merged

* Replace the matview
