### PR TITLE
#1365 add ptc open data tables to bigdata

### DIFF
--- a/dags/eoy_create_tables.py
+++ b/dags/eoy_create_tables.py
@@ -96,12 +96,26 @@ def eoy_create_table_dag():
                         conn_id='congestion_bot',
                         autocommit=True)
         
+        ptc_op_hrs_create = SQLExecuteQueryOperator(
+                        task_id='ptc_op_hrs_create',
+                        sql="SELECT ptc.create_annual_partition('open_data_operating_hours', '{{ ti.xcom_pull(task_ids='yr', key='return_value') }}')",
+                        conn_id='ptc_bot',
+                        autocommit=True)
+        
+        ptc_trips_create = SQLExecuteQueryOperator(
+                        task_id='ptc_trips_create',
+                        sql="SELECT ptc.create_annual_partition('open_data_trips', '{{ ti.xcom_pull(task_ids='yr', key='return_value') }}')",
+                        conn_id='ptc_bot',
+                        autocommit=True)
+        
         bt_replace_trigger(yr=YR)
         insert_holidays(yr=YR)
         here_create_tables
         here_path_create_tables
         bt_create_tables
         congestion_create_table
+        ptc_op_hrs_create
+        ptc_trips_create
 
     @task(trigger_rule='none_failed')
     def success_alert(**context):

--- a/vfh/readme.md
+++ b/vfh/readme.md
@@ -1,0 +1,7 @@
+# Introduction
+
+This folder contains PTC Open Data, which is copied to bigdata `ptc` schema upon publishing for use in analysis. The data is transferred by the `open_data_export_*` DAGs running on VFH Prod server.
+
+The data, including readmes can also be found online at the following links:
+- [Private Transportation Companies – Vehicle Operating Data ](https://open.toronto.ca/dataset/private-transportation-companies-vehicle-operating-data/)
+- [Private Transportation Companies - Summary and Trip Data](https://open.toronto.ca/dataset/private-transportation-companies-summary-and-trip-data/)

--- a/vfh/sql/functions/function-create_annual_partition.sql
+++ b/vfh/sql/functions/function-create_annual_partition.sql
@@ -1,0 +1,46 @@
+CREATE OR REPLACE FUNCTION ptc.create_annual_partition(
+    base_table text,
+    year_ integer
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+COST 100
+VOLATILE PARALLEL UNSAFE
+
+AS $BODY$
+
+DECLARE
+    year_table TEXT := base_table||'_'||year_::text;
+    startdate DATE := (year_::text || '-01-01')::date;
+    tablename TEXT;
+
+BEGIN
+
+    EXECUTE FORMAT($$
+        CREATE TABLE IF NOT EXISTS ptc.%1$I
+        PARTITION OF ptc.%2$I
+        FOR VALUES FROM (%3$L) TO (%3$L::date + interval '1 year');
+        ALTER TABLE IF EXISTS ptc.%1$I OWNER TO ptc_admins;
+        GRANT ALL ON TABLE ptc.%1$I TO ptc_admins;
+        REVOKE ALL ON TABLE ptc.%1$I FROM bdit_humans;
+        GRANT SELECT ON TABLE ptc.%1$I TO bdit_humans;
+        $$,
+        year_table,
+        base_table,
+        startdate
+    );
+
+END;
+$BODY$;
+
+COMMENT ON FUNCTION ptc.create_annual_partition(text, integer) IS
+'''Create a new year partition under the parent table `base_table`.
+Only to be used for ptc schema.
+Example: `SELECT ptc.create_annual_partition(''open_data_trips'', 2023)`''';
+
+ALTER FUNCTION ptc.create_annual_partition(text, integer)
+OWNER TO ptc_admins;
+
+GRANT EXECUTE ON FUNCTION ptc.create_annual_partition(text, integer)
+TO ptc_bot;

--- a/vfh/sql/table-ptc_operating_hours.sql
+++ b/vfh/sql/table-ptc_operating_hours.sql
@@ -1,0 +1,69 @@
+CREATE TABLE ptc.open_data_operating_hours (
+    vehid text,
+    hr timestamp with time zone,
+    reported_trips_started smallint,
+    reported_trip_fractions numeric,
+    pooled_trips_started smallint,
+    pooled_trip_fractions numeric,
+    routed_trips_started smallint,
+    driver_cancelled_trips smallint,
+    passenger_cancelled_trips smallint,
+    toronto_boundary_crossed boolean,
+    fares numeric,
+    time_available numeric,
+    time_enroute numeric,
+    time_waiting numeric,
+    time_ontrip numeric,
+    dist_available_routed numeric,
+    dist_enroute_routed numeric,
+    dist_ontrip_routed numeric,
+    dist_ontrip_reported numeric,
+    CONSTRAINT veh_id_hr_pkey PRIMARY KEY (vehid, hr)
+) PARTITION BY RANGE (hr);
+
+ALTER TABLE IF EXISTS ptc.open_data_operating_hours
+OWNER TO ptc_admins;
+
+GRANT ALL ON TABLE ptc.open_data_operating_hours TO ptc_admins;
+
+REVOKE ALL ON TABLE ptc.open_data_operating_hours FROM bdit_humans;
+GRANT SELECT ON TABLE ptc.open_data_operating_hours TO bdit_humans;
+
+GRANT SELECT, INSERT, DELETE ON TABLE ptc.open_data_operating_hours TO ptc_bot;
+
+-- Partitions SQL
+CREATE TABLE ptc.open_data_operating_hours_2020 PARTITION OF ptc.open_data_operating_hours
+FOR VALUES FROM ('2020-01-01 00:00:00') TO ('2021-01-01 00:00:00')
+TABLESPACE pg_default;
+ALTER TABLE IF EXISTS ptc.open_data_operating_hours_2020
+OWNER TO ptc_admins;
+
+CREATE TABLE ptc.open_data_operating_hours_2021 PARTITION OF ptc.open_data_operating_hours
+FOR VALUES FROM ('2021-01-01 00:00:00') TO ('2022-01-01 00:00:00')
+TABLESPACE pg_default;
+ALTER TABLE IF EXISTS ptc.open_data_operating_hours_2021
+OWNER TO ptc_admins;
+
+CREATE TABLE ptc.open_data_operating_hours_2022 PARTITION OF ptc.open_data_operating_hours
+FOR VALUES FROM ('2022-01-01 00:00:00') TO ('2023-01-01 00:00:00')
+TABLESPACE pg_default;
+ALTER TABLE IF EXISTS ptc.open_data_operating_hours_2022
+OWNER TO ptc_admins;
+
+CREATE TABLE ptc.open_data_operating_hours_2023 PARTITION OF ptc.open_data_operating_hours
+FOR VALUES FROM ('2023-01-01 00:00:00') TO ('2024-01-01 00:00:00')
+TABLESPACE pg_default;
+ALTER TABLE IF EXISTS ptc.open_data_operating_hours_2023
+OWNER TO ptc_admins;
+
+CREATE TABLE ptc.open_data_operating_hours_2024 PARTITION OF ptc.open_data_operating_hours
+FOR VALUES FROM ('2024-01-01 00:00:00') TO ('2025-01-01 00:00:00')
+TABLESPACE pg_default;
+ALTER TABLE IF EXISTS ptc.open_data_operating_hours_2024
+OWNER TO ptc_admins;
+
+CREATE TABLE ptc.open_data_operating_hours_2025 PARTITION OF ptc.open_data_operating_hours
+FOR VALUES FROM ('2025-01-01 00:00:00') TO ('2026-01-01 00:00:00')
+TABLESPACE pg_default;
+ALTER TABLE IF EXISTS ptc.open_data_operating_hours_2025
+OWNER TO ptc_admins;

--- a/vfh/sql/table-ptc_operating_hours.sql
+++ b/vfh/sql/table-ptc_operating_hours.sql
@@ -67,3 +67,7 @@ FOR VALUES FROM ('2025-01-01 00:00:00') TO ('2026-01-01 00:00:00')
 TABLESPACE pg_default;
 ALTER TABLE IF EXISTS ptc.open_data_operating_hours_2025
 OWNER TO ptc_admins;
+
+COMMENT ON TABLE ptc.open_data_operating_hours
+IS 'Private Transportation Companies – Vehicle Operating Data 
+For documentation refer to: https://open.toronto.ca/dataset/private-transportation-companies-vehicle-operating-data/';

--- a/vfh/sql/table-ptc_summary_table.sql
+++ b/vfh/sql/table-ptc_summary_table.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS ptc.open_data_summary (
+    dt date,
+    reported_trips_started bigint,
+    trips_started_wav smallint,
+    trips_started_nonwav bigint,
+    trips_started_pooled bigint,
+    trips_cancelled_driver_wav smallint,
+    trips_cancelled_driver_nonwav bigint,
+    trips_cancelled_passenger_wav smallint,
+    trips_cancelled_passenger_nonwav bigint,
+    dist_avg numeric,
+    fare_avg numeric,
+    waittime_wav_avg numeric,
+    waittime_nonwav_avg numeric,
+    active_vehicles bigint,
+    time_available numeric,
+    time_enroute numeric,
+    time_waiting numeric,
+    time_ontrip numeric,
+    dist_available_routed numeric,
+    dist_enroute_routed numeric,
+    dist_ontrip_routed numeric,
+    dist_ontrip_reported numeric,
+    percent_time_available numeric,
+    percent_time_enroute numeric,
+    percent_time_waiting numeric,
+    percent_time_ontrip numeric,
+    percent_dist_available_routed numeric,
+    percent_dist_enroute_routed numeric,
+    percent_dist_ontrip_routed numeric,
+    CONSTRAINT open_data_summ PRIMARY KEY (dt)
+);
+
+ALTER TABLE IF EXISTS ptc.open_data_summary
+OWNER TO ptc_admins;
+GRANT ALL ON TABLE ptc.open_data_summary TO ptc_admins;
+
+REVOKE ALL ON TABLE ptc.open_data_summary FROM bdit_humans;
+GRANT SELECT ON TABLE ptc.open_data_summary TO bdit_humans;
+
+GRANT SELECT, INSERT, DELETE ON TABLE ptc.open_data_summary TO ptc_bot;

--- a/vfh/sql/table-ptc_summary_table.sql
+++ b/vfh/sql/table-ptc_summary_table.sql
@@ -39,3 +39,7 @@ REVOKE ALL ON TABLE ptc.open_data_summary FROM bdit_humans;
 GRANT SELECT ON TABLE ptc.open_data_summary TO bdit_humans;
 
 GRANT SELECT, INSERT, DELETE ON TABLE ptc.open_data_summary TO ptc_bot;
+
+COMMENT ON TABLE ptc.open_data_summary
+IS 'Private Transportation Companies - Summary Data
+For documentation refer to: https://open.toronto.ca/dataset/private-transportation-companies-summary-and-trip-data/';

--- a/vfh/sql/table-ptc_trips.sql
+++ b/vfh/sql/table-ptc_trips.sql
@@ -1,0 +1,93 @@
+-- DROP TABLE IF EXISTS ptc.open_data_trips;
+
+CREATE TABLE IF NOT EXISTS ptc.open_data_trips (
+    dt date,
+    pickup_hr timestamp with time zone,
+    pickup_municipality text,
+    pickup_community_council text,
+    pickup_ward text,
+    dropoff_municipality text,
+    dropoff_community_council text,
+    dropoff_ward text,
+    trips_total smallint,
+    fare_avg numeric,
+    distance_avg numeric,
+    waittime_avg numeric,
+    duration_avg numeric,
+    CONSTRAINT open_data_trips_unique UNIQUE (
+        dt, pickup_hr, pickup_municipality, pickup_community_council, pickup_ward,
+        dropoff_municipality, dropoff_community_council, dropoff_ward
+    )
+) PARTITION BY RANGE (dt);
+
+ALTER TABLE IF EXISTS ptc.open_data_trips
+OWNER TO ptc_admins;
+GRANT ALL ON TABLE ptc.open_data_trips TO ptc_admins;
+
+REVOKE ALL ON TABLE ptc.open_data_trips FROM bdit_humans;
+GRANT SELECT ON TABLE ptc.open_data_trips TO bdit_humans;
+
+GRANT SELECT, INSERT, DELETE ON TABLE ptc.open_data_trips TO ptc_bot;
+
+-- Partitions SQL
+
+CREATE TABLE ptc.open_data_trips_2016 PARTITION OF ptc.open_data_trips
+FOR VALUES FROM ('2016-01-01') TO ('2017-01-01')
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS ptc.open_data_trips_2016
+OWNER to ptc_admins;
+CREATE TABLE ptc.open_data_trips_2017 PARTITION OF ptc.open_data_trips
+FOR VALUES FROM ('2017-01-01') TO ('2018-01-01')
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS ptc.open_data_trips_2017
+OWNER to ptc_admins;
+CREATE TABLE ptc.open_data_trips_2018 PARTITION OF ptc.open_data_trips
+FOR VALUES FROM ('2018-01-01') TO ('2019-01-01')
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS ptc.open_data_trips_2018
+OWNER to ptc_admins;
+CREATE TABLE ptc.open_data_trips_2019 PARTITION OF ptc.open_data_trips
+FOR VALUES FROM ('2019-01-01') TO ('2020-01-01')
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS ptc.open_data_trips_2019
+OWNER to ptc_admins;
+CREATE TABLE ptc.open_data_trips_2020 PARTITION OF ptc.open_data_trips
+FOR VALUES FROM ('2020-01-01') TO ('2021-01-01')
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS ptc.open_data_trips_2020
+OWNER to ptc_admins;
+CREATE TABLE ptc.open_data_trips_2021 PARTITION OF ptc.open_data_trips
+FOR VALUES FROM ('2021-01-01') TO ('2022-01-01')
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS ptc.open_data_trips_2021
+OWNER to ptc_admins;
+CREATE TABLE ptc.open_data_trips_2022 PARTITION OF ptc.open_data_trips
+FOR VALUES FROM ('2022-01-01') TO ('2023-01-01')
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS ptc.open_data_trips_2022
+OWNER to ptc_admins;
+CREATE TABLE ptc.open_data_trips_2023 PARTITION OF ptc.open_data_trips
+FOR VALUES FROM ('2023-01-01') TO ('2024-01-01')
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS ptc.open_data_trips_2023
+OWNER to ptc_admins;
+CREATE TABLE ptc.open_data_trips_2024 PARTITION OF ptc.open_data_trips
+FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS ptc.open_data_trips_2024
+OWNER to ptc_admins;
+CREATE TABLE ptc.open_data_trips_2025 PARTITION OF ptc.open_data_trips
+FOR VALUES FROM ('2025-01-01') TO ('2026-01-01')
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS ptc.open_data_trips_2025
+OWNER to ptc_admins;

--- a/vfh/sql/table-ptc_trips.sql
+++ b/vfh/sql/table-ptc_trips.sql
@@ -36,58 +36,62 @@ FOR VALUES FROM ('2016-01-01') TO ('2017-01-01')
 TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS ptc.open_data_trips_2016
-OWNER to ptc_admins;
+OWNER TO ptc_admins;
 CREATE TABLE ptc.open_data_trips_2017 PARTITION OF ptc.open_data_trips
 FOR VALUES FROM ('2017-01-01') TO ('2018-01-01')
 TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS ptc.open_data_trips_2017
-OWNER to ptc_admins;
+OWNER TO ptc_admins;
 CREATE TABLE ptc.open_data_trips_2018 PARTITION OF ptc.open_data_trips
 FOR VALUES FROM ('2018-01-01') TO ('2019-01-01')
 TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS ptc.open_data_trips_2018
-OWNER to ptc_admins;
+OWNER TO ptc_admins;
 CREATE TABLE ptc.open_data_trips_2019 PARTITION OF ptc.open_data_trips
 FOR VALUES FROM ('2019-01-01') TO ('2020-01-01')
 TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS ptc.open_data_trips_2019
-OWNER to ptc_admins;
+OWNER TO ptc_admins;
 CREATE TABLE ptc.open_data_trips_2020 PARTITION OF ptc.open_data_trips
 FOR VALUES FROM ('2020-01-01') TO ('2021-01-01')
 TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS ptc.open_data_trips_2020
-OWNER to ptc_admins;
+OWNER TO ptc_admins;
 CREATE TABLE ptc.open_data_trips_2021 PARTITION OF ptc.open_data_trips
 FOR VALUES FROM ('2021-01-01') TO ('2022-01-01')
 TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS ptc.open_data_trips_2021
-OWNER to ptc_admins;
+OWNER TO ptc_admins;
 CREATE TABLE ptc.open_data_trips_2022 PARTITION OF ptc.open_data_trips
 FOR VALUES FROM ('2022-01-01') TO ('2023-01-01')
 TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS ptc.open_data_trips_2022
-OWNER to ptc_admins;
+OWNER TO ptc_admins;
 CREATE TABLE ptc.open_data_trips_2023 PARTITION OF ptc.open_data_trips
 FOR VALUES FROM ('2023-01-01') TO ('2024-01-01')
 TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS ptc.open_data_trips_2023
-OWNER to ptc_admins;
+OWNER TO ptc_admins;
 CREATE TABLE ptc.open_data_trips_2024 PARTITION OF ptc.open_data_trips
 FOR VALUES FROM ('2024-01-01') TO ('2025-01-01')
 TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS ptc.open_data_trips_2024
-OWNER to ptc_admins;
+OWNER TO ptc_admins;
 CREATE TABLE ptc.open_data_trips_2025 PARTITION OF ptc.open_data_trips
 FOR VALUES FROM ('2025-01-01') TO ('2026-01-01')
 TABLESPACE pg_default;
 
 ALTER TABLE IF EXISTS ptc.open_data_trips_2025
-OWNER to ptc_admins;
+OWNER TO ptc_admins;
+
+COMMENT ON TABLE ptc.open_data_trips
+IS 'Private Transportation Companies - Trip Data
+For documentation refer to: https://open.toronto.ca/dataset/private-transportation-companies-summary-and-trip-data/';


### PR DESCRIPTION
## What this pull request accomplishes:

- add PTC open data table definitions to bigdata
- PTC Open data gets copied over to bigdata from bancroft as part of the `open_data_*_export` pipelines. 

## Issue(s) this solves:

- #1365 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
