### PR TITLE
#1438 Add .api-v2-credentials.config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ volumes/miovision/update_intersections/new_intersection_activation_dates.ipynb
 parking/tickets/data/*
 parking/tickets/connect/connect.R
 
+volumes/ecocounter/.api-v2-credentials.config


### PR DESCRIPTION
## What this pull request accomplishes:

- Add .api-v2-credentials.config to .gitignore

## Issue(s) this solves:

- #1438

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
