### PR TITLE
1410 update queens quay flow info

### DIFF
--- a/volumes/ecocounter/updates/ecocounter_update_queens_quay_flow.sql
+++ b/volumes/ecocounter/updates/ecocounter_update_queens_quay_flow.sql
@@ -13,7 +13,7 @@ FROM (
     (353706302, 'Westbound', 'Eastbound'::gwolofs.travel_directions, 'scooter'),
     (353706303, 'Eastbound', 'Westbound'::gwolofs.travel_directions, 'bike'),
     (353706304, 'Westbound', 'Westbound'::gwolofs.travel_directions, 'bike'),
-    (353706305, 'Westbound', 'Westbound'::gwolofs.travel_directions, 'scooter'),
-    (353706306, 'Eastbound', 'Westbound'::gwolofs.travel_directions, 'scooter')
+    (353706305, 'Eastbound', 'Westbound'::gwolofs.travel_directions, 'scooter'),
+    (353706306, 'Westbound', 'Westbound'::gwolofs.travel_directions, 'scooter')
 ) AS vals(flow_id, flow_direction, direction_main, mode_counted)
 WHERE vals.flow_id = fu.flow_id;

--- a/volumes/ecocounter/updates/ecocounter_update_queens_quay_flow.sql
+++ b/volumes/ecocounter/updates/ecocounter_update_queens_quay_flow.sql
@@ -2,18 +2,18 @@ UPDATE ecocounter.flows_unfiltered AS fu
 SET
     flow_direction = vals.flow_direction,
     direction_main = vals.direction_main,
-    includes_contraflow = vals.includes_contraflow,
-    validated = vals.validated,
+    includes_contraflow = FALSE,
+    validated = FALSE,
     mode_counted = vals.mode_counted
 FROM (
     VALUES
-    (353706300, 'Westbound', 'Eastbound'::gwolofs.travel_directions, TRUE,  FALSE, 'bike'),
-    (353706299, 'Eastbound', 'Eastbound'::gwolofs.travel_directions, FALSE, FALSE, 'bike'),
-    (353706301, 'Eastbound', 'Eastbound'::gwolofs.travel_directions, FALSE, FALSE, 'scooter'),
-    (353706302, 'Westbound', 'Eastbound'::gwolofs.travel_directions, TRUE,  FALSE, 'scooter'),
-    (353706303, 'Westbound', 'Westbound'::gwolofs.travel_directions, FALSE, FALSE, 'bike'),
-    (353706304, 'Eastbound', 'Westbound'::gwolofs.travel_directions, TRUE,  FALSE, 'bike'),
-    (353706305, 'Westbound', 'Westbound'::gwolofs.travel_directions, FALSE, FALSE, 'scooter'),
-    (353706306, 'Eastbound', 'Westbound'::gwolofs.travel_directions, TRUE,  FALSE, 'scooter')
-) AS vals(flow_id, flow_direction, direction_main, includes_contraflow, validated, mode_counted)
+    (353706300, 'Westbound', 'Eastbound'::gwolofs.travel_directions, 'bike'),
+    (353706299, 'Eastbound', 'Eastbound'::gwolofs.travel_directions, 'bike'),
+    (353706301, 'Eastbound', 'Eastbound'::gwolofs.travel_directions, 'scooter'),
+    (353706302, 'Westbound', 'Eastbound'::gwolofs.travel_directions, 'scooter'),
+    (353706303, 'Westbound', 'Westbound'::gwolofs.travel_directions, 'bike'),
+    (353706304, 'Eastbound', 'Westbound'::gwolofs.travel_directions, 'bike'),
+    (353706305, 'Westbound', 'Westbound'::gwolofs.travel_directions, 'scooter'),
+    (353706306, 'Eastbound', 'Westbound'::gwolofs.travel_directions, 'scooter')
+) AS vals(flow_id, flow_direction, direction_main, mode_counted)
 WHERE vals.flow_id = fu.flow_id;

--- a/volumes/ecocounter/updates/ecocounter_update_queens_quay_flow.sql
+++ b/volumes/ecocounter/updates/ecocounter_update_queens_quay_flow.sql
@@ -11,8 +11,8 @@ FROM (
     (353706299, 'Eastbound', 'Eastbound'::gwolofs.travel_directions, 'bike'),
     (353706301, 'Eastbound', 'Eastbound'::gwolofs.travel_directions, 'scooter'),
     (353706302, 'Westbound', 'Eastbound'::gwolofs.travel_directions, 'scooter'),
-    (353706303, 'Westbound', 'Westbound'::gwolofs.travel_directions, 'bike'),
-    (353706304, 'Eastbound', 'Westbound'::gwolofs.travel_directions, 'bike'),
+    (353706303, 'Eastbound', 'Westbound'::gwolofs.travel_directions, 'bike'),
+    (353706304, 'Westbound', 'Westbound'::gwolofs.travel_directions, 'bike'),
     (353706305, 'Westbound', 'Westbound'::gwolofs.travel_directions, 'scooter'),
     (353706306, 'Eastbound', 'Westbound'::gwolofs.travel_directions, 'scooter')
 ) AS vals(flow_id, flow_direction, direction_main, mode_counted)

--- a/volumes/ecocounter/updates/ecocounter_update_queens_quay_flow.sql
+++ b/volumes/ecocounter/updates/ecocounter_update_queens_quay_flow.sql
@@ -1,0 +1,19 @@
+UPDATE ecocounter.flows_unfiltered AS fu
+SET
+    flow_direction = vals.flow_direction,
+    direction_main = vals.direction_main,
+    includes_contraflow = vals.includes_contraflow,
+    validated = vals.validated,
+    mode_counted = vals.mode_counted
+FROM (
+    VALUES
+    (353706300, 'Westbound', 'Eastbound'::gwolofs.travel_directions, TRUE,  FALSE, 'bike'),
+    (353706299, 'Eastbound', 'Eastbound'::gwolofs.travel_directions, FALSE, FALSE, 'bike'),
+    (353706301, 'Eastbound', 'Eastbound'::gwolofs.travel_directions, FALSE, FALSE, 'scooter'),
+    (353706302, 'Westbound', 'Eastbound'::gwolofs.travel_directions, TRUE,  FALSE, 'scooter'),
+    (353706303, 'Westbound', 'Westbound'::gwolofs.travel_directions, FALSE, FALSE, 'bike'),
+    (353706304, 'Eastbound', 'Westbound'::gwolofs.travel_directions, TRUE,  FALSE, 'bike'),
+    (353706305, 'Westbound', 'Westbound'::gwolofs.travel_directions, FALSE, FALSE, 'scooter'),
+    (353706306, 'Eastbound', 'Westbound'::gwolofs.travel_directions, TRUE,  FALSE, 'scooter')
+) AS vals(flow_id, flow_direction, direction_main, includes_contraflow, validated, mode_counted)
+WHERE vals.flow_id = fu.flow_id;


### PR DESCRIPTION
Updates `flow_direction`, `direction_main`, `includes_contraflow`, `validated`, and `mode_counted` for 8 flows (353706299–353706306) at the Queens Quay W between Stadium and Little Norway Cres EcoCounter site.
