### PR TITLE
#1431 Ecocounter API V2 Migration

### DIFF
--- a/dags/ecocounter_pull.py
+++ b/dags/ecocounter_pull.py
@@ -31,7 +31,7 @@ try:
     from bdit_dag_utils.utils.common_tasks import check_jan_1st, wait_for_weather_timesensor
     from bdit_dag_utils.utils.custom_operators import SQLCheckOperatorWithReturnValue
     from volumes.ecocounter.pull_data_from_api import (
-        getToken, getSites, siteIsKnownToUs, insertSite, insertFlow,
+        getSites, siteIsKnownToUs, insertSite, insertFlow,
         flowIsKnownToUs, getKnownSites, getKnownFlows, truncate_and_insert
     )
 except:
@@ -87,22 +87,17 @@ def pull_ecocounter_dag():
         create_annual_partition
     
     def get_connections():
-        api_conn = BaseHook.get_connection('ecocounter_api_key')
-        token = getToken(
-            api_conn.host,
-            api_conn.login,
-            api_conn.password,
-            api_conn.extra_dejson['secret_api_hash']
-        )
+        api_conn = BaseHook.get_connection('ecocounter_api_key_v2')
+        pw = api_conn.password
         eco_postgres = PostgresHook("ecocounter_bot")
-        return eco_postgres, token
+        return eco_postgres, pw
 
     @task(trigger_rule='none_failed')
     def update_sites_and_flows(**context):
-        eco_postgres, token = get_connections()
+        eco_postgres, pw = get_connections()
         new_sites, new_flows = [], []
         with eco_postgres.get_conn() as conn:
-            for site in getSites(token):
+            for site in getSites(pw):
                 site_id, site_name, counter = site['id'], site['name'], site['counter']
                 if not siteIsKnownToUs(site_id, conn):
                     insertSite(conn, site_id, site_name, counter, site['longitude'], site['latitude'])
@@ -114,7 +109,7 @@ def pull_ecocounter_dag():
                 for flow in site['channels']:
                     flow_id, flow_name = flow['id'], flow['name']
                     if not flowIsKnownToUs(flow_id, conn):
-                        insertFlow(conn, flow_id, site_id, flow_name, flow['interval'])
+                        insertFlow(conn, flow_id, site_id, flow_name, flow['granularity'])
                         new_flows.append({
                             'site_id': site_id,
                             'flow_id': flow_id,
@@ -145,7 +140,7 @@ def pull_ecocounter_dag():
 
     @task(trigger_rule='none_failed')
     def pull_ecocounter(ds):
-        eco_postgres, token = get_connections()
+        eco_postgres, pw = get_connections()
         start_date = dateutil.parser.parse(str(ds))
         end_date = dateutil.parser.parse(str(ds_add(ds, 1)))
         LOGGER.info(f'Pulling data from {start_date} to {end_date}.')
@@ -153,11 +148,11 @@ def pull_ecocounter_dag():
             for site_id in getKnownSites(conn):
                 LOGGER.debug(f'Starting on site {site_id}.')
                 for flow_id in getKnownFlows(conn, site_id):
-                    truncate_and_insert(conn, token, flow_id, start_date, end_date)
+                    truncate_and_insert(conn, pw, flow_id, start_date, end_date)
 
     @task(trigger_rule='none_failed')
     def pull_recent_outages():
-        eco_postgres, token = get_connections()
+        eco_postgres, pw = get_connections()
         #get list of outages
         outage_query = "SELECT flow_id, start_time, end_time FROM ecocounter.identify_outages('6 months'::interval);"
         with eco_postgres.get_conn() as conn, conn.cursor() as curr:
@@ -167,7 +162,7 @@ def pull_ecocounter_dag():
         with eco_postgres.get_conn() as conn:
             for outage in recent_outages:
                 flow_id, start_date, end_date = outage
-                truncate_and_insert(conn, token, flow_id, start_date, end_date)
+                truncate_and_insert(conn, pw, flow_id, start_date, end_date)
 
     t_done = ExternalTaskMarker(
         task_id="done",

--- a/dags/ecocounter_pull.py
+++ b/dags/ecocounter_pull.py
@@ -88,9 +88,9 @@ def pull_ecocounter_dag():
     
     def get_connections():
         api_conn = BaseHook.get_connection('ecocounter_api_key_v2')
-        pw = api_conn.password
+        password_getter = lambda: api_conn.password
         eco_postgres = PostgresHook("ecocounter_bot")
-        return eco_postgres, pw
+        return eco_postgres, password_getter
 
     @task(trigger_rule='none_failed')
     def update_sites_and_flows(**context):

--- a/dags/ecocounter_pull.py
+++ b/dags/ecocounter_pull.py
@@ -32,7 +32,7 @@ try:
     from bdit_dag_utils.utils.custom_operators import SQLCheckOperatorWithReturnValue
     from volumes.ecocounter.pull_data_from_api import (
         getSites, siteIsKnownToUs, insertSite, insertFlow,
-        flowIsKnownToUs, getKnownSites, getKnownFlows, truncate_and_insert
+        flowIsKnownToUs, getKnownSites, truncate_and_insert
     )
 except:
     raise ImportError("Cannot import DAG helper functions.")
@@ -98,18 +98,17 @@ def pull_ecocounter_dag():
         new_sites, new_flows = [], []
         with eco_postgres.get_conn() as conn:
             for site in getSites(pw):
-                site_id, site_name, counter = site['id'], site['name'], site['counter']
+                site_id, site_name = site['id'], site['name']
                 if not siteIsKnownToUs(site_id, conn):
-                    insertSite(conn, site_id, site_name, counter, site['longitude'], site['latitude'])
+                    insertSite(conn, site_id, site_name, site['longitude'], site['latitude'])
                     new_sites.append({
                         'site_id': site_id,
                         'site_name': site_name
                     })
-                # what we refer to as a flow is known as a "channel" in ecocounter API.
-                for flow in site['channels']:
+                for flow in site['flows']:
                     flow_id, flow_name = flow['id'], flow['name']
                     if not flowIsKnownToUs(flow_id, conn):
-                        insertFlow(conn, flow_id, site_id, flow_name, flow['granularity'])
+                        insertFlow(conn, flow_id, site_id, flow_name, site['granularity'])
                         new_flows.append({
                             'site_id': site_id,
                             'flow_id': flow_id,
@@ -147,22 +146,21 @@ def pull_ecocounter_dag():
         with eco_postgres.get_conn() as conn:
             for site_id in getKnownSites(conn):
                 LOGGER.debug(f'Starting on site {site_id}.')
-                for flow_id in getKnownFlows(conn, site_id):
-                    truncate_and_insert(conn, pw, flow_id, start_date, end_date)
+                truncate_and_insert(conn, pw, site_id, start_date, end_date)
 
     @task(trigger_rule='none_failed')
     def pull_recent_outages():
         eco_postgres, pw = get_connections()
         #get list of outages
-        outage_query = "SELECT flow_id, start_time, end_time FROM ecocounter.identify_outages('6 months'::interval);"
+        outage_query = "SELECT site_id, start_time, end_time FROM ecocounter.identify_site_outages('6 months'::interval);"
         with eco_postgres.get_conn() as conn, conn.cursor() as curr:
             curr.execute(outage_query)
             recent_outages = curr.fetchall()
         #for each outage, try to pull data
         with eco_postgres.get_conn() as conn:
             for outage in recent_outages:
-                flow_id, start_date, end_date = outage
-                truncate_and_insert(conn, pw, flow_id, start_date, end_date)
+                site_id, start_date, end_date = outage
+                truncate_and_insert(conn, pw, site_id, start_date, end_date)
 
     t_done = ExternalTaskMarker(
         task_id="done",
@@ -195,9 +193,9 @@ def pull_ecocounter_dag():
         wait_for_weather_timesensor() >> check_volume
 
     (
-        pull_recent_outages(),
         check_partitions() >>
         update_sites_and_flows() >>
+        pull_recent_outages() >> #move inline to prevent too many concurrent requests
         pull_ecocounter() >>
         t_done >>
         data_checks()

--- a/volumes/ecocounter/functions/create-function-identify-outages.sql
+++ b/volumes/ecocounter/functions/create-function-identify-outages.sql
@@ -1,8 +1,8 @@
-CREATE OR REPLACE FUNCTION ecocounter.identify_outages(
+CREATE OR REPLACE FUNCTION ecocounter.identify_site_outages(
     num_days interval
 )
 RETURNS TABLE (
-    flow_id numeric,
+    site_id numeric,
     start_time timestamp,
     end_time timestamp
 )
@@ -17,7 +17,6 @@ BEGIN
 RETURN QUERY
 WITH ongoing_outages AS (
     SELECT
-        f.flow_id,
         f.site_id,
         dates.dt::date,
         dates.dt - lag(dates.dt) OVER w = interval '1 day' AS consecutive
@@ -39,8 +38,8 @@ WITH ongoing_outages AS (
         f.validated
         AND dates.dt < COALESCE(f.date_decommissioned, now()::date - interval '1 day')
     GROUP BY
-        f.flow_id,
         f.site_id,
+        f.bin_size,
         f.validated,
         f.last_active,
         f.date_decommissioned,
@@ -49,39 +48,39 @@ WITH ongoing_outages AS (
         SUM(c.volume) IS NULL
         --not all datetime bins present, corrected for bin size
         OR COUNT(DISTINCT c.datetime_bin) <> (3600*24 / EXTRACT(epoch FROM f.bin_size))
-    WINDOW w AS (PARTITION BY f.flow_id ORDER BY dates.dt)
+    WINDOW w AS (PARTITION BY f.site_id ORDER BY dates.dt)
     ORDER BY
-        f.flow_id,
+        f.site_id,
         dates.dt
 ),
 
 group_ids AS (
     SELECT
-        oo.flow_id,
+        oo.site_id,
         oo.dt,
         SUM(CASE WHEN oo.consecutive IS TRUE THEN 0 ELSE 1 END) OVER w AS group_id
     FROM ongoing_outages AS oo
-    WINDOW w AS (PARTITION BY oo.flow_id ORDER BY oo.dt)
+    WINDOW w AS (PARTITION BY oo.site_id ORDER BY oo.dt)
 )
 
 SELECT
-    gi.flow_id,
+    gi.site_id,
     MIN(gi.dt)::timestamp AS start_time,
     MAX(gi.dt) + interval '1 day' AS end_time
 FROM group_ids AS gi
 GROUP BY
-    gi.flow_id,
+    gi.site_id,
     gi.group_id;
 
 END;
 $BODY$;
 
-ALTER FUNCTION ecocounter.identify_outages(interval) OWNER TO ecocounter_admins;
-GRANT ALL ON FUNCTION ecocounter.identify_outages(interval) TO ecocounter_admins;
+ALTER FUNCTION ecocounter.identify_site_outages(interval) OWNER TO ecocounter_admins;
+GRANT ALL ON FUNCTION ecocounter.identify_site_outages(interval) TO ecocounter_admins;
 
-GRANT EXECUTE ON FUNCTION ecocounter.identify_outages(interval) TO bdit_humans;
-GRANT EXECUTE ON FUNCTION ecocounter.identify_outages(interval) TO ecocounter_bot;
+GRANT EXECUTE ON FUNCTION ecocounter.identify_site_outages(interval) TO bdit_humans;
+GRANT EXECUTE ON FUNCTION ecocounter.identify_site_outages(interval) TO ecocounter_bot;
 
-COMMENT ON FUNCTION ecocounter.identify_outages(interval)
+COMMENT ON FUNCTION ecocounter.identify_site_outages(interval)
 IS 'A function to identify day level outages (null volume) in Ecocounter data and group
 them into runs for ease of pulling. Used by Airflow ecocounter_pull.pull_recent_outages task.';

--- a/volumes/ecocounter/pull_data_from_api.py
+++ b/volumes/ecocounter/pull_data_from_api.py
@@ -1,5 +1,6 @@
 import requests
 import logging
+from typing import Callable
 from configparser import ConfigParser
 from psycopg2 import connect
 from psycopg2.extras import execute_values
@@ -14,7 +15,8 @@ default_end = datetime.now().replace(hour = 0, minute = 0, second = 0, microseco
 URL = 'https://api.eco-counter.com/api/v2/'
 
 # get a list of all sites from the API
-def getSites(pw: str, sites: any = ()):
+def getSites(password_getter: Callable[[], str], sites: any = ()):
+    pw = password_getter() # Retrieve only when needed
     response = requests.get(
         f'{URL}/sites',
         headers={'X-API-KEY': f'{pw}'}
@@ -29,10 +31,11 @@ def getSites(pw: str, sites: any = ()):
     for site in response.json():
         if site['id'] in sites:
             result.append(site)
-    return result        
+    return result
 
 # get all of a flows ("channel") data from the API
-def getFlowData(pw: str, flow_id: int, startDate: datetime, endDate: datetime):
+def getFlowData(password_getter: Callable[[], str], flow_id: int, startDate: datetime, endDate: datetime):
+    pw = password_getter() # Retrieve only when needed
     requestChunkSize = timedelta(days=100)
     requestStart = startDate
     data = []
@@ -162,8 +165,8 @@ def run_api(
     config.read(CONFIG_PATH)
     conn = connect(**config['DBSETTINGS'])
     conn.autocommit = True
-    pw = config['API']['password']
-    for site in getSites(pw, sites=sites): #optionally specify site_ids here. 
+    password_getter = lambda: config['API']['password']
+    for site in getSites(password_getter, sites=sites): #optionally specify site_ids here. 
         # only update data for sites / flows in the database
         # but announce unknowns for manual validation if necessary
         if not siteIsKnownToUs(site['id'], conn):
@@ -175,4 +178,4 @@ def run_api(
             if not flowIsKnownToUs(flow_id, conn):
                 print('unknown flow', flow_id)
                 continue
-            truncate_and_insert(conn, pw, flow_id, start_date, end_date)
+            truncate_and_insert(conn, password_getter, flow_id, start_date, end_date)

--- a/volumes/ecocounter/pull_data_from_api.py
+++ b/volumes/ecocounter/pull_data_from_api.py
@@ -6,6 +6,7 @@ from psycopg2 import connect
 from psycopg2.extras import execute_values
 from datetime import datetime, timedelta
 from airflow.exceptions import AirflowFailException
+import time
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,7 +20,11 @@ def getSites(password_getter: Callable[[], str], sites: any = ()):
     pw = password_getter() # Retrieve only when needed
     response = requests.get(
         f'{URL}/sites',
-        headers={'X-API-KEY': f'{pw}'}
+        headers={'X-API-KEY': f'{pw}'},
+        params={
+            'include': 'flows',
+            'pageSize': 500
+        }
     )
     if response.status_code!=200:
         raise AirflowFailException(f"{response.status_code}: {response.reason}")
@@ -33,31 +38,38 @@ def getSites(password_getter: Callable[[], str], sites: any = ()):
             result.append(site)
     return result
 
-# get all of a flows ("channel") data from the API
-def getFlowData(password_getter: Callable[[], str], flow_id: int, startDate: datetime, endDate: datetime):
+# get all of a site's data from the API
+def getSiteData(password_getter: Callable[[], str], site_id: int, startDate: datetime, endDate: datetime):
     pw = password_getter() # Retrieve only when needed
-    requestChunkSize = timedelta(days=100)
+    requestChunkSize = timedelta(days=30)
     requestStart = startDate
     data = []
     while requestStart < endDate:
         requestEnd = min(requestStart + requestChunkSize, endDate)
-        response = requests.get(
-            f'{URL}/history/traffic/raw/site/{flow_id}',
-            headers={'X-API-KEY': pw},
-            params={
-                'begin': requestStart.isoformat(timespec='seconds'),
-                'end':  requestEnd.isoformat(timespec='seconds'),
-                'complete': 'false',
-                'step': '15m'
-            }
-        )
-        if response.status_code==200:
-            data += response.json()
-            requestStart += requestChunkSize
-        elif response.status_code==401:
-            raise AirflowFailException(f"{response.status_code}: {response.reason}")
-        else:
-            raise AirflowFailException(f"{response.status_code}: {response.reason}")
+        for _ in range(3):
+            response = requests.get(
+                f'{URL}/history/traffic/raw',
+                headers={'X-API-KEY': pw},
+                params={
+                    'siteId': site_id,
+                    'startDate': requestStart.strftime('%Y-%m-%d'),
+                    'endDate':  requestEnd.strftime('%Y-%m-%d'),
+                    'gapFilling': 'false',
+                    'validatedDataOnly': 'false',
+                    'rawDataOnly': 'true'
+                }
+            )
+            if response.status_code==200:
+                data += response.json()
+                requestStart += requestChunkSize
+                break
+            elif response.status_code==429: #too many requests
+                LOGGER.warning('Retrying in 2 minutes if tries remain.')
+                time.sleep(120)
+            elif response.status_code==401:
+                raise AirflowFailException(f"{response.status_code}: {response.reason}")
+            else:
+                raise AirflowFailException(f"{response.status_code}: {response.reason}")
     return data
 
 def getKnownSites(conn: any):
@@ -65,14 +77,6 @@ def getKnownSites(conn: any):
         cur.execute('SELECT site_id FROM ecocounter.sites_unfiltered WHERE date_decommissioned IS NULL;')
         sites = cur.fetchall()
         return [site[0] for site in sites]
-
-def getKnownFlows(conn: any, site: int):
-    with conn.cursor() as cur:
-        cur.execute('SELECT flow_id FROM ecocounter.flows_unfiltered WHERE date_decommissioned IS NULL AND site_id = %s;',
-                    (site, )
-        )
-        flows = cur.fetchall()
-        return [flow[0] for flow in flows]
 
 # do we have a record of this site in the database?
 def siteIsKnownToUs(site_id: int, conn: any):
@@ -92,67 +96,72 @@ def flowIsKnownToUs(flow_id: int, conn: any):
         )
         return cursor.rowcount > 0
 
-# DANGER delete all count data for a given flow
-def truncateFlowSince(flow_id: int, conn: any, startDate: datetime, endDate: datetime):
+# DANGER delete all count data for a given site
+def truncateSiteSince(site_id: int, conn: any, startDate: datetime, endDate: datetime):
     with conn.cursor() as cursor:
         cursor.execute(
-            """DELETE FROM ecocounter.counts_unfiltered
-            WHERE flow_id = %s
-            AND datetime_bin >= %s
-            AND datetime_bin < %s""",
-            (flow_id, startDate, endDate)
+            """DELETE FROM ecocounter.counts_unfiltered AS c
+            USING ecocounter.flows_unfiltered AS f
+            WHERE
+                f.site_id = %s
+                AND c.flow_id = f.flow_id
+                AND c.datetime_bin >= %s
+                AND c.datetime_bin < %s""",
+            (site_id, startDate, endDate)
         )
 
 # insert records
-def insertFlowCounts(conn: any, volume: any):
+def insertSiteCounts(conn: any, volume: any):
     insert_query="INSERT INTO ecocounter.counts_unfiltered (flow_id, datetime_bin, volume) VALUES %s"
     with conn.cursor() as cur:
         execute_values(cur, insert_query, volume)
     return cur.query
 
 # insert new site record
-def insertSite(conn: any, site_id: int, site_name: str, counter: str, lon: float, lat: float):
+def insertSite(conn: any, site_id: int, site_name: str, lon: float, lat: float):
     insert_query="""
-    INSERT INTO ecocounter.sites_unfiltered (site_id, site_description, counter, geom, validated)
+    INSERT INTO ecocounter.sites_unfiltered (site_id, site_description, geom, validated)
     VALUES (
         %s::numeric,
-        %s::text,
         %s::text,
         ST_SetSRID(ST_MakePoint(%s, %s), 4326),
         null::boolean --not validated by default
     )
     """
     with conn.cursor() as cur:
-        cur.execute(insert_query, (site_id, site_name, counter, lon, lat))
+        cur.execute(insert_query, (site_id, site_name, lon, lat))
 
 # insert new flow record
-def insertFlow(conn: any, flow_id: int, site_id: int, flow_name: str, bin_size: int):
+def insertFlow(conn: any, flow_id: int, site_id: int, flow_name: str, granularity: str):
     insert_query="""
     INSERT INTO ecocounter.flows_unfiltered (flow_id, site_id, flow_direction, bin_size, validated)
     VALUES (
         %s::numeric,
         %s::numeric,
         coalesce(lower(substring(%s::text, '(West|East|North|South)'))||'bound', 'unknown'),
-        (%s::text || ' minutes')::interval,
+        CASE %s WHEN 'PT1H' THEN '60 minutes'::interval WHEN 'PT15M' THEN '15 minutes'::interval ELSE NULL END,
         null::boolean --not validated
     )
     """
     with conn.cursor() as cur:
-        cur.execute(insert_query, (flow_id, site_id, flow_name, bin_size))
+        cur.execute(insert_query, (flow_id, site_id, flow_name, granularity))
 
-def truncate_and_insert(conn, token, flow_id, start_date, end_date):
-    LOGGER.info(f'Attempting to fetch data for flow {flow_id} from {start_date} to {end_date}.')
+def truncate_and_insert(conn, token, site_id, start_date, end_date):
+    LOGGER.info(f'Attempting to fetch data for site {site_id} from {start_date} to {end_date}.')
     # empty the count table for this flow
-    truncateFlowSince(flow_id, conn, start_date, end_date)          
+    truncateSiteSince(site_id, conn, start_date, end_date)
     # and fill it back up!
-    counts = getFlowData(token, flow_id, start_date, end_date)
+    counts = getSiteData(token, site_id, start_date, end_date)
+    
     #convert response into a tuple for inserting
-    volume=[]
-    for count in counts:
-        row=(flow_id, count['date'], count['counts'])
-        volume.append(row)
-    LOGGER.info(f'{len(volume)} rows fetched for flow {flow_id} from {start_date} to {end_date}.')
-    insertFlowCounts(conn, volume)
+    for flow in counts:
+        volume=[]
+        for dt in flow['data']:
+            row=(flow['flowID'], dt['timestamp'], dt['counts'])
+            volume.append(row)
+        #log and insert one flow at a time
+        LOGGER.info(f"{len(volume)} rows fetched for flow {flow['flowID']} from {start_date} to {end_date}.")
+        insertSiteCounts(conn, volume)
 
 #for testing/pulling data without use of airflow.
 def run_api(
@@ -172,10 +181,4 @@ def run_api(
         if not siteIsKnownToUs(site['id'], conn):
             print('unknown site', site['id'], site['name'])
             continue
-        #"flow" == "channel"
-        for flow in site['channels']:
-            flow_id = flow['id']
-            if not flowIsKnownToUs(flow_id, conn):
-                print('unknown flow', flow_id)
-                continue
-            truncate_and_insert(conn, password_getter, flow_id, start_date, end_date)
+        truncate_and_insert(conn, password_getter, site['id'], start_date, end_date)

--- a/volumes/ecocounter/pull_data_from_api.py
+++ b/volumes/ecocounter/pull_data_from_api.py
@@ -11,35 +11,20 @@ LOGGER = logging.getLogger(__name__)
 default_start = datetime.now().replace(hour = 0, minute = 0, second = 0, microsecond = 0)-timedelta(days=1)
 default_end = datetime.now().replace(hour = 0, minute = 0, second = 0, microsecond = 0)
 
-URL = 'https://apieco.eco-counter-tools.com'
-
-# get an authentication token for accessing the API
-def getToken(url: str, login: str, pw: str, secret: str):
-    response = requests.post(
-        f'{url}/token',
-        headers={
-            'Authorization': 'Basic ' + secret
-        },
-        data={
-            'grant_type': 'password',
-            'username': login,
-            'password': pw
-        }
-    )
-    return response.json()['access_token']
+URL = 'https://api.eco-counter.com/api/v2/'
 
 # get a list of all sites from the API
-def getSites(token: str, sites: any = ()):
+def getSites(pw: str, sites: any = ()):
     response = requests.get(
-        f'{URL}/api/site',
-        headers={'Authorization': f'Bearer {token}'}
+        f'{URL}/sites',
+        headers={'X-API-KEY': f'{pw}'}
     )
     if response.status_code!=200:
         raise AirflowFailException(f"{response.status_code}: {response.reason}")
     if sites == ():
         return response.json()
     
-    #otherwise filter sites using optional param.        
+    #otherwise filter sites using optional param.
     result = []
     for site in response.json():
         if site['id'] in sites:
@@ -47,15 +32,15 @@ def getSites(token: str, sites: any = ()):
     return result        
 
 # get all of a flows ("channel") data from the API
-def getFlowData(token: str, flow_id: int, startDate: datetime, endDate: datetime):
+def getFlowData(pw: str, flow_id: int, startDate: datetime, endDate: datetime):
     requestChunkSize = timedelta(days=100)
     requestStart = startDate
     data = []
     while requestStart < endDate:
         requestEnd = min(requestStart + requestChunkSize, endDate)
         response = requests.get(
-            f'{URL}/api/data/site/{flow_id}',
-            headers={'Authorization': f'Bearer {token}'},
+            f'{URL}/history/traffic/raw/site/{flow_id}',
+            headers={'X-API-KEY': pw},
             params={
                 'begin': requestStart.isoformat(timespec='seconds'),
                 'end':  requestEnd.isoformat(timespec='seconds'),
@@ -172,18 +157,13 @@ def run_api(
         end_date: datetime = default_end,
         sites: any = ()
 ):
-    CONFIG_PATH = 'volumes/ecocounter/.api-credentials.config'
+    CONFIG_PATH = '/data/airflow/data_scripts/bdit_data-sources/volumes/ecocounter/.api-v2-credentials.config'
     config = ConfigParser()
     config.read(CONFIG_PATH)
     conn = connect(**config['DBSETTINGS'])
     conn.autocommit = True
-    token = getToken(
-        URL,
-        config['API']['username'],
-        config['API']['password'],
-        config['API']['secret_api_hash']
-    )
-    for site in getSites(token, sites=sites): #optionally specify site_ids here. 
+    pw = config['API']['password']
+    for site in getSites(pw, sites=sites): #optionally specify site_ids here. 
         # only update data for sites / flows in the database
         # but announce unknowns for manual validation if necessary
         if not siteIsKnownToUs(site['id'], conn):
@@ -195,4 +175,4 @@ def run_api(
             if not flowIsKnownToUs(flow_id, conn):
                 print('unknown flow', flow_id)
                 continue
-            truncate_and_insert(conn, token, flow_id, start_date, end_date)
+            truncate_and_insert(conn, pw, flow_id, start_date, end_date)

--- a/volumes/ecocounter/readme.md
+++ b/volumes/ecocounter/readme.md
@@ -186,7 +186,6 @@ When you want to update new rows with missing `centreline_id`s, use [this script
 | first_active | timestamp without time zone | | First timestamp site_id appears in ecocounter.counts_unfiltered. Updated using trigger with each insert on ecocounter.counts_unfiltered. |
 | last_active | timestamp without time zone | | Last timestamp site_id appears in ecocounter.counts_unfiltered. Updated using trigger with each insert on ecocounter.counts_unfiltered. |
 | date_decommissioned  | timestamp without time zone | | |
-| counter              | character varying           | ECO09063082 | This field is pulled from the API and is another unique ID frequently referred to by Ecocounter in communications. |
 | linear_name_full     | text                        | | Main road name taken from centreline. Useful for filtering all sensors on one corridor. |
 | side_street          | text                        | | Side street name | 
 | technology           | text                        | | Technology description, useful when unioning with other data sources. | 

--- a/volumes/ecocounter/tables/sites_unfiltered.sql
+++ b/volumes/ecocounter/tables/sites_unfiltered.sql
@@ -10,7 +10,6 @@ CREATE TABLE ecocounter.sites_unfiltered (
     first_active timestamp without time zone,
     last_active timestamp without time zone,
     date_decommissioned timestamp without time zone,
-    counter character varying(16) COLLATE pg_catalog."default",
     linear_name_full text COLLATE pg_catalog."default",
     side_street text COLLATE pg_catalog."default",
     technology text COLLATE pg_catalog."default",

--- a/volumes/ecocounter/views/create-view-sites.sql
+++ b/volumes/ecocounter/views/create-view-sites.sql
@@ -10,7 +10,6 @@ CREATE OR REPLACE VIEW ecocounter.sites AS (
         first_active,
         last_active,
         date_decommissioned,
-        counter,
         linear_name_full,
         side_street,
         technology


### PR DESCRIPTION
## What this pull request accomplishes:

- Swith to Ecocounter API v2
  - password instead of token authentication + more securely pass password callable around instead of text password (prevent from logging)
  - Instead of iterating through flows, need to iterate through sites now
    - Instead of daily attempt to backfill flow-level outages, now backfilling only site level outages. No evidence that single-flow outages occur. 
  - V2 is more strictly rate limited, add sleep on 429 status code
- Remove `counter` field, which had a non 1:1 relationship with sites under new api = difficult to integrate and not used.

## Issue(s) this solves:

- Closes #1431

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
