### PR TITLE
Clean up btdag PR

### DIFF
--- a/bluetooth/sql/functions/function_broken_readers.sql
+++ b/bluetooth/sql/functions/function_broken_readers.sql
@@ -1,0 +1,38 @@
+-- FUNCTION: bluetooth.broken_readers(date)
+
+-- DROP FUNCTION IF EXISTS bluetooth.broken_readers(date);
+
+CREATE OR REPLACE FUNCTION bluetooth.broken_readers(
+	_dt date)
+    RETURNS TABLE(read_id integer, reader_name character varying) 
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+    ROWS 1000
+
+AS $BODY$
+	
+	BEGIN
+    RETURN query 
+
+SELECT          reader_id, read_name 
+
+FROM            bluetooth.reader_status_history
+INNER join      bluetooth.readers_history_corrected using(reader_id) -- needs to be changed to something else or another version
+WHERE           active IS FALSE and last_active_date = _dt - 1 and dt = _dt;
+
+END
+
+$BODY$;
+
+ALTER FUNCTION bluetooth.broken_readers(date)
+    OWNER TO bt_admins;
+
+GRANT EXECUTE ON FUNCTION bluetooth.broken_readers(date) TO bt_admins;
+
+GRANT EXECUTE ON FUNCTION bluetooth.broken_readers(date) TO bt_bot;
+
+REVOKE ALL ON FUNCTION bluetooth.broken_readers(date) FROM PUBLIC;
+
+COMMENT ON FUNCTION bluetooth.broken_readers(date)
+    IS 'This function identifies the readers that were not active yesterday but were active the day before as broken readers, and returns a list of broken readers.';

--- a/bluetooth/sql/functions/function_insert_report_date.sql
+++ b/bluetooth/sql/functions/function_insert_report_date.sql
@@ -1,0 +1,40 @@
+-- FUNCTION: bluetooth.insert_report_date()
+
+-- DROP FUNCTION IF EXISTS bluetooth.insert_report_date();
+
+CREATE OR REPLACE FUNCTION bluetooth.insert_report_date(
+	)
+    RETURNS void
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+AS $BODY$
+	
+BEGIN
+
+WITH routes_status AS (
+
+    SELECT      analysis_id, max(datetime_bin)::date AS last_reported_date
+    FROM        bluetooth.aggr_5min
+    GROUP BY    analysis_id)
+
+UPDATE bluetooth.routes
+SET date_last_received = (SELECT last_reported_date 
+                          FROM   routes_status 
+                          WHERE  routes_status.analysis_id = routes.analysis_id);
+
+END; 
+		
+$BODY$;
+
+ALTER FUNCTION bluetooth.insert_report_date()
+    OWNER TO bt_admins;
+
+GRANT EXECUTE ON FUNCTION bluetooth.insert_report_date() TO bt_admins;
+
+GRANT EXECUTE ON FUNCTION bluetooth.insert_report_date() TO bt_bot;
+
+REVOKE ALL ON FUNCTION bluetooth.insert_report_date() FROM PUBLIC;
+
+COMMENT ON FUNCTION bluetooth.insert_report_date()
+    IS '''This function updates the table bluetooth.routes with each routes last reported date.''';

--- a/bluetooth/sql/functions/function_reader_status_history.sql
+++ b/bluetooth/sql/functions/function_reader_status_history.sql
@@ -1,0 +1,114 @@
+-- FUNCTION: bluetooth.reader_status_history(date)
+
+-- DROP FUNCTION IF EXISTS bluetooth.reader_status_history(date);
+
+CREATE OR REPLACE FUNCTION bluetooth.reader_status_history(
+	_dt date)
+    RETURNS TABLE(an_id bigint, last_received date, status text, ddown integer, start_route_point_id text, start_detector text, end_route_point_id text, end_detector text) 
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE PARALLEL UNSAFE
+    ROWS 1000
+
+AS $BODY$
+	
+	BEGIN
+		-- Return last reported date and route status for the executed date
+		WITH status_info AS (
+			SELECT      DISTINCT(analysis_id), 
+                     CASE
+                        WHEN MAX (datetime_bin::date)>= (_dt) then _dt
+                        ELSE MAX (datetime_bin::date)
+                     END as last_reported,
+                     CASE
+                        WHEN  MAX (datetime_bin::date)>= (_dt) then True
+                        ELSE False
+                     END AS route_status,
+                     _dt::date AS dt
+
+		   FROM        bluetooth.all_analyses
+		   LEFT JOIN   bluetooth.aggr_5min USING (analysis_id) 
+		   GROUP BY    analysis_id)
+      
+      -- Extract start and end route point id and detector name for each analysis_id
+            -- Extract start and end route point id and detector name for each analysis_id
+      , route_info AS (
+         SELECT      status_info.analysis_id,
+                     status_info.last_reported,
+                     status_info.route_status,
+                     status_info.dt,
+                     (all_analyses.route_points -> 0) ->> 'id'::text AS start_route_point_id,
+                     (all_analyses.route_points -> 0) ->> 'name'::text AS start_detector,
+                     (all_analyses.route_points -> 1) ->> 'id'::text AS end_route_point_id,
+                     (all_analyses.route_points -> 1) ->> 'name'::text AS end_detector
+
+         FROM        status_info
+         INNER JOIN  bluetooth.all_analyses USING (analysis_id))
+
+      -- Create one row for the start and end detector for each analysis_id
+		, detector_list AS (
+         SELECT      route_info.analysis_id,
+                     route_info.start_detector AS detector_name,
+                     route_info.route_status,
+                     route_info.last_reported,
+                     route_info.dt
+         FROM        route_info
+         UNION
+         SELECT      route_info.analysis_id,
+                     route_info.end_detector AS detector_name,
+                     route_info.route_status,
+                     route_info.last_reported,
+			         route_info.dt
+         FROM        route_info)
+
+      -- Select only the detectors that are active
+		, active AS (
+         SELECT      DISTINCT reader_id,
+                     max(detector_list.last_reported) AS last_reported,
+                     detector_list.route_status,
+                     detector_list.dt
+
+         FROM        detector_list
+         INNER JOIN  bluetooth.readers_history_corrected reader_history ON detector_list.detector_name = reader_history.read_name 
+         WHERE       detector_list.route_status = TRUE
+         GROUP BY    detector_list.route_status, reader_history.reader_id, detector_list.dt)
+	
+	-- Update reader_locations' date_last_received with active reader's last reported date 
+		 , update_cte AS (
+		 UPDATE bluetooth.readers_history_corrected reader_locations
+   		set date_last_received = (SELECT DISTINCT max(last_reported) from active where active.reader_id = reader_locations.reader_id)
+		 )
+      	
+		-- Insert into reader_status_history table
+   	INSERT INTO  bluetooth.reader_status_history (reader_id, last_active_date, active, dt)
+		
+        SELECT       DISTINCT reader_id,
+                     max(detector_list.last_reported) AS last_reported,
+                     detector_list.route_status,
+			         detector_list.dt
+					 
+         FROM        detector_list
+         INNER JOIN  bluetooth.readers_history_corrected reader_history ON detector_list.detector_name = reader_history.read_name 
+         WHERE       detector_list.route_status = FALSE AND 
+                     NOT (reader_id IN (SELECT reader_id FROM active))
+         GROUP BY    detector_list.route_status, reader_history.reader_id, detector_list.dt
+
+         UNION ALL
+         
+         SELECT      active.reader_id,
+                     active.last_reported,
+                     active.route_status,
+                     active.dt
+         FROM        active;
+
+END;
+$BODY$;
+
+ALTER FUNCTION bluetooth.reader_status_history(date)
+    OWNER TO bt_admins;
+
+GRANT EXECUTE ON FUNCTION bluetooth.reader_status_history(date) TO bt_admins;
+
+GRANT EXECUTE ON FUNCTION bluetooth.reader_status_history(date) TO bt_bot;
+
+REVOKE ALL ON FUNCTION bluetooth.reader_status_history(date) FROM PUBLIC;

--- a/bluetooth/sql/reader_status_detail.md
+++ b/bluetooth/sql/reader_status_detail.md
@@ -1,0 +1,40 @@
+# Bluetooth reader's status  
+The table `detectors_history_corrected` is prepared by referencing the tables that are available in cnangini schema,  latest tables that are received from our contact person from bliptrack and cross checked with route points from `all_analyses` table in our bluetooth schema. The following tables were used from cnangini schema. 
+
+-  `detectors_validated`
+-  `detector_history`
+-  `detectors`
+
+The table that was received from bliptrack is `mohan.latest_bt_locations_jj`
+
+The table that was used from bluetooth schema is `all_analyses` field `route_points`. This field contains json objects and three key:value pairs `name`, `latitude`, `longitude`were used as a reference. These key:value pairs are there for start point and end point of each route or `analysis_id`. It was used to cross check the information in creating the history of intersections with bluetooth detectors.  
+
+These tables contain common fields such as `BT Unit #` in `detectors_validated` corresponds to `ZONE` in `mohan.latest_bt_locations_jj`. The common corresponding fields in each set of table is listed below.
+
+|latest_bt_locations_jj|detectors_validated|detectors_history_corrected|all_analysis|remarks|
+|----------------------|-------------------|---------------------------|------------|-------|
+|ZONE|BT Unit #|bt_id|
+||detector_name|read_name|name|
+|LOCATION_DATE |date_installed|date_start||The earliest date for the detector at the location among the tables.|
+|LAST_STATUS_UPDATE||last_data_received_date||The latest date for a particular detector among the tables|.
+||date_removed|date_end||This date is assumed to be the date when a bt reader is physically removed from an intersection. The latest date found among the tables that is used.|
+|LAT|latitude|lat|latitude|
+|LNG|longitude|lon|longitude|
+
+The following status are assigned to each reader based on the information available in all tables. 
+- online (readers that are online as per `mohan.latest_bt_locations_jj` and whose details match with the rest of the tables)
+- offline (readers that are offline as per mohan.latest_bt_locations_jj with matching details in other tables)
+- decommissioned ((readers that are in the `detector_history` table but not in the `latest_bt_locations_jj` and whose `date_removed` or `date_end` is populated ))
+
+
+Apart from the above three status following four categories are populated to maintain the history of locations of the detectors/reporting points. Either detectors have been installed in these locations in the past and now moved away or these locations are/were used in creating and reporting routes. 
+
+- added (these are the locations where names are inconsistent for example a reader with bt_id 4035 has a name E in one table and E4035 in another. Despite being at the same intersection at Gardiner & Parliament. Therefore, these two names could refer to the same reader. Thus to distinguish one got the status `added` and another is `offline` )
+  
+- duplicate (`duplicate` does not have a bt_id but based on its location and/or the reader name, there are more than one at a given intersection. The one that has got less details is assigned as `duplicate`)
+  
+- moved (`moved` has a bt_id but the same bt_id existed in a different location in the past. For example bt_id 5331 was at Gerrard & University. But the same bt_id also is at Lawrence & Mt Pleasant and is `offline` as per latest table. Thus 5331 has two entries with status `offline` and `moved`.
+   
+- routepoint name (does not have a bt_id. It is a name given to a point along a route. Could there be a detector at those points ? most likely not)
+
+This table is a working progress and as new details arise, it has to be updated. 

--- a/bluetooth/update/README.md
+++ b/bluetooth/update/README.md
@@ -1,21 +1,18 @@
-# Updating Bluetooth Segments
+# Updating Bluetooth Segments <!-- omit in toc -->
 
-## Overview
+## Overview <!-- omit in toc -->
 
 Ocasionally, new segments need to be added to the `bluetooth` schema. This document will go over the steps and the general process to add new routes along the newly installed bluetooth reader locations. It assumes that bluetooth.all_analyses table does not have rows already created for the proposed new routes. The steps listed here are followed to create an entirely new routes for newly installed bluetooth readers in the city.
 
-## Table of Contents
+## Table of Contents <!-- omit in toc -->
 
-- [Updating Bluetooth Segments](#updating-bluetooth-segments)
-	- [Overview](#overview)
-	- [Table of Contents](#table-of-contents)
-	- [Data Updating](#data-updating)
-	- [Adding Readers](#adding-readers)
-	- [Preparatory Tables and Steps](#preparatory-tables-and-steps)
-	- [Finding Nearest Intersection IDs](#finding-nearest-intersection-ids)
-	- [Using pg_routing](#using-pg_routing)
-	- [Things to note](#things-to-note)
-	- [Validating Output](#validating-output)
+- [Data Updating](#data-updating)
+- [Adding Readers](#adding-readers)
+- [Preparatory Tables and Steps](#preparatory-tables-and-steps)
+- [Finding Nearest Intersection IDs](#finding-nearest-intersection-ids)
+- [Using pg\_routing](#using-pg_routing)
+- [Things to note](#things-to-note)
+- [Validating Output](#validating-output)
 
 ## Data Updating
 
@@ -44,7 +41,9 @@ Therefore the new reader table had the following fields populated:
 `length`			- Length of the route in metres 
 
 ## Preparatory Tables and Steps
-The following steps are utilized to create segments
+
+The following steps are utilized to create segments: 
+
 1. Get start and end geom for each analysis_id using the provided lat and lon 
 2. Create table with detector_id, detector_geom, centreline_int_id
 3. Join the detector's geometry to the closest centreline intersection
@@ -133,15 +132,16 @@ WHERE fcode_desc IN ('Collector','Collector Ramp','Expressway','Expressway Ramp'
 Validate the length of the segments with length `ST_length(geom)` and direction using `gis.direction_from_line(geom)` functions. If the detectors are located very close to the centerline intersections, it is not necessary to do the centreline cutting. If any bluetooth detectors are not located at the start or end point of a centreline, we will need to cut the centreline using `ST_linesubstring()` as explained in [here.](https://github.com/CityofToronto/bdit_data-sources/issues/234).  
 
 Steps to cut centreline using `ST_linesubstring()`:
-1) Find the closest point of the detector on the centreline with [ST_closespoint()](https://postgis.net/docs/ST_ClosestPoint.html).   
+
+1. Find the closest point of the detector on the centreline with [ST_closespoint()](https://postgis.net/docs/ST_ClosestPoint.html).   
 ```sql
 ST_closestpoint(detector_geom, centreline_geom)
 ```
-2) Return the location of the point relative to the centreline using [`ST_linelocatepoint()`](https://postgis.net/docs/ST_LineLocatePoint.html)
+2. Return the location of the point relative to the centreline using [`ST_linelocatepoint()`](https://postgis.net/docs/ST_LineLocatePoint.html)
 ```sql
 ST_linelocatepoint(geom, closest_point_geom)
 ```
-3) Cut the line using [`ST_linesubstring()`](https://postgis.net/docs/ST_LineSubstring.html) 
+3. Cut the line using [`ST_linesubstring()`](https://postgis.net/docs/ST_LineSubstring.html) 
 ```sql
 ST_linesubstring(geom, 0, st_linelocatepoint)
 ```

--- a/bluetooth/update/README.md
+++ b/bluetooth/update/README.md
@@ -2,145 +2,165 @@
 
 ## Overview
 
-Ocasionally, new segments need to be added to the `bluetooth` schema. This will go over the steps and the general process of what occurred during September 2018 to add the new routes. 
+Ocasionally, new segments need to be added to the `bluetooth` schema. This document will go over the steps and the general process to add new routes along the newly installed bluetooth reader locations. It assumes that bluetooth.all_analyses table does not have rows already created for the proposed new routes. The steps listed here are followed to create an entirely new routes for newly installed bluetooth readers in the city.
 
 ## Table of Contents
 
-1. [Parsing Data](#parsing-data)
-2. [Adding Readers](#adding-readers)
-3. [Fuzzy String Matching](#fuzzy-string-matching)
-4. [Cleanup, Warnings, and Alternative Methods](#cleanup-warnings-and-alternative-methods)
-5. [Making Lines](#making-lines)
+- [Updating Bluetooth Segments](#updating-bluetooth-segments)
+	- [Overview](#overview)
+	- [Table of Contents](#table-of-contents)
+	- [Data Updating](#data-updating)
+	- [Adding Readers](#adding-readers)
+	- [Preparatory Tables and Steps](#preparatory-tables-and-steps)
+	- [Finding Nearest Intersection IDs](#finding-nearest-intersection-ids)
+	- [Using pg_routing](#using-pg_routing)
+	- [Things to note](#things-to-note)
+	- [Validating Output](#validating-output)
 
-## Parsing Data
+## Data Updating
 
-In this update, there existed a kml/list of all the new reader names and locations and `bluetooth.all_analyses` already had the routes, `analysis_id` and names of the routes. The names followed whatever was in the bliptrack portal, but does not match the naming convention BDIT uses. The following query parses the `report_name` column into columns for `corridor`, `from_intersection`, and `to_intersection`.
+In this update, there exists an Excel Sheet template that contains details of newly added bluetooth detectors. The details include proposed routes `Name`, `Description`, intersection name as `Name` (according to BDIT convention), four digit bluetooth sensor identification number  as `Sensor` and `latitude/longitude` at start point and the end points along with numerous other fields. 
 
-```SQL
-SELECT analysis_id, split_part(report_name, ' ', 1) AS corridor, report_name
-, 
-CASE WHEN split_part(report_name,  ' ', array_length(regexp_split_to_array(report_name, ' to '), 1))='Mt' THEN 'Mt Pleasant' ELSE split_part(report_name,  ' ', array_length(regexp_split_to_array(report_name, ' to '), 1)) END AS from_intersection,
-split_part(report_name,  ' to ', 2) As to_intersection
---INTO rliu.new_bt_corridors
-FROM rliu.new_bt_routes
+This template was used to include all the details of the routes that can be useful for future analysis. The routes that were updated by adding this batch of new detectors were named with a prefix "DT3_" . 
 
-WHERE split_part(report_name,  ' to ', 2) <> ''
-ORDER BY from_intersection
-```
 
 ## Adding Readers
 
-This update had the lat/long given in the form of a kml file. This data needs to be uploaded to the database. Depending on how many new readers there are, it may be worthwile to develop an automated process in PostgreSQL, but this update was done manually in excel. In addition to the lat/long, the streets where the readers are is also needed in 2 columns, and the segment name. The segment name is always the first two letters of each street, with the corridor street first and the intersecting street second. For example, a reader at Bloor/Christie measuring travel times on Bloor would be named `BL_CH`. 
+New readers were added manually in the Excel template and saved as .csv file. In addition to the lat/lon, the street names at each intersection where the readers are located is also needed in two columns for each route as the `from_street` and `to_street`. The `Description` field contains this information. For each proposed route, the excel sheet is populated and assigned a unique `analysis_id`. For this batch of new readers, analysis id starting from 1600000 with increment of 10 were added. 
 
-After uploading data to PostgreSQL, the geometry string is needed. This can be done by adding a column using `ALTER TABLE schema.table_name ADD COLUMN geom GEOMETRY` and then filling in the column with `UPDATE TABLE schema.table_name SET geom = ST_MakePoint(lat, long)`.
+Therefore the new reader table had the following fields populated: 
 
-## Fuzzy String Matching
+`analysis_id` 		- Unique ID for each route
+`street` 			- Name of the street along the route
+`direction` 		- Route direction(East bound, West Bound, North Bound or South Bound)
+`from_street` 		- Name of the intersecting street where the route begins.
+`to_street`			- Name of the intersecting street where the route ends 
+`from_name`			- The reader name (bdit convention) at the start point of the route
+`from_id` 			- The four digit Unique bluetooth id at the start point
+`from_lat` 			- Latitude at the start point of the route
+`from_lon` 			- Longitude at the start point of the route
+`to_name` 			- The reader name (bdit convention) at the end point of the route
+`to_id`				- The four digit Unique bluetooth id at the end point
+`to_lat`			- Latitude at the end point of the route
+`to_lon`			- Longitude at the end point of the route
+`length`			- Length of the route in metres 
 
-The general process was first done to update the speed limits of roads in the centreline table. Please read the [process done for that](https://github.com/CityofToronto/bdit_data-sources/blob/master/gis/PostedSpeedLimitUpdate.md) for more detail. The gist of it is this:
 
-* A straight line is drawn between two readers
-* Road segments with similar/exact names to the drawn line is matched to that straight line
+## Preparatory Tables and Steps
+The following steps are utilized to create segments
+1. Get start and end geom for each analysis_id using the provided lat and lon 
+2. Create table with detector_id, detector_geom, centreline_int_id
+3. Join the detector's geometry to the closest centreline intersection
+4. Route the segments using centreline's intersection with the base network of `gis.centreline_both_dir` using [pgr_dijkstra].
 
-### Explanation of Query
 
-```SQL
-WITH from_join AS (
-SELECT * FROM rliu.new_bt_corridors B
-CROSS JOIN rliu.new_bt_readers A
-WHERE levenshtein(A.reader_name, B.from_intersection, 1, 1, 2) < 4)
+This .csv file was then imported into our postgresql database. The geometry column was created by adding a column using 
+```sql
+ALTER TABLE mohan.new_added_detectors ADD COLUMN from_geom GEOMETRY;
+ALTER TABLE mohan.new_added_detectors ADD COLUMN to_geom GEOMETRY;
+```
+Then create the geometry using lon and lat
+```sql
+UPDATE mohan.new_added_detectors 
+SET to_geom = ST_SetSRID(ST_MakePoint(to_lon, to_lat), 4326)
+SET from_geom = ST_SetSRID(ST_MakePoint(from_lon, from_lat), 4326)
 ```
 
-Matches the corridors to the names based on similar from intersections.
+## Finding Nearest Intersection IDs
+
+To get the intersection ids that are the closest to the newly added detectors location, create a table named `bluetooth_nodes`. This table has four fields:
+`bluetooth_id`, `geom` (geometry of bluetooth detectors), `int_id` (nearest intersection id) and `int_geom` (geometry of the nearest intersection to the bluetooth detector)
+
+This table is created using the following query:
+```SQL
+CREATE TABLE mohan.bluetooth_nodes AS(
+SELECT DISTINCT mohan.new_added_detectors.from_id::integer AS bluetooth_id,
+    			mohan.new_added_detectors.from_geom,
+    			nodes.int_id,
+    			st_transform(nodes.node_geom, 4326) AS int_geom
+   	FROM 		mohan.new_added_detectors
+ 	CROSS JOIN LATERAL (SELECT 		z.int_id,
+            						st_transform(z.geom, 98012) AS node_geom
+           				FROM 		gis.centreline_intersection z
+          				ORDER BY 	(z.geom <-> mohan.new_added_detectors.from_geom)
+         				LIMIT 1) nodes);
+```
+Check that correct intersections are returned from this query especially for oblique intersections with an offset. If required, correct the intersection_id and geom for such intersections and finalize the table `mohan.bluetooth_nodes`. An example is shown below. The intersection between Dundas St W, Roncesvalles Ave and Boustead Ave is oblique with an offset. The BT reader 5263 (red dot) picked up intersection_id `13466305` (greed dot) as nearest intersection to the reader. But the planned route does not go through this intersection_id. The correct intersection_id for this reader is `13466258`. The intersection_id and geom for this reader was therefore corrected manually.  
+ 
+
+## Using pg_routing
+Once the nearest centreline intersection nodes are linked to the bluetooth readers geom in `mohan.bluetooth_nodes`, we are ready to run the following Query to create new routes by routing. 
 
 ```SQL
-, to_join AS (
-SELECT * FROM rliu.new_bt_corridors B
-CROSS JOIN rliu.new_bt_readers A
-WHERE levenshtein(A.reader_name, B.to_intersection, 1, 1, 2) < 4)
-```
-Does the same thing for the to_intersections
+CREATE table mohan.bt_segments_new AS (
+WITH lookup AS (
+	SELECT 		analysis_id, 
+				from_id, 
+				origin.int_id AS source, 
+				to_id, 
+				dest.int_id AS target
+	FROM 		mohan.new_added_detectors 
+	INNER JOIN 	mohan.bluetooth_nodes origin ON from_id = origin.bluetooth_id 
+	INNER JOIN 	mohan.bluetooth_nodes dest ON to_id = dest.bluetooth_id)
 
-```SQL
-, joined_readers AS (
-SELECT A.analysis_id, A.corridor, A.reader_name AS from_intersection, A.long AS from_long, A.lat AS from_lat, B.reader_name AS to_intersection, B.long AS to_long, B.lat AS to_lat FROM from_join A
-INNER JOIN to_join B USING (analysis_id)
-)
-```
+, results AS (
+	SELECT * 
+	FROM lookup
+	CROSS JOIN LATERAL pgr_dijkstra('SELECT id, source, target, cost FROM gis.centreline_routing_directional inner join gis.centreline on geo_id = id
+where fcode != 207001', source::int, target::int, TRUE))
 
-Makes a single table for the corridors and readers at the from/to intersections.
+, lines as (
+	SELECT 		analysis_id, 
+				street, 
+				direction, 
+				from_street, 
+				to_street, 
+				edge AS geo_id, 
+				geom 
+	FROM 		results			 
+	INNER JOIN 	gis.centreline ON edge=geo_id
+	INNER JOIN 	mohan.new_added_detectors USING (analysis_id)
+	ORDER BY 	analysis_id)
 
-```SQL
-
-, make_lines AS (
-SELECT analysis_id, 
-	corridor, 
-	from_intersection, 
-	from_long, 
-	from_lat, 
-	to_intersection, 
-	to_long, 
-	to_lat,
-	ST_MakeLine(ST_MakePoint(from_long, from_lat), ST_MakePoint(to_long, to_lat)) AS line,
-	ST_LENGTH(ST_MakeLine(ST_MakePoint(from_long, from_lat), ST_MakePoint(to_long, to_lat))) AS length 
-FROM 	joined_readers
---Since there are two readers named Sheppard, this is a check to stop it from matching to the wrong reader
-WHERE  ST_LENGTH(ST_MakeLine(ST_MakePoint(from_long, from_lat), ST_MakePoint(to_long, to_lat)))<0.1
-ORDER BY from_intersection
-)
-```
-Draws lines using the reader locations. This is the result.
-
-![bt_lines](img/bt_lines.PNG)
-
-```SQL
-, conflation AS (
-SELECT analysis_id, 
-	corridor, 
-	from_intersection, 
-	from_long, 
-	from_lat, 
-	to_intersection, 
-	to_long, 
-	to_lat, s.geom, geo_id, s.lf_name, 
-	ST_Length(st_intersection(ST_BUFFER(ST_Transform(ST_SetSRID(line, 4326), 32190), 1.5*b.length, 'endcap=flat join=round') , ST_Transform(s.geom, 32190))) /ST_Length(ST_Transform(s.geom, 32190))
-	
-	FROM make_lines b
-
-INNER JOIN rliu.bt_centreline s 
-ON 
-ST_DWithin( ST_Transform(s.geom, 32190) ,  ST_BUFFER(ST_Transform(ST_SetSRID(line, 4326), 32190), 3*b.length, 'endcap=flat join=round') , 1000)
-
-
---AND ST_Length(st_intersection(ST_BUFFER(ST_Transform(ST_SetSRID(line, 4326), 32190), 1.5*b.length, 'endcap=flat join=round') , ST_Transform(s.geom, 32190))) /ST_Length(ST_Transform(s.geom, 32190)) > 0.4
-)
-
-SELECT * 
-INTO rliu.new_bt_coflate1000 
-FROM conflation
+SELECT analysis_id, street, direction, from_street, to_street,
+	CASE WHEN geom_dir != direction THEN ST_reverse(geom) 
+	ELSE geom 
+	END AS geom, 
+	length
+FROM ( 
+SELECT analysis_id, street, direction, from_street, to_street, 
+		gis.twochar_direction(gis.direction_from_line(ST_linemerge(ST_union(geom)))) AS geom_dir,
+		ST_linemerge(ST_union(geom)) AS geom, 
+		ST_length(ST_transform(ST_linemerge(ST_union(geom)), 2952)) AS length
+FROM lines
+GROUP BY analysis_id, street, direction, from_street, to_street) a)
 ```
 
-Matches the centreline road segment to the drawn lines. Note the buffer is really large (1000 units) to account for segments that run accross multiple roads.
+## Things to note 
+A number of centreline need to be excluded during routing, for example: Geostatistical lines and planning boundaries. Those can be filtered using the following where clause: 
+```sql
+WHERE fcode_desc IN ('Collector','Collector Ramp','Expressway','Expressway Ramp',
+'Local','Major Arterial','Major Arterial Ramp','Minor Arterial',
+'Minor Arterial Ramp','Pending')
+``` 
 
-After proper QC (see next section) is applied, it should something like this.
+## Validating Output
+Validate the length of the segments with length `ST_length(geom)` and direction using `gis.direction_from_line(geom)` functions. If the detectors are located very close to the centerline intersections, it is not necessary to do the centreline cutting. If any bluetooth detectors are not located at the start or end point of a centreline, we will need to cut the centreline using `ST_linesubstring()` as explained in [here.](https://github.com/CityofToronto/bdit_data-sources/issues/234).  
 
-![bt_segments](img/bt_segments.PNG)
-
-## Cleanup, Warnings, and Alternative Methods
-
-This method works really well for straight roads/segments. However, this is especially challenging for segments that are perpendicular, involves curves, or weird geometries/routes. 
-
-A lot of mannual cleanup was required to delete extraneous roads, or add roads to the route, mainly through the `UPDATE` and `DELETE` clauses and using the `geo_ids` from the centreline table.
-
-An alternative method is drawing routes in QGIS connecting the readers on the centreline layer. This may be faster for low number of segments (ex <500).
-
-## Making Lines
-
-At this point, the layer has multiple entries containing centreline segments for each analysis_id. Instead, we need a single line/entry for each analysis_id. This query concatenates the individual centreline segments into one line. The main function doing this work is [`ST_LineMerge()`](https://postgis.net/docs/ST_LineMerge.html)
-
-```SQL
-SELECT A.analysis_id, A.corridor, A.from_intersection,A.from_long, A.from_lat, A.to_intersection, A.to_long, A.to_lat,  A.geo_id,  A.lf_name, (ST_Dump(A.geom)).geom AS geom 
-INTO rliu.new_bt_segments
-from (SELECT ST_LineMerge(ST_Union(A.geom)) AS geom, A.analysis_id, A.corridor,A.from_intersection, A.from_long, A.from_lat, A.to_intersection, A.to_long, A.to_lat, array_agg(DISTINCT A.geo_id) AS geo_id, array_agg(DISTINCT A.lf_name) AS lf_name FROM new_bt_coflate300 A
-GROUP BY A.analysis_id, A.corridor, A.from_intersection, A.from_long, A.from_lat, A.to_intersection, A.to_long, A.to_lat ORDER BY analysis_id) A
+Steps to cut centreline using `ST_linesubstring()`:
+1) Find the closest point of the detector on the centreline with [ST_closespoint()](https://postgis.net/docs/ST_ClosestPoint.html).   
+```sql
+ST_closestpoint(detector_geom, centreline_geom)
 ```
-After this, the only step is to format the table so it matches `bluetooth.segments`.
+2) Return the location of the point relative to the centreline using [`ST_linelocatepoint()`](https://postgis.net/docs/ST_LineLocatePoint.html)
+```sql
+ST_linelocatepoint(geom, closest_point_geom)
+```
+3) Cut the line using [`ST_linesubstring()`](https://postgis.net/docs/ST_LineSubstring.html) 
+```sql
+ST_linesubstring(geom, 0, st_linelocatepoint)
+```
+
+The new routes table is now ready to append to the existing routes table.  
+
+[pgr_dijkstra]:https://docs.pgrouting.org/latest/en/pgr_dijkstra.html

--- a/bluetooth/update/README.md
+++ b/bluetooth/update/README.md
@@ -19,94 +19,79 @@ Ocasionally, new segments need to be added to the `bluetooth` schema. This docum
 
 ## Data Updating
 
-In this update, there exists an Excel Sheet template that contains details of newly added bluetooth detectors. The details include proposed routes `Name`, `Description`, intersection name as `Name` (according to BDIT convention), four digit bluetooth sensor identification number  as `Sensor` and `latitude/longitude` at start point and the end points along with numerous other fields. 
-
-This template was used to include all the details of the routes that can be useful for future analysis. The routes that were updated by adding this batch of new detectors were named with a prefix "DT3_" . 
+To update segments, the vendor will provide an excel file containing the details of newly added bluetooth detectors, which includes proposed routes `Name`, `Description`, intersection name as `Name`, four digit bluetooth sensor identification number as `Sensor` and `latitude/longitude` as start point and the end points along with numerous other fields. 
 
 
 ## Adding Readers
 
-New readers were added manually in the Excel template and saved as .csv file. In addition to the lat/lon, the street names at each intersection where the readers are located is also needed in two columns for each route as the `from_street` and `to_street`. The `Description` field contains this information. For each proposed route, the excel sheet is populated and assigned a unique `analysis_id`. For this batch of new readers, analysis id starting from 1600000 with increment of 10 were added. 
+New readers were added manually to the database. In addition to the lat/lon, street names at each intersection where the readers are located is also needed in two columns for each route as the `from_street` and `to_street`. The `Description` field contains this information. For each proposed route, the excel sheet is populated and assigned a unique `analysis_id`. 
 
 Therefore the new reader table had the following fields populated: 
 
 `analysis_id` 		- Unique ID for each route
 `street` 			- Name of the street along the route
-`direction` 		- Route direction(East bound, West Bound, North Bound or South Bound)
+`direction` 		- Route direction(Eastbound, WestBound, NorthBound or SouthBound)
 `from_street` 		- Name of the intersecting street where the route begins.
 `to_street`			- Name of the intersecting street where the route ends 
-`from_name`			- The reader name (bdit convention) at the start point of the route
+`from_name`			- The reader name  at the start point of the route
 `from_id` 			- The four digit Unique bluetooth id at the start point
 `from_lat` 			- Latitude at the start point of the route
 `from_lon` 			- Longitude at the start point of the route
-`to_name` 			- The reader name (bdit convention) at the end point of the route
+`to_name` 			- The reader name  at the end point of the route
 `to_id`				- The four digit Unique bluetooth id at the end point
 `to_lat`			- Latitude at the end point of the route
 `to_lon`			- Longitude at the end point of the route
 `length`			- Length of the route in metres 
-
 
 ## Preparatory Tables and Steps
 The following steps are utilized to create segments
 1. Get start and end geom for each analysis_id using the provided lat and lon 
 2. Create table with detector_id, detector_geom, centreline_int_id
 3. Join the detector's geometry to the closest centreline intersection
-4. Route the segments using centreline's intersection with the base network of `gis.centreline_both_dir` using [pgr_dijkstra].
+4. Route the segments using centreline's intersection with the base network of `gis_core.routing_centreline_directional` using [pgr_dijkstra].
 
-
-This .csv file was then imported into our postgresql database. The geometry column was created by adding a column using 
-```sql
-ALTER TABLE mohan.new_added_detectors ADD COLUMN from_geom GEOMETRY;
-ALTER TABLE mohan.new_added_detectors ADD COLUMN to_geom GEOMETRY;
-```
-Then create the geometry using lon and lat
-```sql
-UPDATE mohan.new_added_detectors 
-SET to_geom = ST_SetSRID(ST_MakePoint(to_lon, to_lat), 4326)
-SET from_geom = ST_SetSRID(ST_MakePoint(from_lon, from_lat), 4326)
-```
 
 ## Finding Nearest Intersection IDs
 
 To get the intersection ids that are the closest to the newly added detectors location, create a table named `bluetooth_nodes`. This table has four fields:
 `bluetooth_id`, `geom` (geometry of bluetooth detectors), `int_id` (nearest intersection id) and `int_geom` (geometry of the nearest intersection to the bluetooth detector)
 
-This table is created using the following query:
+This table can be created using the following query:
 ```SQL
-CREATE TABLE mohan.bluetooth_nodes AS(
-SELECT DISTINCT mohan.new_added_detectors.from_id::integer AS bluetooth_id,
-    			mohan.new_added_detectors.from_geom,
+CREATE TABLE your_schema.bluetooth_nodes AS(
+SELECT DISTINCT your_schema.new_added_detectors.from_id::integer AS bluetooth_id,
+    			your_schema.new_added_detectors.from_geom,
     			nodes.int_id,
     			st_transform(nodes.node_geom, 4326) AS int_geom
-   	FROM 		mohan.new_added_detectors
+   	FROM 		your_schema.new_added_detectors
  	CROSS JOIN LATERAL (SELECT 		z.int_id,
-            						st_transform(z.geom, 98012) AS node_geom
-           				FROM 		gis.centreline_intersection z
-          				ORDER BY 	(z.geom <-> mohan.new_added_detectors.from_geom)
+            						st_transform(z.geom, 2952) AS node_geom
+           				FROM 		gis_core.centreline_intersection_point_latest z
+          				ORDER BY 	(z.geom <-> your_schema.new_added_detectors.from_geom)
          				LIMIT 1) nodes);
 ```
-Check that correct intersections are returned from this query especially for oblique intersections with an offset. If required, correct the intersection_id and geom for such intersections and finalize the table `mohan.bluetooth_nodes`. An example is shown below. The intersection between Dundas St W, Roncesvalles Ave and Boustead Ave is oblique with an offset. The BT reader 5263 (red dot) picked up intersection_id `13466305` (greed dot) as nearest intersection to the reader. But the planned route does not go through this intersection_id. The correct intersection_id for this reader is `13466258`. The intersection_id and geom for this reader was therefore corrected manually.  
+Check that correct intersections are returned from this query especially for oblique intersections with an offset. If required, correct the intersection_id and geom for such intersections and finalize the table `your_schema.bluetooth_nodes`. 
  
 
 ## Using pg_routing
-Once the nearest centreline intersection nodes are linked to the bluetooth readers geom in `mohan.bluetooth_nodes`, we are ready to run the following Query to create new routes by routing. 
+Once the nearest centreline intersection nodes are linked to the bluetooth readers geom in `your_schema.bluetooth_nodes`, we are ready to run the following Query to create new routes by routing. 
 
 ```SQL
-CREATE table mohan.bt_segments_new AS (
+CREATE table your_schema.bt_segments_new AS (
 WITH lookup AS (
 	SELECT 		analysis_id, 
 				from_id, 
 				origin.int_id AS source, 
 				to_id, 
 				dest.int_id AS target
-	FROM 		mohan.new_added_detectors 
-	INNER JOIN 	mohan.bluetooth_nodes origin ON from_id = origin.bluetooth_id 
-	INNER JOIN 	mohan.bluetooth_nodes dest ON to_id = dest.bluetooth_id)
+	FROM 		your_schema.new_added_detectors 
+	INNER JOIN 	your_schema.bluetooth_nodes origin ON from_id = origin.bluetooth_id 
+	INNER JOIN 	your_schema.bluetooth_nodes dest ON to_id = dest.bluetooth_id)
 
 , results AS (
 	SELECT * 
 	FROM lookup
-	CROSS JOIN LATERAL pgr_dijkstra('SELECT id, source, target, cost FROM gis.centreline_routing_directional inner join gis.centreline on geo_id = id
+	CROSS JOIN LATERAL pgr_dijkstra('SELECT id, source, target, cost FROM gis_core.routing_centreline_directional inner join gis_core.centreline_latest on geo_id = id
 where fcode != 207001', source::int, target::int, TRUE))
 
 , lines as (
@@ -118,8 +103,8 @@ where fcode != 207001', source::int, target::int, TRUE))
 				edge AS geo_id, 
 				geom 
 	FROM 		results			 
-	INNER JOIN 	gis.centreline ON edge=geo_id
-	INNER JOIN 	mohan.new_added_detectors USING (analysis_id)
+	INNER JOIN 	gis_core.centreline_latest ON edge=geo_id
+	INNER JOIN 	your_schema.new_added_detectors USING (analysis_id)
 	ORDER BY 	analysis_id)
 
 SELECT analysis_id, street, direction, from_street, to_street,


### PR DESCRIPTION
## What this pull request accomplishes:

- supersede PR #381 
- Added 3 functions that are currently in use and remove `_temp` from them
- merge parts of readme that is still relevant and updated outdated tables

## Issue(s) this solves:

- #381 

## What, in particular, needs to reviewed:

- if i missed anything needed from 381

## What needs to be done by a sysadmin after this PR is merged

un _temp all relevant tables and functions in the database + airflow dag

Once this is merged, we can close the 381 PR