### PR TITLE
#1379 switch gis_core mat view refresh functions to plpgsql for dynamic comment capability

### DIFF
--- a/gis/centreline/sql/functions/function-refresh_centreline_intersection_point_latest.sql
+++ b/gis/centreline/sql/functions/function-refresh_centreline_intersection_point_latest.sql
@@ -1,10 +1,15 @@
-CREATE FUNCTION gis_core.refresh_centreline_intersection_point_latest()
+-- FUNCTION: gis_core.refresh_centreline_intersection_point_latest()
+
+-- DROP FUNCTION IF EXISTS gis_core.refresh_centreline_intersection_point_latest();
+
+CREATE OR REPLACE FUNCTION gis_core.refresh_centreline_intersection_point_latest()
 RETURNS void
-LANGUAGE sql
+LANGUAGE 'plpgsql'
 COST 100
 VOLATILE SECURITY DEFINER PARALLEL UNSAFE
-AS $$
+AS $BODY$
 
+BEGIN
 TRUNCATE gis_core.centreline_intersection_point_latest;
 
 --in case of duplicate intersection_id (rare), only take the latest by objectid
@@ -27,18 +32,25 @@ ORDER BY
     intersection_id ASC,
     objectid DESC;
 
-COMMENT ON TABLE gis_core.centreline_intersection_point_latest IS E''
-'Table containing the latest version of centreline intersection point,'
-'derived from gis_core.centreline_intersection_point. Removes some (rare) duplicate intersection_ids.'
-|| ' Last refreshed: ' || CURRENT_DATE || '.';
+EXECUTE format(
+    $msg$
+    COMMENT ON TABLE gis_core.centreline_intersection_point_latest IS
+    'Table containing the latest version of centreline intersection point, derived from gis_core.centreline_intersection_point. Removes some (rare) duplicate intersection_ids. Last refreshed: %s.'
+    $msg$,
+    CURRENT_DATE
+);
 
-$$;
+END;
+$BODY$;
 
-ALTER FUNCTION gis_core.refresh_centreline_intersection_point_latest OWNER TO gis_admins;
+ALTER FUNCTION gis_core.refresh_centreline_intersection_point_latest()
+OWNER TO gis_admins;
 
-GRANT EXECUTE ON gis_core.refresh_centreline_intersection_point_latest TO gcc_bot;
+GRANT EXECUTE ON FUNCTION gis_core.refresh_centreline_intersection_point_latest() TO gcc_bot;
 
-REVOKE ALL ON FUNCTION gis_core.refresh_centreline_intersection_point_latest FROM public;
+GRANT EXECUTE ON FUNCTION gis_core.refresh_centreline_intersection_point_latest() TO gis_admins;
 
-COMMENT ON FUNCTION gis_core.refresh_centreline_intersection_point_latest
+REVOKE ALL ON FUNCTION gis_core.refresh_centreline_intersection_point_latest() FROM public;
+
+COMMENT ON FUNCTION gis_core.refresh_centreline_intersection_point_latest()
 IS 'Function to refresh gis_core.centreline_intersection_point_latest with truncate/insert.';

--- a/gis/centreline/sql/functions/function-refresh_centreline_latest.sql
+++ b/gis/centreline/sql/functions/function-refresh_centreline_latest.sql
@@ -1,9 +1,15 @@
-CREATE OR REPLACE FUNCTION gis_core.refresh_centreline_latest() AS
+-- FUNCTION: gis_core.refresh_centreline_latest()
+
+-- DROP FUNCTION IF EXISTS gis_core.refresh_centreline_latest();
+
+CREATE OR REPLACE FUNCTION gis_core.refresh_centreline_latest()
 RETURNS void
-LANGUAGE sql
+LANGUAGE 'plpgsql'
 COST 100
 VOLATILE SECURITY DEFINER PARALLEL UNSAFE
-AS $$
+AS $BODY$
+
+BEGIN
 
 TRUNCATE gis_core.centreline_latest;
 
@@ -32,17 +38,25 @@ WHERE
         'Pending'
     );
 
-COMMENT ON TABLE gis_core.centreline_latest
-IS 'Table containing the latest version of centreline, derived from gis_core.centreline, excluding Busway and Trail.'
-|| ' Last refreshed: ' || CURRENT_DATE || '.';
+EXECUTE format(
+    $msg$
+    COMMENT ON TABLE gis_core.centreline_latest IS
+    'Table containing the latest version of centreline, derived from gis_core.centreline, excluding Busway and Trail. Last refreshed: %s.'
+    $msg$,
+    CURRENT_DATE
+);
 
-$$;
+END;
+$BODY$;
 
-ALTER FUNCTION gis_core.refresh_centreline_latest OWNER TO gis_admins;
+ALTER FUNCTION gis_core.refresh_centreline_latest()
+OWNER TO gis_admins;
 
-GRANT EXECUTE ON FUNCTION gis_core.refresh_centreline_latest TO gcc_bot;
+GRANT EXECUTE ON FUNCTION gis_core.refresh_centreline_latest() TO gcc_bot;
 
-REVOKE ALL ON FUNCTION gis_core.refresh_centreline_latest FROM public;
+GRANT EXECUTE ON FUNCTION gis_core.refresh_centreline_latest() TO gis_admins;
 
-COMMENT ON FUNCTION gis_core.refresh_centreline_latest
+REVOKE ALL ON FUNCTION gis_core.refresh_centreline_latest() FROM public;
+
+COMMENT ON FUNCTION gis_core.refresh_centreline_latest()
 IS 'Function to refresh gis_core.centreline_latest with truncate/insert.';

--- a/gis/centreline/sql/functions/function-refresh_centreline_latest_all_feature.sql
+++ b/gis/centreline/sql/functions/function-refresh_centreline_latest_all_feature.sql
@@ -1,9 +1,15 @@
+-- FUNCTION: gis_core.refresh_centreline_latest_all_feature()
+
+-- DROP FUNCTION IF EXISTS gis_core.refresh_centreline_latest_all_feature();
+
 CREATE OR REPLACE FUNCTION gis_core.refresh_centreline_latest_all_feature()
 RETURNS void
-LANGUAGE sql
+LANGUAGE 'plpgsql'
 COST 100
 VOLATILE SECURITY DEFINER PARALLEL UNSAFE
-AS $$
+AS $BODY$
+
+BEGIN
 
     TRUNCATE gis_core.centreline_latest_all_feature;
 
@@ -18,15 +24,23 @@ AS $$
             FROM gis_core.centreline
         );
 
-    COMMENT ON TABLE gis_core.centreline_latest_all_feature
-    IS 'Table containing the latest version of centreline with all feature code, derived from gis_core.centreline.'
-    || ' Last refreshed: ' || CURRENT_DATE || '.';
+EXECUTE format(
+    $msg$
+    COMMENT ON TABLE gis_core.centreline_latest_all_feature IS
+    'Table containing the latest version of centreline with all feature code, derived from gis_core.centreline. Last refreshed: %s.'
+    $msg$,
+    CURRENT_DATE
+);
 
-$$;
+END;
+$BODY$;
 
-ALTER FUNCTION gis_core.refresh_centreline_latest_all_feature OWNER TO gis_admins;
+ALTER FUNCTION gis_core.refresh_centreline_latest_all_feature()
+OWNER TO gis_admins;
 
-GRANT EXECUTE ON gis_core.refresh_centreline_latest_all_feature TO gcc_bot;
+GRANT EXECUTE ON FUNCTION gis_core.refresh_centreline_latest_all_feature() TO gcc_bot;
+
+GRANT EXECUTE ON FUNCTION gis_core.refresh_centreline_latest_all_feature() TO gis_admins;
 
 REVOKE ALL ON FUNCTION gis_core.refresh_centreline_latest_all_feature() FROM public;
 

--- a/gis/centreline/sql/functions/function-refresh_centreline_leg_directions.sql
+++ b/gis/centreline/sql/functions/function-refresh_centreline_leg_directions.sql
@@ -1,11 +1,15 @@
---DROP FUNCTION gis_core.refresh_centreline_leg_directions;
+-- FUNCTION: gis_core.refresh_centreline_leg_directions()
 
-CREATE FUNCTION gis_core.refresh_centreline_leg_directions()
+-- DROP FUNCTION IF EXISTS gis_core.refresh_centreline_leg_directions();
+
+CREATE OR REPLACE FUNCTION gis_core.refresh_centreline_leg_directions()
 RETURNS void
-LANGUAGE sql
+LANGUAGE 'plpgsql'
 COST 100
 VOLATILE SECURITY DEFINER PARALLEL UNSAFE
-AS $$
+AS $BODY$
+
+BEGIN
 
 TRUNCATE gis_core.centreline_leg_directions;
 
@@ -263,7 +267,9 @@ The final select adds names from the edge table, and also removes
 (via DISTINCT ON) legs assigned to more than one direction
 (this will happen in the fourth pass for intersections with 3 legs).
 */
-INSERT INTO gis_core.centreline_leg_directions (intersection_centreline_id, leg_centreline_id, leg, intersection_geom, street_name, angular_offset_from_cardinal_direction, leg_stub_geom, leg_full_geom)
+INSERT INTO gis_core.centreline_leg_directions (
+    intersection_centreline_id, leg_centreline_id, leg, intersection_geom, street_name, angular_offset_from_cardinal_direction, leg_stub_geom, leg_full_geom
+)
 SELECT DISTINCT ON (
     unified_legs.intersection_centreline_id,
     unified_legs.leg_centreline_id
@@ -286,17 +292,25 @@ ORDER BY
     -- take the best match of any repeatedly assigned legs
     unified_legs.angular_distance ASC;
 
-COMMENT ON TABLE gis_core.centreline_leg_directions
-IS 'Automated mapping of centreline intersection legs onto the four cardinal directions. Please report any issues/inconsistencies with this view here: https://github.com/CityofToronto/bdit_data-sources/issues/1190'
-|| ' Last refreshed: ' || CURRENT_DATE || '.';
+EXECUTE format(
+    $msg$
+    COMMENT ON TABLE gis_core.centreline_leg_directions IS 'Automated mapping of centreline intersection legs onto the four cardinal directions. Please report any issues/inconsistencies with this view here: https://github.com/CityofToronto/bdit_data-sources/issues/1190. Last refreshed: %s.'
+    $msg$,
+    CURRENT_DATE
+);
 
-$$;
+END;
 
-ALTER FUNCTION gis_core.refresh_centreline_leg_directions OWNER TO gis_admins;
+$BODY$;
 
-GRANT EXECUTE ON FUNCTION gis_core.refresh_centreline_leg_directions TO gcc_bot;
+ALTER FUNCTION gis_core.refresh_centreline_leg_directions()
+OWNER TO gis_admins;
 
-REVOKE ALL ON FUNCTION gis_core.refresh_centreline_leg_directions FROM public;
+GRANT EXECUTE ON FUNCTION gis_core.refresh_centreline_leg_directions() TO gcc_bot;
 
-COMMENT ON FUNCTION gis_core.refresh_centreline_leg_directions
-IS 'Function to refresh gis_core.centreline_leg_directions with truncate/insert.';
+GRANT EXECUTE ON FUNCTION gis_core.refresh_centreline_leg_directions() TO gis_admins;
+
+REVOKE ALL ON FUNCTION gis_core.refresh_centreline_leg_directions() FROM public;
+
+COMMENT ON FUNCTION gis_core.refresh_centreline_leg_directions()
+IS 'Function to refresh gis_core.refresh_centreline_leg_directions with truncate/insert.';

--- a/gis/centreline/sql/functions/function-refresh_intersection_latest.sql
+++ b/gis/centreline/sql/functions/function-refresh_intersection_latest.sql
@@ -1,9 +1,15 @@
-CREATE FUNCTION gis_core.refresh_intersection_latest()
+-- FUNCTION: gis_core.refresh_intersection_latest()
+
+-- DROP FUNCTION IF EXISTS gis_core.refresh_intersection_latest();
+
+CREATE OR REPLACE FUNCTION gis_core.refresh_intersection_latest()
 RETURNS void
-LANGUAGE sql
+LANGUAGE 'plpgsql'
 COST 100
 VOLATILE SECURITY DEFINER PARALLEL UNSAFE
-AS $$
+AS $BODY$
+
+BEGIN
 
 TRUNCATE gis_core.intersection_latest;
 
@@ -23,18 +29,24 @@ WHERE
         FROM gis_core.intersection
     );
 
-COMMENT ON TABLE gis_core.intersection_latest IS E''
-'Table containing the latest version of intersection,'
-'derived from gis_core.intersection.'
-|| ' Last refreshed: ' || CURRENT_DATE || '.';
+EXECUTE format(
+    $msg$
+    COMMENT ON TABLE gis_core.intersection_latest IS 'Table containing the latest version of intersection, derived from gis_core.intersection. Last refreshed: %s.'
+    $msg$,
+    CURRENT_DATE
+);
 
-$$;
+END;
+$BODY$;
 
-ALTER FUNCTION gis_core.refresh_intersection_latest OWNER TO gis_admins;
+ALTER FUNCTION gis_core.refresh_intersection_latest()
+OWNER TO gis_admins;
 
-GRANT EXECUTE ON gis_core.refresh_intersection_latest TO gcc_bot;
+GRANT EXECUTE ON FUNCTION gis_core.refresh_intersection_latest() TO gcc_bot;
 
-REVOKE ALL ON FUNCTION gis_core.refresh_intersection_latest FROM public;
+GRANT EXECUTE ON FUNCTION gis_core.refresh_intersection_latest() TO gis_admins;
 
-COMMENT ON FUNCTION gis_core.refresh_intersection_latest
+REVOKE ALL ON FUNCTION gis_core.refresh_intersection_latest() FROM public;
+
+COMMENT ON FUNCTION gis_core.refresh_intersection_latest()
 IS 'Function to refresh gis_core.centreline_latest_all_feature with truncate/insert.';

--- a/gis/centreline/sql/functions/function-refresh_svc_centreline_directions.sql
+++ b/gis/centreline/sql/functions/function-refresh_svc_centreline_directions.sql
@@ -1,8 +1,10 @@
+-- FUNCTION: traffic.refresh_svc_centreline_directions()
+
 -- DROP FUNCTION IF EXISTS traffic.refresh_svc_centreline_directions();
 
 CREATE OR REPLACE FUNCTION traffic.refresh_svc_centreline_directions()
 RETURNS void
-LANGUAGE sql
+LANGUAGE 'plpgsql'
 COST 100
 VOLATILE SECURITY DEFINER PARALLEL UNSAFE
 AS $BODY$
@@ -22,6 +24,8 @@ unlikely combinations are kept just in case.
 As such, this view should be joined on the actual directions assigned to SVCs
 rather than used on its own. Such a join *should* filter out most silly values.
 */
+
+BEGIN
 
 TRUNCATE traffic.svc_centreline_directions;
 
@@ -83,11 +87,18 @@ WHERE
     ad.angular_distance < radians(80)
     OR ad.angular_distance > radians(100);
 
-COMMENT ON TABLE traffic.svc_centreline_directions
-IS 'Maps the four cardinal directions (NB, SB, EB, & WB) referenced by SVCs onto '
-'specific directions of travel along edges of the `gis_core.centreline_latest` network. '
-'Refreshed automatically by `gcc_layers_pull_bigdata` DAG after inserts into '
-'`gis_core.centreline_latest`.' || ' Last refreshed: ' || CURRENT_DATE || '.';
+EXECUTE format(
+    $msg$
+    COMMENT ON TABLE traffic.svc_centreline_directions
+    IS 'Maps the four cardinal directions (NB, SB, EB, & WB) referenced by SVCs onto '
+    'specific directions of travel along edges of the `gis_core.centreline_latest` network. '
+    'Refreshed automatically by `gcc_layers_pull_bigdata` DAG after inserts into '
+    '`gis_core.centreline_latest`. Last refreshed: %s'
+    $msg$,
+    CURRENT_DATE
+);
+
+END;
 
 $BODY$;
 
@@ -95,6 +106,8 @@ ALTER FUNCTION traffic.refresh_svc_centreline_directions()
 OWNER TO gis_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.refresh_svc_centreline_directions() TO gcc_bot;
+
+GRANT EXECUTE ON FUNCTION traffic.refresh_svc_centreline_directions() TO gis_admins;
 
 GRANT EXECUTE ON FUNCTION traffic.refresh_svc_centreline_directions() TO traffic_admins;
 


### PR DESCRIPTION
## What this pull request accomplishes:

- switch functions to plpgsql for dynamic comment capability
- (made this change earlier but forgot to add to https://github.com/CityofToronto/bdit_data-sources/pull/1360 before merging)


## Issue(s) this solves:

- #1379 

## What, in particular, needs to reviewed:

- nothing, changes tested this morning via gcc_pull_layers_bigdata
 
## What needs to be done by a sysadmin after this PR is merged

Nothing