### PR TITLE
#1406 Trigger for adding minor movements to Miovision `intersection_movements`

### DIFF
--- a/volumes/miovision/sql/function/function-intersection_movement_exclude.sql
+++ b/volumes/miovision/sql/function/function-intersection_movement_exclude.sql
@@ -26,7 +26,7 @@ BEGIN
     ) INTO row_in_im USING NEW;
     
     IF (row_in_im) THEN
-        RAISE NOTICE 'Row % is not being inserted. Already in % table.', new, TG_TABLE_NAME::text;
+        RAISE NOTICE 'Row % is not being inserted. Already in % table.', new, opposing_table;
         --Return null to stop insert. 
         RETURN NULL;
     ELSE

--- a/volumes/miovision/sql/function/function-intersection_movements_insert_other_modes.sql
+++ b/volumes/miovision/sql/function/function-intersection_movements_insert_other_modes.sql
@@ -1,0 +1,50 @@
+-- FUNCTION: miovision_api.intersection_movements_insert_other_modes()
+
+-- DROP FUNCTION IF EXISTS miovision_api.intersection_movements_insert_other_modes();
+
+CREATE OR REPLACE FUNCTION miovision_api.intersection_movements_insert_other_modes()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE NOT LEAKPROOF
+AS $BODY$
+
+BEGIN
+
+    IF NEW.classification_uid = 1 THEN
+        INSERT INTO miovision_api.intersection_movements (
+            intersection_uid, classification_uid, leg, movement_uid
+        )
+        SELECT
+            a.intersection_uid,
+            other_modes.classification_uid,
+            a.leg,
+            a.movement_uid
+        FROM (VALUES (NEW.intersection_uid, NEW.leg, NEW.movement_uid)) AS a (intersection_uid, leg, movement_uid)
+        CROSS JOIN (VALUES (3), (4), (5), (8), (9)) AS other_modes (classification_uid)
+        LEFT JOIN miovision_api.intersection_movements
+            USING (intersection_uid, classification_uid, leg, movement_uid)
+        LEFT JOIN miovision_api.intersection_movements_denylist
+            USING (intersection_uid, classification_uid, leg, movement_uid)
+        WHERE
+            --anti join existing movements
+            intersection_movements.intersection_uid IS NULL
+            --anti join denylist
+            AND intersection_movements_denylist.intersection_uid IS NULL;
+    END IF;
+    RETURN NULL;
+
+END;
+$BODY$;
+
+ALTER FUNCTION miovision_api.intersection_movements_insert_other_modes()
+OWNER TO miovision_admins;
+
+REVOKE EXECUTE ON FUNCTION miovision_api.intersection_movements_insert_other_modes() FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION miovision_api.intersection_movements_insert_other_modes() TO miovision_admins;
+
+GRANT EXECUTE ON FUNCTION miovision_api.intersection_movements_insert_other_modes() TO miovision_api_bot;
+
+COMMENT ON FUNCTION miovision_api.intersection_movements_insert_other_modes()
+IS 'Runs after insert into miovision_api.intersection_movements to insert non-light auto modes.';

--- a/volumes/miovision/sql/function/function-intersection_movements_insert_other_modes.sql
+++ b/volumes/miovision/sql/function/function-intersection_movements_insert_other_modes.sql
@@ -3,10 +3,10 @@
 -- DROP FUNCTION IF EXISTS miovision_api.intersection_movements_insert_other_modes();
 
 CREATE OR REPLACE FUNCTION miovision_api.intersection_movements_insert_other_modes()
-    RETURNS trigger
-    LANGUAGE 'plpgsql'
-    COST 100
-    VOLATILE NOT LEAKPROOF
+RETURNS trigger
+LANGUAGE plpgsql
+COST 100
+VOLATILE NOT LEAKPROOF
 AS $BODY$
 
 BEGIN
@@ -40,11 +40,13 @@ $BODY$;
 ALTER FUNCTION miovision_api.intersection_movements_insert_other_modes()
 OWNER TO miovision_admins;
 
-REVOKE EXECUTE ON FUNCTION miovision_api.intersection_movements_insert_other_modes() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION miovision_api.intersection_movements_insert_other_modes() FROM public;
 
-GRANT EXECUTE ON FUNCTION miovision_api.intersection_movements_insert_other_modes() TO miovision_admins;
+GRANT EXECUTE ON FUNCTION miovision_api.intersection_movements_insert_other_modes()
+TO miovision_admins;
 
-GRANT EXECUTE ON FUNCTION miovision_api.intersection_movements_insert_other_modes() TO miovision_api_bot;
+GRANT EXECUTE ON FUNCTION miovision_api.intersection_movements_insert_other_modes()
+TO miovision_api_bot;
 
 COMMENT ON FUNCTION miovision_api.intersection_movements_insert_other_modes()
 IS 'Runs after insert into miovision_api.intersection_movements to insert non-light auto modes.';

--- a/volumes/miovision/sql/table/create-table-intersection_movements.sql
+++ b/volumes/miovision/sql/table/create-table-intersection_movements.sql
@@ -22,6 +22,7 @@ GRANT ALL ON TABLE miovision_api.intersection_movements TO miovision_admins;
 COMMENT ON TABLE miovision_api.intersection_movements
 IS 'Unique movements for each intersection by classification';
 
+--prevent insertion of movements that are in denylist
 CREATE OR REPLACE TRIGGER intersection_movements_denylist_exclusion
 BEFORE INSERT ON miovision_api.intersection_movements
 FOR EACH ROW
@@ -35,7 +36,15 @@ ALTER TABLE IF EXISTS miovision_api.intersection_movements
 ADD CONSTRAINT intersecton_movements_exclude_xwalk_bikes
 CHECK (NOT (classification_uid = 7));
 
+--insert padding values into volumes_15min_mvt_unfiltered
 CREATE TRIGGER miovision_intersection_movements_pad
 AFTER INSERT ON miovision_api.intersection_movements
 FOR EACH ROW
 EXECUTE FUNCTION miovision_api.fn_add_intersection_movement_padding_values();
+
+--insert other vehicle modes besides light autos upon insert of light autos
+CREATE OR REPLACE TRIGGER miovision_intersection_movements_insert_other_modes
+AFTER INSERT
+ON miovision_api.intersection_movements
+FOR EACH ROW
+EXECUTE FUNCTION miovision_api.intersection_movements_insert_other_modes();

--- a/volumes/miovision/sql/views/create-view-monitor_intersection_movements.sql
+++ b/volumes/miovision/sql/views/create-view-monitor_intersection_movements.sql
@@ -28,9 +28,11 @@ CREATE OR REPLACE VIEW miovision_api.monitor_intersection_movements AS (
     LEFT JOIN miovision_api.classifications AS c USING (classification_uid)
     LEFT JOIN miovision_api.movements AS m USING (movement_uid)
     LEFT JOIN intersection_classification_totals AS ict USING (intersection_uid, classification_uid)
+    JOIN miovision_api.intersections AS i USING (intersection_uid)
     WHERE
         v.volume_15min_mvt_uid IS NULL --not aggregated
         AND v.datetime_bin >= CURRENT_DATE - 100
+        AND v.datetime_bin >= i.date_installed + 1 --match criteria used for zero padding
         AND NOT (v.classification_uid = 10 AND movement_uid = 8) --bike exit
         AND NOT (v.classification_uid = 7) --bikes in crosswalk
         AND im_dl.intersection_uid IS NULL

--- a/volumes/miovision/sql/views/create-view-monitor_intersection_movements.sql
+++ b/volumes/miovision/sql/views/create-view-monitor_intersection_movements.sql
@@ -28,13 +28,11 @@ CREATE OR REPLACE VIEW miovision_api.monitor_intersection_movements AS (
     LEFT JOIN miovision_api.classifications AS c USING (classification_uid)
     LEFT JOIN miovision_api.movements AS m USING (movement_uid)
     LEFT JOIN intersection_classification_totals AS ict USING (intersection_uid, classification_uid)
-    JOIN miovision_api.intersections AS i USING (intersection_uid)
     WHERE
         v.volume_15min_mvt_uid IS NULL --not aggregated
         AND v.datetime_bin >= CURRENT_DATE - 100
-        AND v.datetime_bin >= i.date_installed + 1 --match criteria used for zero padding
+        AND v.classification_uid IN (1,2,6,10) --other vehicular modes are added using trigger
         AND NOT (v.classification_uid = 10 AND movement_uid = 8) --bike exit
-        AND NOT (v.classification_uid = 7) --bikes in crosswalk
         AND im_dl.intersection_uid IS NULL
     GROUP BY
         v.intersection_uid,

--- a/volumes/miovision/sql/views/create-view-monitor_intersection_movements.sql
+++ b/volumes/miovision/sql/views/create-view-monitor_intersection_movements.sql
@@ -31,7 +31,7 @@ CREATE OR REPLACE VIEW miovision_api.monitor_intersection_movements AS (
     WHERE
         v.volume_15min_mvt_uid IS NULL --not aggregated
         AND v.datetime_bin >= CURRENT_DATE - 100
-        AND v.classification_uid IN (1,2,6,10) --other vehicular modes are added using trigger
+        AND v.classification_uid IN (1, 2, 6, 10) --other vehicular modes are added using trigger
         AND NOT (v.classification_uid = 10 AND movement_uid = 8) --bike exit
         AND im_dl.intersection_uid IS NULL
     GROUP BY


### PR DESCRIPTION
## What this pull request accomplishes:

- Step 3 **[here](https://github.com/CityofToronto/bdit_data-sources/tree/master/volumes/miovision/update_intersections#update-miovision_apiintersection_movements)** tells us to add an equivalent `classification_uid IN (3, 4, 5, 8, 9)` for every `classification_uid = 1` movement. This new trigger will take care of that step automatically. 
  - That change to readme is handled here: https://github.com/CityofToronto/bdit_data-sources/pull/1473/

## Issue(s) this solves:

- Closes #1406 

## What, in particular, needs to reviewed:

- 

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
