### PR TITLE
#1239 Use midblock model instead of centreline where appropriate

### DIFF
--- a/volumes/short_term_counting_program/sql/create-view-svc_daily_totals.sql
+++ b/volumes/short_term_counting_program/sql/create-view-svc_daily_totals.sql
@@ -4,17 +4,17 @@ SELECT
     suv.study_id,
     suv.count_date,
     suv.direction,
-    meta.centreline_id,
+    meta.midblock_id,
     cl.geom AS centreline_geom,
     SUM(suv.volume) AS daily_volume
 FROM traffic.svc_unified_volumes AS suv
 JOIN traffic.svc_metadata AS meta USING (study_id)
-JOIN gis_core.centreline_latest AS cl USING (centreline_id)
+JOIN traffic.centreline2_midblocks AS cl USING (midblock_id)
 GROUP BY
     suv.study_id,
     suv.count_date,
     suv.direction,
-    meta.centreline_id,
+    meta.midblock_id,
     cl.geom
 HAVING COUNT(*) = 4 * 24; --15 minute bins
 

--- a/volumes/short_term_counting_program/sql/create-view-svc_daily_totals.sql
+++ b/volumes/short_term_counting_program/sql/create-view-svc_daily_totals.sql
@@ -5,8 +5,9 @@ SELECT
     suv.count_date,
     suv.direction,
     meta.midblock_id,
-    cl.geom AS centreline_geom,
-    SUM(suv.volume) AS daily_volume
+    cl.geom AS midblock_geom,
+    SUM(suv.volume) AS daily_volume,
+    centreline_id_array
 FROM traffic.svc_unified_volumes AS suv
 JOIN traffic.svc_metadata AS meta USING (study_id)
 JOIN traffic.centreline2_midblocks AS cl USING (midblock_id)
@@ -15,6 +16,7 @@ GROUP BY
     suv.count_date,
     suv.direction,
     meta.midblock_id,
+    centreline_id_array,
     cl.geom
 HAVING COUNT(*) = 4 * 24; --15 minute bins
 


### PR DESCRIPTION
## What this pull request accomplishes:

- Use new midblock model in place of centreline where relevant.

## Issue(s) this solves:

- Closes #1239

## What, in particular, needs to reviewed:

- Within the `traffic` schema I think this one view was the extent of changes necessary, but it would be worth discussing other dependents of `gis_core.centreline_*` objects to see if they would be better off pointing to midblock model.

## What needs to be done by a sysadmin after this PR is merged

_E.g.: these tables need to be migrated/created in the production schema._
