### PR TITLE
#1385 update dependabot 'airflow' to 'apache-airflow'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,4 +25,4 @@ updates:
     cooldown:
       default-days: 7
     allow:
-      - dependency-name: "airflow"
+      - dependency-name: "apache-airflow"


### PR DESCRIPTION
## What this pull request accomplishes:

- update airflow dependabot notification 
- it is `apache-airflow` on pypi: https://pypi.org/project/apache-airflow/

## Issue(s) this solves:

- Closes #1385 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
