### PR TITLE
#1338 add file clicks & api usage stats from Open Data, add to db

### DIFF
--- a/dags/open_data_checks.py
+++ b/dags/open_data_checks.py
@@ -7,25 +7,21 @@
 
 import os
 import sys
-import json
-import logging
-import requests
 import pendulum
-import pandas as pd
 from datetime import datetime, timedelta
-import dateutil.parser
+from psycopg2 import sql
+import pandas as pd
 
-from airflow.sdk import dag, task, Variable
-from airflow.models.taskinstance import TaskInstance
-from airflow.exceptions import AirflowFailException
-
-LOGGER = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+from airflow.sdk import dag, task
 
 repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 sys.path.insert(0, repo_path)
 from bdit_dag_utils.utils.dag_functions import task_fail_slack_alert, send_slack_msg
+from bdit_dag_utils.utils.custom_operators import SQLCheckOperatorWithReturnValue
 from dags.dag_owners import owners
+from open_data.od_checks import (
+    get_usage_stats, get_file_clicks, get_api_usage, get_resources, get_connection
+)
 
 DAG_NAME = 'open_data_checks'
 DAG_OWNERS = owners.get(DAG_NAME, ['Unknown'])
@@ -38,107 +34,78 @@ default_args = {
     'email_on_retry': False,
     'retry_delay': timedelta(minutes=5),
     'retry_exponential_backoff': True, #Allow for progressive longer waits between retries
-    'on_failure_callback': task_fail_slack_alert,
+    #'on_failure_callback': task_fail_slack_alert,
 }
-
-BASE_URL = "https://ckan0.cf.opendata.inter.prod-toronto.ca"
 
 @dag(
     dag_id=DAG_NAME,
     default_args=default_args,
     max_active_runs=1,
     doc_md=__doc__,
+    template_searchpath=os.path.join(repo_path,'open_data/sql'),
     tags=['bdit_data-sources', 'open_data', 'data_check'],
     schedule='0 0 5 * *', #fifth day of every month
     catchup=False,
 )
 
 def od_check_dag():
+    
     @task
-    def fetch_datasets():
-        return Variable.get('open_data_ids', deserialize_json=True)
+    def usage_stats():
+        conn=get_connection()
+        get_usage_stats(conn)
         
-    @task(map_index_template="{{ od_id }}")
-    def check_freshness(od_id = None, **context):
-        #name mapped task
-        context["od_id"] = od_id
         
-        #get open data metadata
-        p = {"id": od_id}
-        package_show_url = BASE_URL + "/api/3/action/package_show"
-        package = requests.get(package_show_url, params = p).json()
-        try:
-            result = package.get('result')
-            refresh_rate = result.get('refresh_rate')
-            last_refreshed = dateutil.parser.parse(result.get('last_refreshed'))
-        except KeyError as e:
-            LOGGER.error("Problem retrieving Open Data portal info.")
-            raise AirflowFailException(e)
-        LOGGER.info("`%s` last_refreshed: %s", od_id, last_refreshed)
+    @task
+    def file_clicks():
+        conn=get_connection()
+        get_file_clicks(conn)
         
-        if refresh_rate == 'Daily':
-            max_offset = timedelta(days=3)
-        elif refresh_rate == 'Monthly':
-            max_offset = timedelta(days=60)
-        elif refresh_rate == 'Quarterly':
-            max_offset = timedelta(days=120)
-        else:
-            max_offset = timedelta(days=60)
         
-        if last_refreshed < datetime.now() - max_offset:
-            days_old=(datetime.now() - last_refreshed).days
-            md_url=f"<https://open.toronto.ca/dataset/{od_id}/|`{od_id}`>"
-            failure_msg = f"{md_url} is out of date. Last refreshed: `{last_refreshed}` (days old: {days_old})."
-            context["task_instance"].xcom_push(key="failure_msg", value=failure_msg)
-    
-    @task(
+    @task
+    def api_usage():
+        conn=get_connection()
+        get_api_usage(conn)
+        
+    @task
+    def resources():
+        conn=get_connection()
+        get_resources(conn)
+        
+    check_outdated = SQLCheckOperatorWithReturnValue(
+        task_id="check_outdated",
+        sql="select-outdated.sql",
+        conn_id="ref_bot",
         retries=0,
-        trigger_rule='all_done',
-        doc_md="""A status message to report any failures from the `check_freshness` task."""
     )
-    def freshness_message(ids, ti: TaskInstance | None = None):
-        failures = []
-        #iterate through mapped tasks to find any failure messages
-        for m_i in range(0, len(ids)):
-            failure_msg = ti.xcom_pull(task_ids="check_freshness", key="failure_msg", map_indexes=m_i)
-            if failure_msg is not None:
-                failures.append(failure_msg)
-        if failures != []:
-            failure_extra_msg = ['One or more Open Data pages is outdated:', failures]
-            ti.xcom_push(key="extra_msg", value=failure_extra_msg)
-            raise AirflowFailException('One or more Open Data pages is outdated.')
-    
-    @task()
-    def usage_stats(ids, **context):
-        # file clicks are also available under a different non-datastore resource
-        resource_id = "3f5d6284-0e9f-43d3-979e-01cefcc92f72" #'Page Views and Time Based Metrics.csv'
-        datastore_search_url = BASE_URL + "/api/3/action/datastore_search"
-        last_month = pendulum.now().subtract(months=1)
-        page_urls = [f"open.toronto.ca/dataset/{id}/" for id in ids]
-        p = {
-            "resource_id": resource_id,
-            "filters": json.dumps({
-                "Link Source -Page URL": page_urls,
-                "Month": last_month.format('YMM')
-            })
-        }
-        resource_search_data = requests.get(datastore_search_url, params = p).json()["result"]
-        # Convert to DataFrame and clean
-        df = pd.DataFrame(resource_search_data['records'])
-        df["Id"] = df["Link Source -Page URL"].str.extract(r'open.toronto.ca/dataset/([^/]+)')
+   
+    @task
+    def check_usage_stats(**context):
         
-        #filter columns and sort
-        df_sorted = df[["Id", "Sessions", "Users", "Views", "Avg Session Duration (Sec)"]]
-        df_sorted = df_sorted.sort_values(by="Views", ascending=False)
-        dt_md = df_sorted.to_markdown(index = False, tablefmt="slack")
+        last_month = pendulum.now().subtract(months=1).set(day=1)
+        fpath = os.path.join(repo_path, 'open_data/sql/select-monthly_stats.sql')
+        with open(fpath, 'r', encoding="utf-8") as file:
+            query = sql.SQL(file.read()).format(
+                mnth = sql.Literal(last_month.to_date_string())
+            )
+        
+        conn=get_connection()
+        with conn.cursor() as cur:
+            cur.execute(query)
+            results = cur.fetchall()
+            cols = [desc[0] for desc in cur.description]
+            df = pd.DataFrame(results, columns=cols)
+        
+        dt_md = df.to_markdown(index = False, tablefmt="slack")
         
         send_slack_msg(
             context=context,
             msg=f":open_data_to: page view analytics from `{last_month.format('MMMM Y')}`:```{dt_md}```"
         )
 
-    ids=fetch_datasets()
-    check_freshness.expand(od_id = ids) >> freshness_message(ids)
-    usage_stats(ids)
+    usage_stats() >> file_clicks() >> api_usage() >> resources() >> (
+        check_outdated,
+        check_usage_stats()
+    )
 
 od_check_dag()

--- a/dags/open_data_checks.py
+++ b/dags/open_data_checks.py
@@ -34,7 +34,7 @@ default_args = {
     'email_on_retry': False,
     'retry_delay': timedelta(minutes=5),
     'retry_exponential_backoff': True, #Allow for progressive longer waits between retries
-    #'on_failure_callback': task_fail_slack_alert,
+    'on_failure_callback': task_fail_slack_alert,
 }
 
 @dag(
@@ -62,12 +62,16 @@ def od_check_dag():
         get_file_clicks(conn)
         
         
-    @task
+    @task(
+        trigger_rule='all_done' #file clicks is optional
+    )
     def api_usage():
         conn=get_connection()
         get_api_usage(conn)
         
-    @task
+    @task(
+        trigger_rule='all_done' #api_usage is optional, currently down
+    )
     def resources():
         conn=get_connection()
         get_resources(conn)

--- a/open_data/od_checks.py
+++ b/open_data/od_checks.py
@@ -1,0 +1,182 @@
+
+
+import json
+import logging
+import requests
+import logging
+import pendulum
+import pandas as pd
+import dateutil.parser
+import configparser
+import psycopg2
+
+from airflow.exceptions import AirflowNotFoundException
+from airflow.providers.postgres.hooks.postgres import PostgresHook
+
+LOGGER = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+BASE_URL = "https://ckan0.cf.opendata.inter.prod-toronto.ca"
+
+def get_usage_stats(conn):
+    # file clicks are also available under a different non-datastore resource
+    datastore_search_url = BASE_URL + "/api/3/action/datastore_search"
+    last_month = pendulum.now().subtract(months=1)
+    ids = get_ids(conn)
+    page_urls = [f"open.toronto.ca/dataset/{id}/" for id in ids]
+    p = {
+        "resource_id": "3f5d6284-0e9f-43d3-979e-01cefcc92f72", #'Page Views and Time Based Metrics.csv',
+        "filters": json.dumps({
+            "Link Source -Page URL": page_urls,
+            "Month": last_month.format('YMM')
+        })
+    }
+    resource_search_data = requests.get(datastore_search_url, params = p).json()["result"]
+    # Convert to DataFrame and clean
+    df = pd.DataFrame(resource_search_data['records'])
+    df["Id"] = df["Link Source -Page URL"].str.extract(r'open.toronto.ca/dataset/([^/]+)')
+    df["Month"] = pd.to_datetime(df["Month"], format="%Y%m")
+
+    #filter columns and sort
+    df_sorted = df[["Id", "Month", "Sessions", "Users", "Views", "Avg Session Duration (Sec)"]]
+    data_tuples = [tuple(x) for x in df_sorted.to_numpy()]
+    
+    sql = """
+    INSERT INTO open_data.od_page_views (page_id, mnth, sessions, users, views, avg_session_duration)
+    VALUES (%s, %s, %s, %s, %s, %s)
+    ON CONFLICT ON CONSTRAINT od_page_views_pkey
+    DO NOTHING
+    """
+    
+    with conn.cursor() as cur:
+        cur.executemany(sql, data_tuples)
+
+def get_file_clicks(conn):
+    sql = "SELECT MAX(_id) FROM open_data.od_file_clicks"
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        max_id = cur.fetchone()[0]
+
+    datastore_search_url = BASE_URL + "/api/3/action/datastore_search"
+    records = []
+    offset = 0
+    while True:
+        p = {
+            "resource_id": 'b308378d-2ec9-40ea-9182-f94cb63d73f3', #File URL Clicks
+            "limit": 1000,
+            "offset": offset
+        }
+        result = requests.get(datastore_search_url, params = p).json()["result"]
+        records.extend(result['records'])
+        if offset >= result["total"]:
+            break
+        offset += 1000
+
+    # Convert to DataFrame and clean
+    df = pd.DataFrame(records)
+    df = df[df["_id"] > max_id]
+    df["Month"] = pd.to_datetime(df["Month"], format="%Y%m")
+    data_tuples = [tuple(x) for x in df.to_numpy()]
+
+    sql = """INSERT INTO open_data.od_file_clicks (_id, url, clicks, mnth, package_name, resource_name)
+        VALUES (%s, %s, %s, %s, %s, %s)"""
+    with conn.cursor() as cur:
+        cur.executemany(sql, data_tuples)
+    
+def get_ids(conn):
+    ids_sql = "SELECT page_id FROM open_data.od_pages"
+    with conn.cursor() as cur:
+        cur.execute(ids_sql)
+        ids = [r[0] for r in cur.fetchall()]
+    return ids
+
+def get_api_usage(conn):
+    sql = "SELECT MAX(_id) FROM open_data.od_api_usage"
+    with conn.cursor() as cur:
+        cur.execute(sql)
+        max_id = cur.fetchone()[0]
+    
+    datastore_search_url = BASE_URL + "/api/3/action/datastore_search"
+    records = []
+    offset = 0
+    while True:
+        p = {
+            "resource_id": 'a67a1fa2-7c16-4d25-9c70-aa1bcb341b39', #API Usage
+            "limit": 1000,
+            "offset": offset
+        }
+        result = requests.get(datastore_search_url, params = p).json()["result"]
+        records.extend(result['records'])
+        if offset >= result["total"]:
+            break
+        offset += 1000
+    
+    # Convert to DataFrame and clean
+    df = pd.DataFrame(records)
+    df = df[df["_id"] > max_id]
+    data_tuples = [tuple(x) for x in df.to_numpy()]
+    
+    sql = """
+    INSERT INTO open_data.od_api_usage (_id, uri, count, dt, resource_id)
+    VALUES (%s, %s, %s, %s, %s)
+    ON CONFLICT ON CONSTRAINT od_api_usage_pkey
+    DO NOTHING
+    """
+    
+    with conn.cursor() as cur:
+        cur.executemany(sql, data_tuples)
+            
+
+def get_resources(conn):
+    resources = []
+    pages = []
+    ids = get_ids(conn)
+    for id in ids:
+        p = {"id": id}
+        package_show_url = BASE_URL + "/api/3/action/package_show"
+        result = requests.get(package_show_url, params = p).json()["result"]
+        refresh_rate = result["refresh_rate"]
+        last_refreshed = dateutil.parser.parse(result['last_refreshed'])
+        pages.append((id, refresh_rate, last_refreshed))
+        for resource in result["resources"]:
+            resources.append((id, resource["name"], resource["id"]))
+            
+    sql="""INSERT INTO open_data.od_resources (page_id, resource_name, resource_id)
+    VALUES (%s, %s, %s)
+    ON CONFLICT DO NOTHING;"""
+    
+    with conn.cursor() as cur:
+        cur.executemany(sql, resources)
+        
+    sql="""INSERT INTO open_data.od_pages (page_id, refresh_rate, last_refreshed)
+    VALUES (%s, %s, %s)
+    ON CONFLICT ON CONSTRAINT od_pages_pkey
+    DO UPDATE SET
+        refresh_rate = EXCLUDED.refresh_rate,
+        last_refreshed = EXCLUDED.last_refreshed;
+    """
+    
+    with conn.cursor() as cur:
+        cur.executemany(sql, pages)
+    
+def get_connection(path=None):
+    """
+    Returns (conn, key). Uses Airflow hooks if running in Airflow,
+    otherwise falls back to a local config file.
+    """
+    try:
+        postgres = PostgresHook("ref_bot")
+        conn = postgres.get_conn()
+        conn.autocommit = True
+        return conn
+    except AirflowNotFoundException:
+        if path is None:
+            raise ValueError("Must provide a config path when running locally.")
+        CONFIG = configparser.ConfigParser()
+        CONFIG.read(path)
+        dbset = CONFIG['DBSETTINGS']
+        conn = psycopg2.connect(**dbset)
+        conn.autocommit = True
+        return conn
+
+conn = get_connection('/data/home/gwolofs/db.cfg')

--- a/open_data/sql/select-monthly_stats.sql
+++ b/open_data/sql/select-monthly_stats.sql
@@ -1,0 +1,10 @@
+SELECT
+    pg.page_id,
+    pg.views AS pg_views,
+    api.api_interactions,
+    click.clicks AS file_clicks
+FROM open_data.od_page_views AS pg 
+LEFT JOIN open_data.monthly_api_interactions AS api USING (page_id, mnth)
+LEFT JOIN open_data.monthly_file_clicks AS click USING (page_id, mnth)
+WHERE mnth = {mnth}
+ORDER BY pg.views + api.api_interactions + click.clicks DESC;

--- a/open_data/sql/select-outdated.sql
+++ b/open_data/sql/select-outdated.sql
@@ -1,0 +1,17 @@
+WITH outdated AS (
+    SELECT
+        '<https://open.toronto.ca/dataset/' || page_id || '|`' || page_id || '`> is out of date. Last refreshed: `'
+        || last_refreshed || '` (days old: ' || CURRENT_DATE - last_refreshed::date || ').' AS msg
+    FROM open_data.od_pages
+    WHERE last_refreshed < CURRENT_TIMESTAMP -
+        CASE refresh_rate
+            WHEN 'Daily' THEN interval '3 days'
+            WHEN 'Monthly' THEN interval '60 days'
+            WHEN 'Quarterly' THEN interval '120 days'
+            ELSE interval '60 days'
+        END
+    ORDER BY page_id ASC
+)
+
+SELECT COUNT(*) = 0 AS _check, 'One or more Open Data pages is outdated:' AS msg, array_agg(outdated.msg)
+FROM outdated;

--- a/open_data/sql/table-api_usage.sql
+++ b/open_data/sql/table-api_usage.sql
@@ -1,0 +1,33 @@
+-- Table: open_data.od_api_usage
+
+-- DROP TABLE IF EXISTS open_data.od_api_usage;
+
+CREATE TABLE IF NOT EXISTS open_data.od_api_usage
+(
+    _id bigint NOT NULL,
+    resource_id text COLLATE pg_catalog."default",
+    dt date,
+    uri text COLLATE pg_catalog."default",
+    count integer,
+    CONSTRAINT od_api_usage_pkey PRIMARY KEY (_id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS open_data.od_api_usage
+OWNER TO od_admins;
+
+REVOKE ALL ON TABLE open_data.od_api_usage FROM bdit_humans;
+REVOKE ALL ON TABLE open_data.od_api_usage FROM ref_bot;
+
+GRANT SELECT, TRIGGER, REFERENCES ON TABLE open_data.od_api_usage TO bdit_humans WITH GRANT OPTION;
+
+GRANT ALL ON TABLE open_data.od_api_usage TO od_admins;
+
+GRANT ALL ON TABLE open_data.od_api_usage TO rds_superuser WITH GRANT OPTION;
+
+GRANT INSERT, SELECT ON TABLE open_data.od_api_usage TO ref_bot;
+
+COMMENT ON TABLE open_data.od_api_usage
+IS 'Stores a list of Open Data API Usage from https://open.toronto.ca/dataset/open-data-web-analytics/.
+Updated Monthly by Airflow open_data_checks.';

--- a/open_data/sql/table-file_clicks.sql
+++ b/open_data/sql/table-file_clicks.sql
@@ -1,0 +1,33 @@
+-- Table: open_data.od_file_clicks
+
+-- DROP TABLE IF EXISTS open_data.od_file_clicks;
+
+CREATE TABLE IF NOT EXISTS open_data.od_file_clicks
+(
+    _id bigint NOT NULL,
+    url text COLLATE pg_catalog."default" NOT NULL,
+    clicks integer,
+    mnth date NOT NULL,
+    package_name text COLLATE pg_catalog."default",
+    resource_name text COLLATE pg_catalog."default",
+    CONSTRAINT od_file_clicks_pkey PRIMARY KEY (_id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS open_data.od_file_clicks
+OWNER TO od_admins;
+
+REVOKE ALL ON TABLE open_data.od_file_clicks FROM bdit_humans;
+
+GRANT SELECT, TRIGGER, REFERENCES ON TABLE open_data.od_file_clicks TO bdit_humans WITH GRANT OPTION;
+
+GRANT ALL ON TABLE open_data.od_file_clicks TO od_admins;
+
+GRANT INSERT, SELECT ON TABLE open_data.od_file_clicks TO ref_bot;
+
+GRANT ALL ON TABLE open_data.od_file_clicks TO rds_superuser WITH GRANT OPTION;
+
+COMMENT ON TABLE open_data.od_file_clicks
+IS 'Stores a list of Open Data File Clicks from https://open.toronto.ca/dataset/open-data-web-analytics/.
+Updated Monthly by Airflow open_data_checks.';

--- a/open_data/sql/table-od_page_views.sql
+++ b/open_data/sql/table-od_page_views.sql
@@ -1,0 +1,34 @@
+-- Table: open_data.od_page_views
+
+-- DROP TABLE IF EXISTS open_data.od_page_views;
+
+CREATE TABLE IF NOT EXISTS open_data.od_page_views
+(
+    page_id text COLLATE pg_catalog."default" NOT NULL,
+    mnth date NOT NULL,
+    sessions integer,
+    users integer,
+    views integer,
+    avg_session_duration numeric,
+    CONSTRAINT od_page_views_pkey PRIMARY KEY (page_id, mnth)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS open_data.od_page_views
+OWNER TO od_admins;
+
+REVOKE ALL ON TABLE open_data.od_page_views FROM bdit_humans;
+
+GRANT SELECT, TRIGGER, REFERENCES ON TABLE open_data.od_page_views TO bdit_humans WITH GRANT OPTION;
+
+GRANT ALL ON TABLE open_data.od_page_views TO od_admins;
+
+GRANT ALL ON TABLE open_data.od_page_views TO rds_superuser WITH GRANT OPTION;
+
+REVOKE ALL ON TABLE open_data.od_page_views FROM ref_bot;
+GRANT INSERT, SELECT ON TABLE open_data.od_page_views TO ref_bot;
+
+COMMENT ON TABLE open_data.od_page_views
+IS 'Stores a list of Open Data Page Views from https://open.toronto.ca/dataset/open-data-web-analytics/.
+Updated Monthly by Airflow open_data_checks.';

--- a/open_data/sql/table-od_pages.sql
+++ b/open_data/sql/table-od_pages.sql
@@ -1,0 +1,29 @@
+-- Table: open_data.od_pages
+
+-- DROP TABLE IF EXISTS open_data.od_pages;
+
+CREATE TABLE IF NOT EXISTS open_data.od_pages
+(
+    page_id text COLLATE pg_catalog."default" NOT NULL,
+    last_refreshed timestamp without time zone,
+    refresh_rate text COLLATE pg_catalog."default",
+    CONSTRAINT od_pages_pkey PRIMARY KEY (page_id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS open_data.od_pages
+OWNER TO od_admins;
+
+REVOKE ALL ON TABLE open_data.od_pages FROM bdit_humans;
+GRANT SELECT, TRIGGER, REFERENCES ON TABLE open_data.od_pages TO bdit_humans WITH GRANT OPTION;
+
+GRANT ALL ON TABLE open_data.od_pages TO od_admins;
+
+GRANT ALL ON TABLE open_data.od_pages TO rds_superuser WITH GRANT OPTION;
+
+REVOKE ALL ON TABLE open_data.od_pages FROM ref_bot;
+GRANT INSERT, SELECT, UPDATE ON TABLE open_data.od_pages TO ref_bot;
+
+COMMENT ON TABLE open_data.od_pages
+IS 'List of Open Data pages maintained by Data & Analytics.';

--- a/open_data/sql/table-od_resources.sql
+++ b/open_data/sql/table-od_resources.sql
@@ -1,0 +1,29 @@
+-- Table: open_data.od_resources
+
+-- DROP TABLE IF EXISTS open_data.od_resources;
+
+CREATE TABLE IF NOT EXISTS open_data.od_resources
+(
+    page_id text COLLATE pg_catalog."default" NOT NULL,
+    resource_name text COLLATE pg_catalog."default" NOT NULL,
+    resource_id text COLLATE pg_catalog."default" NOT NULL,
+    CONSTRAINT od_resources_pkey PRIMARY KEY (page_id, resource_name, resource_id)
+)
+
+TABLESPACE pg_default;
+
+ALTER TABLE IF EXISTS open_data.od_resources
+OWNER TO od_admins;
+
+REVOKE ALL ON TABLE open_data.od_resources FROM bdit_humans;
+
+GRANT SELECT, TRIGGER, REFERENCES ON TABLE open_data.od_resources TO bdit_humans WITH GRANT OPTION;
+
+GRANT ALL ON TABLE open_data.od_resources TO od_admins;
+
+GRANT INSERT, SELECT ON TABLE open_data.od_resources TO ref_bot;
+
+GRANT ALL ON TABLE open_data.od_resources TO rds_superuser WITH GRANT OPTION;
+
+COMMENT ON TABLE open_data.od_resources
+IS 'Stores a list of our Open Data resources. Updated Monthly by Airflow open_data_checks.';

--- a/open_data/sql/view-monthly_api_interactions.sql
+++ b/open_data/sql/view-monthly_api_interactions.sql
@@ -1,0 +1,36 @@
+--DROP VIEW open_data.monthly_api_interactions;
+CREATE OR REPLACE VIEW open_data.monthly_api_interactions AS
+WITH api_usage AS (
+    --specific resource interaction
+    SELECT
+        r.page_id,
+        api.count,
+        api.dt
+    FROM open_data.od_api_usage AS api
+    JOIN open_data.od_resources AS r USING (resource_id)
+    
+    UNION
+
+    --page interaction
+    SELECT
+        p.page_id,
+        api.count,
+        api.dt
+    FROM open_data.od_api_usage AS api
+    JOIN open_data.od_pages AS p ON p.page_id = api.resource_id
+)
+
+SELECT
+    api.page_id,
+    date_trunc('month', api.dt)::date AS mnth,
+    SUM(api.count) AS api_interactions
+FROM api_usage AS api
+GROUP BY
+    api.page_id,
+    mnth;
+
+ALTER TABLE open_data.monthly_api_interactions OWNER TO od_admins;
+
+GRANT SELECT ON TABLE open_data.monthly_api_interactions TO bdit_humans;
+
+GRANT SELECT ON TABLE open_data.monthly_api_interactions TO ref_bot;

--- a/open_data/sql/view-monthly_file_clicks.sql
+++ b/open_data/sql/view-monthly_file_clicks.sql
@@ -1,0 +1,19 @@
+CREATE VIEW open_data.monthly_file_clicks AS
+SELECT
+    click.mnth,
+    r.page_id,
+    SUM(click.clicks) AS clicks
+FROM
+    open_data.od_file_clicks AS click
+    JOIN open_data.od_resources AS r ON click.package_name = r.page_id
+GROUP BY
+    click.mnth,
+    r.page_id
+ORDER BY
+    clicks DESC;
+
+ALTER TABLE open_data.monthly_file_clicks owner TO od_admins;
+
+GRANT SELECT ON TABLE open_data.monthly_file_clicks TO bdit_humans;
+
+GRANT SELECT ON TABLE open_data.monthly_file_clicks TO ref_bot;


### PR DESCRIPTION
## What this pull request accomplishes:

- Add additional stats from: https://open.toronto.ca/dataset/open-data-web-analytics/
  -  API Usage (`open_data.od_api_usage`)
  - File URL Clicks (`open_data.od_file_clicks`)
- New database tables to store existing stats:
  - `open_data.od_pages` replaces Airflow variable. Also now stores last_refreshed.
  - `open_data.od_resources` stores resource ids for all the pages
  - `open_data.od_page_views` stores Page Views and Time Based Metrics
 - New views for monthly summary:
   - `open_data.monthly_api_interactions`
   - `open_data.monthly_file_clicks`

## Issue(s) this solves:

- Closes #1338  

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
