### PR TITLE
Expose absolute angular offset for easier downstream QC of leg assignment

### DIFF
--- a/gis/centreline/sql/create_matview_centreline_leg_directions.sql
+++ b/gis/centreline/sql/create_matview_centreline_leg_directions.sql
@@ -295,7 +295,7 @@ COMMENT ON COLUMN gis_core.centreline_leg_directions.leg
 IS 'cardinal direction, one of (north, east, south, west)';
 
 COMMENT ON COLUMN gis_core.centreline_leg_directions.angular_offset_from_cardinal_direction
-IS 'degrees difference from ideal cardinal direction (oriented to Toronto grid)';
+IS 'absolute degrees difference from ideal cardinal direction (oriented to Toronto grid)';
 
 COMMENT ON COLUMN gis_core.centreline_leg_directions.leg_stub_geom
 IS 'first (up to) 30m of the centreline segment geometry pointing *inbound* toward the reference intersection';


### PR DESCRIPTION
## What this pull request accomplishes:

- Exposes the measure of angular offset from the "true" cardinal direction assigned to a leg

## Issue(s) this solves:

- Makes it easier downstream to do QC on the leg assignment

## What, in particular, needs to reviewed:

- Would there be any value in this being a signed delta? Or is the absolute difference fine?
- Is there a better name for this field?

## What needs to be done by a sysadmin after this PR is merged

* Matview (table?) needs to be recreated
