### PR TITLE
#1407 Re-enable local execution of miovision intersection_tmc backfill with local config

### DIFF
--- a/dags/miovision_pull.py
+++ b/dags/miovision_pull.py
@@ -22,7 +22,7 @@ try:
     from bdit_dag_utils.utils.custom_operators import SQLCheckOperatorWithReturnValue
     from bdit_dag_utils.utils.common_tasks import check_jan_1st, check_1st_of_month, wait_for_weather_timesensor
     from volumes.miovision.api.intersection_tmc import (
-        run_api, find_gaps, aggregate_15_min_mvt, aggregate_15_min, aggregate_volumes_daily,
+        run_api, find_gaps, aggregate_15_min_mvt, aggregate_volumes_daily,
         get_intersection_info, agg_zero_volume_anomalous_ranges
     )
     from volumes.miovision.api.pull_alert import run_alerts_api

--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -613,6 +613,7 @@ def get_connection(path=None):
         key = api_key.extra_dejson['key']
         mio_postgres = PostgresHook("miovision_api_bot")
         conn = mio_postgres.get_conn()
+        conn.autocommit = True
         return conn, key
 
     except AirflowNotFoundException:

--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -295,7 +295,6 @@ def process_data(conn, start_time, end_time, intersections):
     find_gaps(conn, time_period, intersections)
     aggregate_15_min_mvt(conn, time_period, intersections)
     agg_zero_volume_anomalous_ranges(conn, time_period, intersections)
-    aggregate_15_min(conn, time_period, intersections)
     aggregate_volumes_daily(conn, time_period, intersections)
 
 def find_gaps(conn, time_period, intersections = None):
@@ -345,38 +344,6 @@ def aggregate_15_min_mvt(
                 cur.execute(update, query_params)
                 logger.info('Aggregated intersections %s to 15 minute movement bins',
                             [x.uid for x in intersections]) 
-    except psycopg2.Error as exc:
-        logger.exception(exc)
-        sys.exit(1)
-
-def aggregate_15_min(
-        conn, time_period, intersections = None
-):
-    """Aggregate into miovision_api.volumes_15min.
-
-    First clears previous inserts for the date range and
-    sets processed column to null for corresponding values in
-    volumes_15min_mvt. Takes optional intersection param to 
-    specify certain intersections to clear/aggregate.
-    """
-    try:
-        with conn.cursor() as cur:
-            if intersections is None:
-                delete_sql="SELECT miovision_api.clear_volumes_15min(%s::timestamp, %s::timestamp);"
-                cur.execute(delete_sql, time_period)
-                atr_aggregation="SELECT miovision_api.aggregate_15_min(%s::date, %s::date)"
-                cur.execute(atr_aggregation, time_period)
-                logger.info('Completed aggregating into miovision_api.volumes_15min for %s to %s',
-                            time_period[0], time_period[1])
-            else:
-                query_params = time_period + ([x.uid for x in intersections], )
-                delete_sql="SELECT miovision_api.clear_volumes_15min(%s::timestamp, %s::timestamp, %s::integer []);"
-                cur.execute(delete_sql, query_params)
-                update="""SELECT miovision_api.aggregate_15_min(
-                            %s::date, %s::date, %s::integer []);"""
-                cur.execute(update, query_params)
-                logger.info('Completed aggregating intersections %s into miovision_api.volumes_15min for %s to %s',
-                            [x.uid for x in intersections], time_period[0], time_period[1])
     except psycopg2.Error as exc:
         logger.exception(exc)
         sys.exit(1)

--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -75,7 +75,7 @@ def cli():
 def run_api_cli(start_date, end_date, intersection, pull, agg, path):
     return run_api(start_date, end_date, intersection, pull, agg, path)
 
-def run_api(start_date, end_date, intersection, pull, agg, path):
+def run_api(start_date, end_date, intersection, pull, agg, path=None):
     conn, key = get_connection(path=path)
     start_date = dateutil.parser.parse(str(start_date))
     end_date = dateutil.parser.parse(str(end_date))

--- a/volumes/miovision/api/intersection_tmc.py
+++ b/volumes/miovision/api/intersection_tmc.py
@@ -11,9 +11,11 @@ import click
 import traceback
 from time import sleep
 from collections import namedtuple
+import configparser
 
 from airflow.sdk.bases.hook import BaseHook
 from airflow.providers.postgres.hooks.postgres import PostgresHook
+from airflow.exceptions import AirflowNotFoundException
 
 class BreakingError(Exception):
     """Base class for exceptions that immediately halt API pulls."""
@@ -68,21 +70,19 @@ def cli():
 @click.option('--intersection' , multiple=True, help='enter the intersection_uid of the intersection')
 @click.option('--pull' , is_flag=True, help='Use flag to run data pull.')
 @click.option('--agg' , is_flag=True, help='Use flag to run data processing.')
+@click.option('--path' , default='/data/airflow/data_scripts/bdit_data-sources/volumes/miovision/api/config.cfg', help='enter the path/directory of the config.cfg file')
 
-def run_api_cli(start_date, end_date, intersection, pull, agg):
-    return run_api(start_date, end_date, intersection, pull, agg)
+def run_api_cli(start_date, end_date, intersection, pull, agg, path):
+    return run_api(start_date, end_date, intersection, pull, agg, path)
 
-def run_api(start_date, end_date, intersection, pull, agg):
-    api_key = BaseHook.get_connection('miovision_api_key')
-    key = api_key.extra_dejson['key']
-    mio_postgres = PostgresHook("miovision_api_bot")
+def run_api(start_date, end_date, intersection, pull, agg, path):
+    conn, key = get_connection(path=path)
     start_date = dateutil.parser.parse(str(start_date))
     end_date = dateutil.parser.parse(str(end_date))
     if pull:
         try:
             logger.info('Pulling from %s to %s' %(start_date, end_date))
-            with mio_postgres.get_conn() as conn:
-                pull_data(conn, start_date, end_date, intersection, key)
+            pull_data(conn, start_date, end_date, intersection, key)
         except Exception as e:
             logger.critical(traceback.format_exc())
             sys.exit(1)
@@ -90,9 +90,8 @@ def run_api(start_date, end_date, intersection, pull, agg):
         logger.info('Skipping pulling volume data.')
     if agg:
         logger.info('Aggregating data from %s to %s' %(start_date, end_date))
-        with mio_postgres.get_conn() as conn:
-            intersections = get_intersection_info(conn, intersection)
-            process_data(conn, start_date, end_date, intersections=intersections)
+        intersections = get_intersection_info(conn, intersection)
+        process_data(conn, start_date, end_date, intersections=intersections)
     else:
         logger.info('Skipping aggregating and processing volume data')
 
@@ -636,6 +635,30 @@ def pull_data(conn, start_time, end_time, intersection, key):
             logger.exception(exc)
             sys.exit(1)
     logger.info('Done pulling data.')
+
+def get_connection(path=None):
+    """
+    Returns (conn, key). Uses Airflow hooks if running in Airflow,
+    otherwise falls back to a local config file.
+    """
+    try:
+        api_key = BaseHook.get_connection('miovision_api_key')
+        key = api_key.extra_dejson['key']
+        mio_postgres = PostgresHook("miovision_api_bot")
+        conn = mio_postgres.get_conn()
+        return conn, key
+
+    except AirflowNotFoundException:
+        if path is None:
+            raise ValueError("Must provide a config path when running locally.")
+
+        CONFIG = configparser.ConfigParser()
+        CONFIG.read(path)
+        key = CONFIG['API']['key']
+        dbset = CONFIG['DBSETTINGS']
+        conn = psycopg2.connect(**dbset)
+        conn.autocommit = True
+        return conn, key
 
 if __name__ == '__main__':
     cli()

--- a/volumes/miovision/api/readme.md
+++ b/volumes/miovision/api/readme.md
@@ -130,6 +130,7 @@ In command prompt, navigate to the folder where the python file is [located](../
 |intersection|integer|Specifies the `intersection_uid` from the `miovision_api.intersections` table to pull data for. Multiple allowed. |12|Pulls data for all intersection|
 |pull|BOOLEAN flag|Use flag to run data pull.|--pull|false|
 |agg|BOOLEAN flag|Use flag to run data processing.|--agg|false|
+|path|path|Specifies the directory where the config.cfg file is.|config.cfg|/data/airflow/data_scripts/bdit_data-sources/volumes/miovision/api/config.cfg|
 
 `python3 intersection_tmc.py run-api-cli --pull --agg --start_date=2018-08-01 --end_date=2018-08-05 --intersection=10 --intersection=12` is an example with all the options specified:  
 - both data pulling and aggregation specified


### PR DESCRIPTION
## What this pull request accomplishes:

- add `get_connection` function to enable both Airflow connections and local config connections for `cli` backfilling
  - successfully tested both methods ✅ 
- remove unused `aggregate_15_min` (previously deprecated but not removed)

## Issue(s) this solves:

- Closes #1407

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
